### PR TITLE
Fixed bad styling in list line subtitle

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -6827,13 +6827,13 @@ v-card-title-position-left {
   content: "";
   will-change: opacity, transform; }
 
-.mdc-ripple-upgraded--unbounded .mdc-checkbox__background::before {
+.mdc-ripple-upgraded--background-focused .mdc-checkbox__background::before {
   content: none; }
 
 .mdc-checkbox__native-control:focus ~ .mdc-checkbox__background::before {
   transform: scale(2.75, 2.75);
   transition: opacity 80ms 0ms cubic-bezier(0, 0, 0.2, 1), transform 80ms 0ms cubic-bezier(0, 0, 0.2, 1);
-  opacity: 0.26; }
+  opacity: 0.12; }
 
 .mdc-checkbox__native-control {
   position: absolute;
@@ -7715,7 +7715,7 @@ v-card-title-position-left {
     background-color: rgba(0, 0, 0, 0.87); }
   .mdc-text-field--box:hover::before {
     opacity: 0.04; }
-  .mdc-text-field--box:not(.mdc-ripple-upgraded):focus::before, .mdc-text-field--box:not(.mdc-ripple-upgraded):focus-within::before, .mdc-text-field--box.mdc-ripple-upgraded--background-focused::before {
+  .mdc-text-field--box:not(.mdc-ripple-upgraded):focus::before, .mdc-text-field--box.mdc-ripple-upgraded--background-focused::before {
     transition-duration: 75ms;
     opacity: 0.12; }
   .mdc-text-field--box::before, .mdc-text-field--box::after {
@@ -8013,7 +8013,8 @@ v-card-title-position-left {
   margin-bottom: 4px; }
 
 .mdc-text-field--box + .mdc-text-field-helper-text,
-.mdc-text-field--outlined + .mdc-text-field-helper-text {
+.mdc-text-field--outlined + .mdc-text-field-helper-text,
+.mdc-text-field--textarea + .mdc-text-field-helper-text {
   margin-right: 16px;
   margin-left: 16px; }
 
@@ -8639,6 +8640,9 @@ a.mdc-list-item {
   padding-left: 6px;
   padding-right: 6px; }
 
+.mdc-list-item__secondary-text::before {
+  content: unset; }
+
 .mdc-icon-toggle {
   --mdc-ripple-fg-size: 0;
   --mdc-ripple-left: 0;
@@ -9135,7 +9139,7 @@ a.mdc-list-item {
     background-color: rgba(0, 0, 0, 0.87); }
   .mdc-select--box:hover::before {
     opacity: 0.04; }
-  .mdc-select--box:not(.mdc-ripple-upgraded):focus::before, .mdc-select--box:not(.mdc-ripple-upgraded):focus-within::before, .mdc-select--box.mdc-ripple-upgraded--background-focused::before {
+  .mdc-select--box:not(.mdc-ripple-upgraded):focus::before, .mdc-select--box.mdc-ripple-upgraded--background-focused::before {
     transition-duration: 75ms;
     opacity: 0.12; }
   [dir="rtl"] .mdc-select--box, .mdc-select--box[dir="rtl"] {
@@ -10630,7 +10634,7 @@ select {
     opacity: 0;
     cursor: inherit;
     z-index: 1; }
-  .mdc-radio.mdc-ripple-upgraded .mdc-radio__background::before {
+  .mdc-radio.mdc-ripple-upgraded--background-focused .mdc-radio__background::before {
     content: none; }
 
 .mdc-radio__native-control:checked + .mdc-radio__background,
@@ -10664,7 +10668,7 @@ select {
 .mdc-radio__native-control:focus + .mdc-radio__background::before {
   transform: scale(2, 2);
   transition: opacity 120ms 0ms cubic-bezier(0, 0, 0.2, 1), transform 120ms 0ms cubic-bezier(0, 0, 0.2, 1);
-  opacity: .26; }
+  opacity: 0.12; }
 
 @keyframes mdc-slider-emphasize {
   0% {

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -60,7 +60,7 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 44);
+/******/ 	return __webpack_require__(__webpack_require__.s = 45);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -277,7 +277,7 @@ class MDCComponent {
 /* unused harmony export RippleCapableSurface */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(17);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(51);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(52);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(7);
 /* harmony reexport (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return __WEBPACK_IMPORTED_MODULE_2__foundation__["a"]; });
 /* unused harmony reexport util */
@@ -519,7 +519,7 @@ class MDCSelectionControl {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSnackbar;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(69);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(70);
 
 
 // This class displays a page level message
@@ -795,26 +795,26 @@ class VBase extends __WEBPACK_IMPORTED_MODULE_1__utils_urls__["a" /* VUrls */] {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initialize;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(50);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(53);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(54);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(51);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(54);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(55);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(18);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(66);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(80);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__icon_toggles__ = __webpack_require__(81);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__menus__ = __webpack_require__(86);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__selects__ = __webpack_require__(90);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__chips__ = __webpack_require__(93);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__cards__ = __webpack_require__(98);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__forms__ = __webpack_require__(99);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(67);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(81);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__icon_toggles__ = __webpack_require__(82);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__menus__ = __webpack_require__(87);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__selects__ = __webpack_require__(91);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__chips__ = __webpack_require__(94);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__cards__ = __webpack_require__(99);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__forms__ = __webpack_require__(100);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__snackbar__ = __webpack_require__(6);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__checkboxes__ = __webpack_require__(100);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__switches__ = __webpack_require__(105);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__rich_text_area__ = __webpack_require__(113);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__steppers__ = __webpack_require__(120);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__radios__ = __webpack_require__(121);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__sliders__ = __webpack_require__(130);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__hidden_fields__ = __webpack_require__(133);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__checkboxes__ = __webpack_require__(101);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__switches__ = __webpack_require__(106);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__rich_text_area__ = __webpack_require__(114);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__steppers__ = __webpack_require__(121);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__radios__ = __webpack_require__(122);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__sliders__ = __webpack_require__(131);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__hidden_fields__ = __webpack_require__(134);
 
 
 
@@ -872,10 +872,10 @@ function initialize() {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_util__ = __webpack_require__(7);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(19);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__adapter__ = __webpack_require__(20);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__foundation__ = __webpack_require__(58);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__foundation__ = __webpack_require__(59);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__material_line_ripple_index__ = __webpack_require__(23);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__helper_text_index__ = __webpack_require__(61);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_index__ = __webpack_require__(62);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__helper_text_index__ = __webpack_require__(62);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_index__ = __webpack_require__(63);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__material_floating_label_index__ = __webpack_require__(25);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__material_notched_outline_index__ = __webpack_require__(27);
 /* unused harmony reexport MDCTextFieldFoundation */
@@ -1331,7 +1331,7 @@ class MDCTextField extends __WEBPACK_IMPORTED_MODULE_0__material_base_component_
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(21);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(56);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(57);
 /**
  * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
@@ -1464,7 +1464,7 @@ class MDCTextFieldHelperTextFoundation extends __WEBPACK_IMPORTED_MODULE_0__mate
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(22);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(57);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(58);
 /**
  * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
@@ -1737,8 +1737,8 @@ function getCorrectPropertyName(windowObj, eventType) {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCChipFoundation; });
 /* unused harmony export MDCChipInteractionEventType */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(37);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(38);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(38);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(39);
 /**
  * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
@@ -2742,7 +2742,7 @@ class MDCTextFieldIconAdapter {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLineRipple; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(24);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(59);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(60);
 /* unused harmony reexport MDCLineRippleFoundation */
 /**
  * @license
@@ -2904,7 +2904,7 @@ class MDCLineRippleAdapter {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCFloatingLabel; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(26);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(64);
 /* unused harmony reexport MDCFloatingLabelFoundation */
 /**
  * @license
@@ -3059,7 +3059,7 @@ class MDCFloatingLabelAdapter {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCNotchedOutline; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(28);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(65);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(66);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(29);
 /* unused harmony reexport MDCNotchedOutlineFoundation */
 /**
@@ -3500,8 +3500,8 @@ class VErrors {
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return MDCMenu; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util__ = __webpack_require__(87);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(88);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util__ = __webpack_require__(88);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(89);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(34);
 /* unused harmony reexport MDCMenuFoundation */
 /* unused harmony reexport AnchorMargin */
@@ -3803,10 +3803,134 @@ const Corner = {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint no-unused-vars: [2, {"args": "none"}] */
+
+/**
+ * Adapter for MDC Select. Provides an interface for managing
+ * - classes
+ * - dom
+ * - event handlers
+ *
+ * Additionally, provides type information for the adapter to the Closure
+ * compiler.
+ *
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md
+ *
+ * @record
+ */
+
+class MDCSelectAdapter {
+  /**
+   * Adds class to root element.
+   * @param {string} className
+   */
+  addClass(className) {}
+
+  /**
+   * Removes a class from the root element.
+   * @param {string} className
+   */
+  removeClass(className) {}
+
+  /**
+   * Returns true if the root element contains the given class name.
+   * @param {string} className
+   * @return {boolean}
+   */
+  hasClass(className) {}
+
+  /**
+   * Activates the bottom line, showing a focused state.
+   */
+  activateBottomLine() {}
+
+  /**
+   * Deactivates the bottom line.
+   */
+  deactivateBottomLine() {}
+
+  /**
+   * Returns the selected value of the select element.
+   * @return {string}
+   */
+  getValue() {}
+
+  /**
+   * Returns true if the direction of the root element is set to RTL.
+   * @return {boolean}
+   */
+  isRtl() {}
+
+  /**
+   * Returns true if label element exists, false if it doesn't.
+   * @return {boolean}
+   */
+  hasLabel() {}
+
+  /**
+   * Floats label determined based off of the shouldFloat argument.
+   * @param {boolean} shouldFloat
+   */
+  floatLabel(shouldFloat) {}
+
+  /**
+   * Returns width of label in pixels, if the label exists.
+   * @return {number}
+   */
+  getLabelWidth() {}
+
+  /**
+   * Returns true if outline element exists, false if it doesn't.
+   * @return {boolean}
+   */
+  hasOutline() {}
+
+  /**
+   * Updates SVG Path and outline element based on the
+   * label element width and RTL context, if the outline exists.
+   * @param {number} labelWidth
+   * @param {boolean=} isRtl
+   */
+  notchOutline(labelWidth, isRtl) {}
+
+  /**
+   * Closes notch in outline element, if the outline exists.
+   */
+  closeOutline() {}
+}
+
+/* unused harmony default export */ var _unused_webpack_default_export = (MDCSelectAdapter);
+
+/***/ }),
+/* 36 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return cssClasses; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "c", function() { return strings; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return numbers; });
 /**
+ * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -3821,6 +3945,8 @@ const Corner = {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/** @enum {string} */
 const cssClasses = {
   BOX: 'mdc-select--box',
   DISABLED: 'mdc-select--disabled',
@@ -3828,6 +3954,7 @@ const cssClasses = {
   OUTLINED: 'mdc-select--outlined'
 };
 
+/** @enum {string} */
 const strings = {
   CHANGE_EVENT: 'MDCSelect:change',
   LINE_RIPPLE_SELECTOR: '.mdc-line-ripple',
@@ -3844,16 +3971,16 @@ const numbers = {
 
 
 /***/ }),
-/* 36 */
+/* 37 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCChip; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_ripple_index__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__adapter__ = __webpack_require__(37);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__adapter__ = __webpack_require__(38);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__foundation__ = __webpack_require__(15);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__constants__ = __webpack_require__(38);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__constants__ = __webpack_require__(39);
 /* harmony reexport (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return __WEBPACK_IMPORTED_MODULE_3__foundation__["a"]; });
 /**
  * @license
@@ -4046,7 +4173,7 @@ class MDCChip extends __WEBPACK_IMPORTED_MODULE_0__material_base_component__["a"
 
 
 /***/ }),
-/* 37 */
+/* 38 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4154,7 +4281,7 @@ class MDCChipAdapter {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCChipAdapter);
 
 /***/ }),
-/* 38 */
+/* 39 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4201,7 +4328,7 @@ const cssClasses = {
 
 
 /***/ }),
-/* 39 */
+/* 40 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4256,15 +4383,15 @@ class MDCChipSetAdapter {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCChipSetAdapter);
 
 /***/ }),
-/* 40 */
+/* 41 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCRipple; });
 /* unused harmony export RippleCapableSurface */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(41);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(108);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(42);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(109);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(16);
 /* harmony reexport (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return __WEBPACK_IMPORTED_MODULE_2__foundation__["a"]; });
 /* unused harmony reexport util */
@@ -4419,7 +4546,7 @@ RippleCapableSurface.prototype.disabled;
 
 
 /***/ }),
-/* 41 */
+/* 42 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4535,7 +4662,7 @@ class MDCRippleAdapter {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCRippleAdapter);
 
 /***/ }),
-/* 42 */
+/* 43 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4594,7 +4721,7 @@ const numbers = {
 
 
 /***/ }),
-/* 43 */
+/* 44 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4792,22 +4919,22 @@ class MDCSliderAdapter {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCSliderAdapter);
 
 /***/ }),
-/* 44 */
+/* 45 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(45);
+module.exports = __webpack_require__(46);
 
 
 /***/ }),
-/* 45 */
+/* 46 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__components_initialize__ = __webpack_require__(10);
-__webpack_require__(46);
 __webpack_require__(47);
-window.dialogPolyfill = __webpack_require__(48);
+__webpack_require__(48);
+window.dialogPolyfill = __webpack_require__(49);
 
 
 document.addEventListener("DOMContentLoaded", function (event) {
@@ -4815,7 +4942,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 });
 
 /***/ }),
-/* 46 */
+/* 47 */
 /***/ (function(module, exports) {
 
 ;(function() {
@@ -8817,7 +8944,7 @@ componentHandler.register({
 
 
 /***/ }),
-/* 47 */
+/* 48 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -9921,7 +10048,7 @@ componentHandler.register({
 /******/]);
 
 /***/ }),
-/* 48 */
+/* 49 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_RESULT__;(function () {
@@ -10666,7 +10793,7 @@ var __WEBPACK_AMD_DEFINE_RESULT__;(function () {
   dialogPolyfill['forceRegisterDialog'] = dialogPolyfill.forceRegisterDialog;
   dialogPolyfill['registerDialog'] = dialogPolyfill.registerDialog;
 
-  if ("function" === 'function' && 'amd' in __webpack_require__(49)) {
+  if ("function" === 'function' && 'amd' in __webpack_require__(50)) {
     // AMD support
     !(__WEBPACK_AMD_DEFINE_RESULT__ = (function () {
       return dialogPolyfill;
@@ -10682,7 +10809,7 @@ var __WEBPACK_AMD_DEFINE_RESULT__;(function () {
 })();
 
 /***/ }),
-/* 49 */
+/* 50 */
 /***/ (function(module, exports) {
 
 module.exports = function() {
@@ -10691,7 +10818,7 @@ module.exports = function() {
 
 
 /***/ }),
-/* 50 */
+/* 51 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -10714,13 +10841,13 @@ function initButtons() {
 }
 
 /***/ }),
-/* 51 */
+/* 52 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(17);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(52);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(53);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(7);
 /**
  * @license
@@ -10900,7 +11027,7 @@ class MDCRippleFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_fou
    * @return {boolean}
    * @private
    */
-  isSupported_() {
+  supportsPressRipple_() {
     return this.adapter_.browserSupportsCssVars();
   }
 
@@ -10920,57 +11047,61 @@ class MDCRippleFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_fou
 
   /** @override */
   init() {
-    if (!this.isSupported_()) {
-      return;
-    }
-    this.registerRootHandlers_();
+    const supportsPressRipple = this.supportsPressRipple_();
 
-    const { ROOT, UNBOUNDED } = MDCRippleFoundation.cssClasses;
-    requestAnimationFrame(() => {
-      this.adapter_.addClass(ROOT);
-      if (this.adapter_.isUnbounded()) {
-        this.adapter_.addClass(UNBOUNDED);
-        // Unbounded ripples need layout logic applied immediately to set coordinates for both shade and ripple
-        this.layoutInternal_();
-      }
-    });
+    this.registerRootHandlers_(supportsPressRipple);
+
+    if (supportsPressRipple) {
+      const { ROOT, UNBOUNDED } = MDCRippleFoundation.cssClasses;
+      requestAnimationFrame(() => {
+        this.adapter_.addClass(ROOT);
+        if (this.adapter_.isUnbounded()) {
+          this.adapter_.addClass(UNBOUNDED);
+          // Unbounded ripples need layout logic applied immediately to set coordinates for both shade and ripple
+          this.layoutInternal_();
+        }
+      });
+    }
   }
 
   /** @override */
   destroy() {
-    if (!this.isSupported_()) {
-      return;
-    }
+    if (this.supportsPressRipple_()) {
+      if (this.activationTimer_) {
+        clearTimeout(this.activationTimer_);
+        this.activationTimer_ = 0;
+        const { FG_ACTIVATION } = MDCRippleFoundation.cssClasses;
+        this.adapter_.removeClass(FG_ACTIVATION);
+      }
 
-    if (this.activationTimer_) {
-      clearTimeout(this.activationTimer_);
-      this.activationTimer_ = 0;
-      const { FG_ACTIVATION } = MDCRippleFoundation.cssClasses;
-      this.adapter_.removeClass(FG_ACTIVATION);
+      const { ROOT, UNBOUNDED } = MDCRippleFoundation.cssClasses;
+      requestAnimationFrame(() => {
+        this.adapter_.removeClass(ROOT);
+        this.adapter_.removeClass(UNBOUNDED);
+        this.removeCssVars_();
+      });
     }
 
     this.deregisterRootHandlers_();
     this.deregisterDeactivationHandlers_();
-
-    const { ROOT, UNBOUNDED } = MDCRippleFoundation.cssClasses;
-    requestAnimationFrame(() => {
-      this.adapter_.removeClass(ROOT);
-      this.adapter_.removeClass(UNBOUNDED);
-      this.removeCssVars_();
-    });
   }
 
-  /** @private */
-  registerRootHandlers_() {
-    ACTIVATION_EVENT_TYPES.forEach(type => {
-      this.adapter_.registerInteractionHandler(type, this.activateHandler_);
-    });
+  /**
+   * @param {boolean} supportsPressRipple Passed from init to save a redundant function call
+   * @private
+   */
+  registerRootHandlers_(supportsPressRipple) {
+    if (supportsPressRipple) {
+      ACTIVATION_EVENT_TYPES.forEach(type => {
+        this.adapter_.registerInteractionHandler(type, this.activateHandler_);
+      });
+      if (this.adapter_.isUnbounded()) {
+        this.adapter_.registerResizeHandler(this.resizeHandler_);
+      }
+    }
+
     this.adapter_.registerInteractionHandler('focus', this.focusHandler_);
     this.adapter_.registerInteractionHandler('blur', this.blurHandler_);
-
-    if (this.adapter_.isUnbounded()) {
-      this.adapter_.registerResizeHandler(this.resizeHandler_);
-    }
   }
 
   /**
@@ -11317,7 +11448,7 @@ class MDCRippleFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_fou
 /* harmony default export */ __webpack_exports__["a"] = (MDCRippleFoundation);
 
 /***/ }),
-/* 52 */
+/* 53 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -11372,7 +11503,7 @@ const numbers = {
 
 
 /***/ }),
-/* 53 */
+/* 54 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -11411,12 +11542,12 @@ function initDialogs() {
 }
 
 /***/ }),
-/* 54 */
+/* 55 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDateTime;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(55);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(56);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__text_fields__ = __webpack_require__(18);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_textfield__ = __webpack_require__(11);
@@ -11467,7 +11598,7 @@ class VDateTime extends __WEBPACK_IMPORTED_MODULE_1__text_fields__["a" /* VTextF
 
 
 /***/ }),
-/* 55 */
+/* 56 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* flatpickr v4.5.1, @license MIT */
@@ -13626,7 +13757,7 @@ class VDateTime extends __WEBPACK_IMPORTED_MODULE_1__text_fields__["a" /* VTextF
 });
 
 /***/ }),
-/* 56 */
+/* 57 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -13664,7 +13795,7 @@ const cssClasses = {
 
 
 /***/ }),
-/* 57 */
+/* 58 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -13695,7 +13826,7 @@ const strings = {
 
 
 /***/ }),
-/* 58 */
+/* 59 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14144,13 +14275,13 @@ class MDCTextFieldFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_
 /* harmony default export */ __webpack_exports__["a"] = (MDCTextFieldFoundation);
 
 /***/ }),
-/* 59 */
+/* 60 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(24);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(60);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(61);
 /**
  * @license
  * Copyright 2018 Google Inc. All Rights Reserved.
@@ -14261,7 +14392,7 @@ class MDCLineRippleFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base
 /* harmony default export */ __webpack_exports__["a"] = (MDCLineRippleFoundation);
 
 /***/ }),
-/* 60 */
+/* 61 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14292,7 +14423,7 @@ const cssClasses = {
 
 
 /***/ }),
-/* 61 */
+/* 62 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14363,7 +14494,7 @@ class MDCTextFieldHelperText extends __WEBPACK_IMPORTED_MODULE_0__material_base_
 
 
 /***/ }),
-/* 62 */
+/* 63 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14435,13 +14566,13 @@ class MDCTextFieldIcon extends __WEBPACK_IMPORTED_MODULE_0__material_base_compon
 
 
 /***/ }),
-/* 63 */
+/* 64 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(26);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(65);
 /**
  * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
@@ -14556,7 +14687,7 @@ class MDCFloatingLabelFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_b
 /* harmony default export */ __webpack_exports__["a"] = (MDCFloatingLabelFoundation);
 
 /***/ }),
-/* 64 */
+/* 65 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14587,7 +14718,7 @@ const cssClasses = {
 
 
 /***/ }),
-/* 65 */
+/* 66 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14708,22 +14839,22 @@ class MDCNotchedOutlineFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_
 /* harmony default export */ __webpack_exports__["a"] = (MDCNotchedOutlineFoundation);
 
 /***/ }),
-/* 66 */
+/* 67 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initEvents;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(67);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(68);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(72);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(73);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(68);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(69);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(73);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(74);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(32);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(74);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_snackbar__ = __webpack_require__(75);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_autocomplete__ = __webpack_require__(76);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_navigates__ = __webpack_require__(77);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_clears__ = __webpack_require__(78);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(79);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(75);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_snackbar__ = __webpack_require__(76);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_autocomplete__ = __webpack_require__(77);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_navigates__ = __webpack_require__(78);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_clears__ = __webpack_require__(79);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(80);
 
 
 
@@ -14879,7 +15010,7 @@ function fireAfterLoad() {
 }
 
 /***/ }),
-/* 67 */
+/* 68 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14911,7 +15042,7 @@ class VLoads extends __WEBPACK_IMPORTED_MODULE_0__utils_urls__["a" /* VUrls */] 
 
 
 /***/ }),
-/* 68 */
+/* 69 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15020,12 +15151,12 @@ class VPosts extends __WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */] {
 
 
 /***/ }),
-/* 69 */
+/* 70 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_index__ = __webpack_require__(8);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(70);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(71);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_animation_index__ = __webpack_require__(14);
 /* unused harmony reexport MDCSnackbarFoundation */
 /**
@@ -15110,12 +15241,12 @@ class MDCSnackbar extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a"
 
 
 /***/ }),
-/* 70 */
+/* 71 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_index__ = __webpack_require__(8);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__constants__ = __webpack_require__(71);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__constants__ = __webpack_require__(72);
 /**
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
@@ -15364,7 +15495,7 @@ class MDCSnackbarFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_i
 
 
 /***/ }),
-/* 71 */
+/* 72 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15412,7 +15543,7 @@ const numbers = {
 
 
 /***/ }),
-/* 72 */
+/* 73 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15503,7 +15634,7 @@ class VReplaces extends __WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */] {
 
 
 /***/ }),
-/* 73 */
+/* 74 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15536,7 +15667,7 @@ class VDialog {
 
 
 /***/ }),
-/* 74 */
+/* 75 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15570,7 +15701,7 @@ class VToggleVisibility {
 
 
 /***/ }),
-/* 75 */
+/* 76 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15602,7 +15733,7 @@ class VSnackbarEvent {
 
 
 /***/ }),
-/* 76 */
+/* 77 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15709,7 +15840,7 @@ class VAutoComplete extends __WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */]
 
 
 /***/ }),
-/* 77 */
+/* 78 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15734,7 +15865,7 @@ class VNavigates {
 
 
 /***/ }),
-/* 78 */
+/* 79 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15767,7 +15898,7 @@ class VClears {
 
 
 /***/ }),
-/* 79 */
+/* 80 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15799,7 +15930,7 @@ class VStepperEvent extends __WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]
 
 
 /***/ }),
-/* 80 */
+/* 81 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15893,12 +16024,12 @@ function initLists() {
 }
 
 /***/ }),
-/* 81 */
+/* 82 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initIconToggles;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_icon_toggle__ = __webpack_require__(82);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_icon_toggle__ = __webpack_require__(83);
 
 
 function initIconToggles() {
@@ -15922,13 +16053,13 @@ function initIconToggles() {
 //         });
 
 /***/ }),
-/* 82 */
+/* 83 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCIconToggle; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(83);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(84);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(2);
 /* unused harmony reexport MDCIconToggleFoundation */
 /**
@@ -16047,13 +16178,13 @@ class MDCIconToggle extends __WEBPACK_IMPORTED_MODULE_0__material_base_component
 
 
 /***/ }),
-/* 83 */
+/* 84 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(84);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(85);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(85);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(86);
 /**
  * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
@@ -16288,7 +16419,7 @@ IconToggleState.prototype.cssClass;
 /* harmony default export */ __webpack_exports__["a"] = (MDCIconToggleFoundation);
 
 /***/ }),
-/* 84 */
+/* 85 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -16389,7 +16520,7 @@ let IconToggleEvent;
 
 
 /***/ }),
-/* 85 */
+/* 86 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -16431,7 +16562,7 @@ const strings = {
 
 
 /***/ }),
-/* 86 */
+/* 87 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -16470,7 +16601,7 @@ function initMenus() {
 }
 
 /***/ }),
-/* 87 */
+/* 88 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -16633,14 +16764,14 @@ function solvePositionFromXValue_(xVal, x1, x2) {
 
 
 /***/ }),
-/* 88 */
+/* 89 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCMenuFoundation; });
 /* unused harmony export AnchorMargin */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(89);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(90);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(34);
 /**
  * @license
@@ -17284,7 +17415,7 @@ class MDCMenuFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_found
 
 
 /***/ }),
-/* 89 */
+/* 90 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -17455,12 +17586,12 @@ class MDCMenuAdapter {
 
 
 /***/ }),
-/* 90 */
+/* 91 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSelects;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(91);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(92);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(4);
 
@@ -17505,17 +17636,19 @@ class VSelect extends Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__
 
 
 /***/ }),
-/* 91 */
+/* 92 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCSelect; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_index__ = __webpack_require__(8);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_floating_label_index__ = __webpack_require__(25);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_line_ripple_index__ = __webpack_require__(23);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_ripple_index__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__material_notched_outline_index__ = __webpack_require__(27);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__foundation__ = __webpack_require__(92);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__constants__ = __webpack_require__(35);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__foundation__ = __webpack_require__(93);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__adapter__ = __webpack_require__(35);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__constants__ = __webpack_require__(36);
 /* unused harmony reexport MDCSelectFoundation */
 /**
  * Copyright 2016 Google Inc. All Rights Reserved.
@@ -17543,34 +17676,81 @@ class VSelect extends Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__
 
 
 
-
+/**
+ * @extends MDCComponent<!MDCSelectFoundation>
+ */
 class MDCSelect extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a" /* MDCComponent */] {
+  /**
+   * @param {...?} args
+   */
+  constructor(...args) {
+    super(...args);
+    /** @private {?Element} */
+    this.nativeControl_;
+    /** @type {?MDCRipple} */
+    this.ripple;
+    /** @private {?MDCLineRipple} */
+    this.lineRipple_;
+    /** @private {?MDCFloatingLabel} */
+    this.label_;
+    /** @private {?MDCNotchedOutline} */
+    this.outline_;
+    /** @private {!Function} */
+    this.handleChange_;
+    /** @private {!Function} */
+    this.handleFocus_;
+    /** @private {!Function} */
+    this.handleBlur_;
+  }
+
+  /**
+   * @param {!Element} root
+   * @return {!MDCSelect}
+   */
   static attachTo(root) {
     return new MDCSelect(root);
   }
 
+  /**
+   * @return {string} The value of the select.
+   */
   get value() {
     return this.nativeControl_.value;
   }
 
+  /**
+   * @param {string} value The value to set on the select.
+   */
   set value(value) {
     this.nativeControl_.value = value;
     this.foundation_.handleChange();
   }
 
+  /**
+   * @return {number} The selected index of the select.
+   */
   get selectedIndex() {
     return this.nativeControl_.selectedIndex;
   }
 
+  /**
+   * @param {number} selectedIndex The index of the option to be set on the select.
+   */
   set selectedIndex(selectedIndex) {
     this.nativeControl_.selectedIndex = selectedIndex;
     this.foundation_.handleChange();
   }
 
+  /**
+   * @return {boolean} True if the select is disabled.
+   */
   get disabled() {
     return this.nativeControl_.disabled;
   }
 
+  /**
+   * @param {boolean} disabled Sets the select disabled or enabled.
+   */
   set disabled(disabled) {
     this.nativeControl_.disabled = disabled;
     this.foundation_.updateDisabledStyle(disabled);
@@ -17584,26 +17764,35 @@ class MDCSelect extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a" /
     this.foundation_.notchOutline(openNotch);
   }
 
+  /**
+   * @param {(function(!Element): !MDCLineRipple)=} lineRippleFactory A function which creates a new MDCLineRipple.
+   * @param {(function(!Element): !MDCFloatingLabel)=} labelFactory A function which creates a new MDCFloatingLabel.
+   * @param {(function(!Element): !MDCNotchedOutline)=} outlineFactory A function which creates a new MDCNotchedOutline.
+   */
   initialize(labelFactory = el => new __WEBPACK_IMPORTED_MODULE_1__material_floating_label_index__["a" /* MDCFloatingLabel */](el), lineRippleFactory = el => new __WEBPACK_IMPORTED_MODULE_2__material_line_ripple_index__["a" /* MDCLineRipple */](el), outlineFactory = el => new __WEBPACK_IMPORTED_MODULE_4__material_notched_outline_index__["a" /* MDCNotchedOutline */](el)) {
-    this.nativeControl_ = this.root_.querySelector(__WEBPACK_IMPORTED_MODULE_6__constants__["c" /* strings */].NATIVE_CONTROL_SELECTOR);
-    const labelElement = this.root_.querySelector(__WEBPACK_IMPORTED_MODULE_6__constants__["c" /* strings */].LABEL_SELECTOR);
+    this.nativeControl_ = this.root_.querySelector(__WEBPACK_IMPORTED_MODULE_7__constants__["c" /* strings */].NATIVE_CONTROL_SELECTOR);
+    const labelElement = this.root_.querySelector(__WEBPACK_IMPORTED_MODULE_7__constants__["c" /* strings */].LABEL_SELECTOR);
     if (labelElement) {
       this.label_ = labelFactory(labelElement);
     }
-    const lineRippleElement = this.root_.querySelector(__WEBPACK_IMPORTED_MODULE_6__constants__["c" /* strings */].LINE_RIPPLE_SELECTOR);
+    const lineRippleElement = this.root_.querySelector(__WEBPACK_IMPORTED_MODULE_7__constants__["c" /* strings */].LINE_RIPPLE_SELECTOR);
     if (lineRippleElement) {
       this.lineRipple_ = lineRippleFactory(lineRippleElement);
     }
-    const outlineElement = this.root_.querySelector(__WEBPACK_IMPORTED_MODULE_6__constants__["c" /* strings */].OUTLINE_SELECTOR);
+    const outlineElement = this.root_.querySelector(__WEBPACK_IMPORTED_MODULE_7__constants__["c" /* strings */].OUTLINE_SELECTOR);
     if (outlineElement) {
       this.outline_ = outlineFactory(outlineElement);
     }
 
-    if (this.root_.classList.contains(__WEBPACK_IMPORTED_MODULE_6__constants__["a" /* cssClasses */].BOX)) {
+    if (this.root_.classList.contains(__WEBPACK_IMPORTED_MODULE_7__constants__["a" /* cssClasses */].BOX)) {
       this.ripple = this.initRipple_();
     }
   }
 
+  /**
+   * @private
+   * @return {!MDCRipple}
+   */
   initRipple_() {
     const adapter = Object.assign(__WEBPACK_IMPORTED_MODULE_3__material_ripple_index__["a" /* MDCRipple */].createAdapter(this), {
       registerInteractionHandler: (type, handler) => this.nativeControl_.addEventListener(type, handler),
@@ -17613,6 +17802,10 @@ class MDCSelect extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a" /
     return new __WEBPACK_IMPORTED_MODULE_3__material_ripple_index__["a" /* MDCRipple */](this.root_, foundation);
   }
 
+  /**
+   * Initializes the select's event listeners and internal state based
+   * on the environment's state.
+   */
   initialSyncWithDOM() {
     this.handleChange_ = () => this.foundation_.handleChange();
     this.handleFocus_ = () => this.foundation_.handleFocus();
@@ -17645,11 +17838,17 @@ class MDCSelect extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a" /
     super.destroy();
   }
 
+  /**
+   * @return {!MDCSelectFoundation}
+   */
   getDefaultFoundation() {
-    return new __WEBPACK_IMPORTED_MODULE_5__foundation__["a" /* default */](Object.assign({
+    return new __WEBPACK_IMPORTED_MODULE_5__foundation__["a" /* default */](
+    /** @type {!MDCSelectAdapter} */Object.assign({
       addClass: className => this.root_.classList.add(className),
       removeClass: className => this.root_.classList.remove(className),
       hasClass: className => this.root_.classList.contains(className),
+      getValue: () => this.nativeControl_.value,
+      isRtl: () => window.getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
       activateBottomLine: () => {
         if (this.lineRipple_) {
           this.lineRipple_.activate();
@@ -17659,20 +17858,20 @@ class MDCSelect extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a" /
         if (this.lineRipple_) {
           this.lineRipple_.deactivate();
         }
-      },
-      isRtl: () => window.getComputedStyle(this.root_).getPropertyValue('direction') === 'rtl',
-      getValue: () => this.nativeControl_.value
+      }
     }, this.getOutlineAdapterMethods_(), this.getLabelAdapterMethods_()));
   }
 
   /**
    * @return {!{
-   *   notchOutline: function(number, boolean): undefined,
    *   hasOutline: function(): boolean,
+   *   notchOutline: function(number, boolean): undefined,
+   *   closeOutline: function(): undefined,
    * }}
    */
   getOutlineAdapterMethods_() {
     return {
+      hasOutline: () => !!this.outline_,
       notchOutline: (labelWidth, isRtl) => {
         if (this.outline_) {
           this.outline_.notch(labelWidth, isRtl);
@@ -17682,26 +17881,25 @@ class MDCSelect extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a" /
         if (this.outline_) {
           this.outline_.closeNotch();
         }
-      },
-      hasOutline: () => !!this.outline_
+      }
     };
   }
 
   /**
    * @return {!{
-   *   floatLabel: function(boolean): undefined,
    *   hasLabel: function(): boolean,
+   *   floatLabel: function(boolean): undefined,
    *   getLabelWidth: function(): number,
    * }}
    */
   getLabelAdapterMethods_() {
     return {
+      hasLabel: () => !!this.label_,
       floatLabel: shouldFloat => {
         if (this.label_) {
           this.label_.float(shouldFloat);
         }
       },
-      hasLabel: () => !!this.label_,
       getLabelWidth: () => {
         if (this.label_) {
           return this.label_.getWidth();
@@ -17710,16 +17908,17 @@ class MDCSelect extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a" /
     };
   }
 }
-/* harmony export (immutable) */ __webpack_exports__["a"] = MDCSelect;
+
 
 
 /***/ }),
-/* 92 */
+/* 93 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_index__ = __webpack_require__(8);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__constants__ = __webpack_require__(35);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(35);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(36);
 /**
  * Copyright 2016 Google Inc. All Rights Reserved.
  *
@@ -17737,46 +17936,66 @@ class MDCSelect extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["a" /
  */
 
 
+/* eslint-disable no-unused-vars */
+
+/* eslint-enable no-unused-vars */
 
 
+/**
+ * @extends {MDCFoundation<!MDCSelectAdapter>}
+ * @final
+ */
 class MDCSelectFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_index__["b" /* MDCFoundation */] {
+  /** @return enum {string} */
   static get cssClasses() {
-    return __WEBPACK_IMPORTED_MODULE_1__constants__["a" /* cssClasses */];
+    return __WEBPACK_IMPORTED_MODULE_2__constants__["a" /* cssClasses */];
   }
 
+  /** @return enum {number} */
   static get numbers() {
-    return __WEBPACK_IMPORTED_MODULE_1__constants__["b" /* numbers */];
+    return __WEBPACK_IMPORTED_MODULE_2__constants__["b" /* numbers */];
   }
 
+  /** @return enum {string} */
   static get strings() {
-    return __WEBPACK_IMPORTED_MODULE_1__constants__["c" /* strings */];
+    return __WEBPACK_IMPORTED_MODULE_2__constants__["c" /* strings */];
   }
 
+  /**
+   * {@see MDCSelectAdapter} for typing information on parameters and return
+   * types.
+   * @return {!MDCSelectAdapter}
+   */
   static get defaultAdapter() {
-    return {
-      addClass: () => /* className: string */{},
-      removeClass: () => /* className: string */{},
-      hasClass: () => /* className: string */false,
-      floatLabel: () => /* value: boolean */{},
-      activateBottomLine: () => {},
-      deactivateBottomLine: () => {},
-      getValue: () => {},
-      isRtl: () => false,
-      hasLabel: () => {},
-      getLabelWidth: () => {},
-      hasOutline: () => {},
-      notchOutline: () => {},
-      closeOutline: () => {}
-    };
+    return (/** @type {!MDCSelectAdapter} */{
+        addClass: () => /* className: string */{},
+        removeClass: () => /* className: string */{},
+        hasClass: () => /* className: string */false,
+        activateBottomLine: () => {},
+        deactivateBottomLine: () => {},
+        getValue: () => {},
+        isRtl: () => false,
+        hasLabel: () => false,
+        floatLabel: () => /* value: boolean */{},
+        getLabelWidth: () => {},
+        hasOutline: () => false,
+        notchOutline: () => /* labelWidth: number, isRtl: boolean */{},
+        closeOutline: () => {}
+      }
+    );
   }
 
+  /**
+   * @param {!MDCSelectAdapter} adapter
+   */
   constructor(adapter) {
     super(Object.assign(MDCSelectFoundation.defaultAdapter, adapter));
-
-    this.focusHandler_ = evt => this.handleFocus_(evt);
-    this.blurHandler_ = evt => this.handleBlur_(evt);
   }
 
+  /**
+   * Updates the styles of the select to show the disasbled state.
+   * @param {boolean} disabled
+   */
   updateDisabledStyle(disabled) {
     const { DISABLED } = MDCSelectFoundation.cssClasses;
     if (disabled) {
@@ -17786,18 +18005,27 @@ class MDCSelectFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_ind
     }
   }
 
+  /**
+   * Handles value changes, via change event or programmatic updates.
+   */
   handleChange() {
     const optionHasValue = this.adapter_.getValue().length > 0;
     this.adapter_.floatLabel(optionHasValue);
     this.notchOutline(optionHasValue);
   }
 
+  /**
+   * Handles focus events from root element.
+   */
   handleFocus() {
     this.adapter_.floatLabel(true);
     this.notchOutline(true);
     this.adapter_.activateBottomLine();
   }
 
+  /**
+   * Handles blur events from root element.
+   */
   handleBlur() {
     this.handleChange();
     this.adapter_.deactivateBottomLine();
@@ -17813,7 +18041,7 @@ class MDCSelectFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_ind
     }
 
     if (openNotch) {
-      const labelScale = __WEBPACK_IMPORTED_MODULE_1__constants__["b" /* numbers */].LABEL_SCALE;
+      const labelScale = __WEBPACK_IMPORTED_MODULE_2__constants__["b" /* numbers */].LABEL_SCALE;
       const labelWidth = this.adapter_.getLabelWidth() * labelScale;
       const isRtl = this.adapter_.isRtl();
       this.adapter_.notchOutline(labelWidth, isRtl);
@@ -17822,16 +18050,16 @@ class MDCSelectFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_ind
     }
   }
 }
-/* harmony export (immutable) */ __webpack_exports__["a"] = MDCSelectFoundation;
 
+/* harmony default export */ __webpack_exports__["a"] = (MDCSelectFoundation);
 
 /***/ }),
-/* 93 */
+/* 94 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initChips;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(94);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(95);
 
 
 function initChips() {
@@ -17846,12 +18074,12 @@ function initChips() {
 }
 
 /***/ }),
-/* 94 */
+/* 95 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__chip_index__ = __webpack_require__(36);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__chip_set_index__ = __webpack_require__(95);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__chip_index__ = __webpack_require__(37);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__chip_set_index__ = __webpack_require__(96);
 /* unused harmony reexport MDCChipFoundation */
 /* harmony reexport (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return __WEBPACK_IMPORTED_MODULE_0__chip_index__["a"]; });
 /* unused harmony reexport MDCChipSetFoundation */
@@ -17878,15 +18106,15 @@ function initChips() {
 
 
 /***/ }),
-/* 95 */
+/* 96 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* unused harmony export MDCChipSet */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(39);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(96);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__chip_index__ = __webpack_require__(36);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(40);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(97);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__chip_index__ = __webpack_require__(37);
 /* unused harmony reexport MDCChipSetFoundation */
 /**
  * @license
@@ -18010,14 +18238,14 @@ class MDCChipSet extends __WEBPACK_IMPORTED_MODULE_0__material_base_component__[
 
 
 /***/ }),
-/* 96 */
+/* 97 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(39);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(40);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__chip_foundation__ = __webpack_require__(15);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(97);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(98);
 /**
  * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
@@ -18145,7 +18373,7 @@ class MDCChipSetFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_fo
 /* harmony default export */ __webpack_exports__["a"] = (MDCChipSetFoundation);
 
 /***/ }),
-/* 97 */
+/* 98 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -18182,7 +18410,7 @@ const cssClasses = {
 
 
 /***/ }),
-/* 98 */
+/* 99 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -18192,7 +18420,7 @@ function initCards() {
 }
 
 /***/ }),
-/* 99 */
+/* 100 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -18267,12 +18495,12 @@ class VForm {
 
 
 /***/ }),
-/* 100 */
+/* 101 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initCheckboxes;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_checkbox__ = __webpack_require__(101);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_checkbox__ = __webpack_require__(102);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(4);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(3);
 
@@ -18311,7 +18539,7 @@ class VCheckbox extends Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler
 
 
 /***/ }),
-/* 101 */
+/* 102 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -18319,7 +18547,7 @@ class VCheckbox extends Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_animation_index__ = __webpack_require__(14);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_selection_control_index__ = __webpack_require__(5);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__foundation__ = __webpack_require__(102);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__foundation__ = __webpack_require__(103);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__material_ripple_index__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__material_ripple_util__ = __webpack_require__(7);
 /* unused harmony reexport MDCCheckboxFoundation */
@@ -18463,14 +18691,14 @@ class MDCCheckbox extends __WEBPACK_IMPORTED_MODULE_1__material_base_component__
 
 
 /***/ }),
-/* 102 */
+/* 103 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_selection_control_index__ = __webpack_require__(5);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__adapter__ = __webpack_require__(103);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(104);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__adapter__ = __webpack_require__(104);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(105);
 /**
  * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
@@ -18789,7 +19017,7 @@ function validDescriptor(inputPropDesc) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCCheckboxFoundation);
 
 /***/ }),
-/* 103 */
+/* 104 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -18876,7 +19104,7 @@ class MDCCheckboxAdapter {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCCheckboxAdapter);
 
 /***/ }),
-/* 104 */
+/* 105 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -18936,14 +19164,14 @@ const numbers = {
 
 
 /***/ }),
-/* 105 */
+/* 106 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSwitches;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(4);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(106);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(107);
 
 
 
@@ -18983,15 +19211,15 @@ class VSwitch extends Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__
 
 
 /***/ }),
-/* 106 */
+/* 107 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCSwitch; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_selection_control_index__ = __webpack_require__(107);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(110);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_ripple_index__ = __webpack_require__(40);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_selection_control_index__ = __webpack_require__(108);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(111);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_ripple_index__ = __webpack_require__(41);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__material_ripple_util__ = __webpack_require__(16);
 /* unused harmony reexport MDCSwitchFoundation */
 /**
@@ -19124,13 +19352,13 @@ class MDCSwitch extends __WEBPACK_IMPORTED_MODULE_0__material_base_component__["
 
 
 /***/ }),
-/* 107 */
+/* 108 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* unused harmony export MDCSelectionControlState */
 /* unused harmony export MDCSelectionControl */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple_index__ = __webpack_require__(40);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple_index__ = __webpack_require__(41);
 /**
  * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
@@ -19173,13 +19401,13 @@ class MDCSelectionControl {
 
 
 /***/ }),
-/* 108 */
+/* 109 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(41);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(109);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(42);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(110);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(16);
 /**
  * @license
@@ -19776,7 +20004,7 @@ class MDCRippleFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_fou
 /* harmony default export */ __webpack_exports__["a"] = (MDCRippleFoundation);
 
 /***/ }),
-/* 109 */
+/* 110 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -19831,13 +20059,13 @@ const numbers = {
 
 
 /***/ }),
-/* 110 */
+/* 111 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(111);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(112);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(112);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(113);
 /**
  * @license
  * Copyright 2018 Google Inc. All Rights Reserved.
@@ -19947,7 +20175,7 @@ class MDCSwitchFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_fou
 /* harmony default export */ __webpack_exports__["a"] = (MDCSwitchFoundation);
 
 /***/ }),
-/* 111 */
+/* 112 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -20008,7 +20236,7 @@ class MDCSwitchAdapter {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCSwitchAdapter);
 
 /***/ }),
-/* 112 */
+/* 113 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -20046,12 +20274,12 @@ const strings = {
 
 
 /***/ }),
-/* 113 */
+/* 114 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRichTextArea;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(114);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(115);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
 
 
@@ -20092,7 +20320,7 @@ function initRichTextArea() {
 }
 
 /***/ }),
-/* 114 */
+/* 115 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(Buffer) {/*!
@@ -32988,10 +33216,10 @@ function initRichTextArea() {
     /******/)["default"]
   );
 });
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(115).Buffer))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(116).Buffer))
 
 /***/ }),
-/* 115 */
+/* 116 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -33005,9 +33233,9 @@ function initRichTextArea() {
 
 
 
-var base64 = __webpack_require__(117);
-var ieee754 = __webpack_require__(118);
-var isArray = __webpack_require__(119);
+var base64 = __webpack_require__(118);
+var ieee754 = __webpack_require__(119);
+var isArray = __webpack_require__(120);
 
 exports.Buffer = Buffer;
 exports.SlowBuffer = SlowBuffer;
@@ -34732,10 +34960,10 @@ function blitBuffer(src, dst, offset, length) {
 function isnan(val) {
   return val !== val; // eslint-disable-line no-self-compare
 }
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(116)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(117)))
 
 /***/ }),
-/* 116 */
+/* 117 */
 /***/ (function(module, exports) {
 
 var g;
@@ -34760,7 +34988,7 @@ try {
 module.exports = g;
 
 /***/ }),
-/* 117 */
+/* 118 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -34887,7 +35115,7 @@ function fromByteArray(uint8) {
 }
 
 /***/ }),
-/* 118 */
+/* 119 */
 /***/ (function(module, exports) {
 
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
@@ -34976,7 +35204,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 };
 
 /***/ }),
-/* 119 */
+/* 120 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -34986,7 +35214,7 @@ module.exports = Array.isArray || function (arr) {
 };
 
 /***/ }),
-/* 120 */
+/* 121 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -35042,15 +35270,15 @@ class VStepper extends Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler_
 
 
 /***/ }),
-/* 121 */
+/* 122 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRadios;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(4);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(122);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_radio__ = __webpack_require__(126);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_radio__ = __webpack_require__(127);
 
 
 
@@ -35088,13 +35316,13 @@ class VRadio extends Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__[
 
 
 /***/ }),
-/* 122 */
+/* 123 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* unused harmony export MDCFormField */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(124);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_selection_control_index__ = __webpack_require__(5);
 /* unused harmony reexport MDCFormFieldFoundation */
 /**
@@ -35177,13 +35405,13 @@ class MDCFormField extends __WEBPACK_IMPORTED_MODULE_0__material_base_component_
 
 
 /***/ }),
-/* 123 */
+/* 124 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(124);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(125);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(125);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(126);
 /**
  * @license
  * Copyright 2017 Google Inc. All Rights Reserved.
@@ -35254,7 +35482,7 @@ class MDCFormFieldFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_
 /* harmony default export */ __webpack_exports__["a"] = (MDCFormFieldFoundation);
 
 /***/ }),
-/* 124 */
+/* 125 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -35313,7 +35541,7 @@ class MDCFormFieldAdapter {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCFormFieldAdapter);
 
 /***/ }),
-/* 125 */
+/* 126 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -35349,14 +35577,14 @@ const strings = {
 
 
 /***/ }),
-/* 126 */
+/* 127 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCRadio; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_selection_control_index__ = __webpack_require__(5);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(127);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(128);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_ripple_index__ = __webpack_require__(2);
 /* unused harmony reexport MDCRadioFoundation */
 /**
@@ -35480,14 +35708,14 @@ class MDCRadio extends __WEBPACK_IMPORTED_MODULE_0__material_base_component__["a
 
 
 /***/ }),
-/* 127 */
+/* 128 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_selection_control_index__ = __webpack_require__(5);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__adapter__ = __webpack_require__(128);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(129);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__adapter__ = __webpack_require__(129);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(130);
 /**
  * @license
  * Copyright 2016 Google Inc. All Rights Reserved.
@@ -35588,7 +35816,7 @@ class MDCRadioFoundation extends __WEBPACK_IMPORTED_MODULE_0__material_base_foun
 /* harmony default export */ __webpack_exports__["a"] = (MDCRadioFoundation);
 
 /***/ }),
-/* 128 */
+/* 129 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -35644,7 +35872,7 @@ class MDCRadioAdapter {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCRadioAdapter);
 
 /***/ }),
-/* 129 */
+/* 130 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -35681,14 +35909,14 @@ const cssClasses = {
 
 
 /***/ }),
-/* 130 */
+/* 131 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSliders;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(4);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(131);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(132);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(30);
 
 
@@ -35725,15 +35953,15 @@ class VSlider extends Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_obse
 
 
 /***/ }),
-/* 131 */
+/* 132 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCSlider; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__constants__ = __webpack_require__(42);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__adapter__ = __webpack_require__(43);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__foundation__ = __webpack_require__(132);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__constants__ = __webpack_require__(43);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__adapter__ = __webpack_require__(44);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__foundation__ = __webpack_require__(133);
 /* unused harmony reexport MDCSliderFoundation */
 /**
  * @license
@@ -35939,12 +36167,12 @@ class MDCSlider extends __WEBPACK_IMPORTED_MODULE_0__material_base_component__["
 
 
 /***/ }),
-/* 132 */
+/* 133 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(42);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(43);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(43);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(44);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_animation_index__ = __webpack_require__(14);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_base_foundation__ = __webpack_require__(0);
 /**
@@ -36519,7 +36747,7 @@ class MDCSliderFoundation extends __WEBPACK_IMPORTED_MODULE_3__material_base_fou
 /* harmony default export */ __webpack_exports__["a"] = (MDCSliderFoundation);
 
 /***/ }),
-/* 133 */
+/* 134 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";

--- a/views/mdc/assets/scss/components/list.scss
+++ b/views/mdc/assets/scss/components/list.scss
@@ -26,4 +26,8 @@
   padding-right: 6px;
 }
 
+.mdc-list-item__secondary-text::before {
+    content: unset;
+}
+
 

--- a/views/mdc/package-lock.json
+++ b/views/mdc/package-lock.json
@@ -13,114 +13,107 @@
       "integrity": "sha512-PYuluVzcH8hxtionVvpTSygTENlgyOHvJ5ka7JfbCRQfXlxjV8zKYwhh9u/1HqA6y1OonG1oGFCaBHopbdsNEQ=="
     },
     "@material/button": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/button/-/button-0.37.0.tgz",
-      "integrity": "sha512-R0fpPCpl0dh3lbYbAK18tTx/rUAzUBihpRI+uh+//q2snPkZjG57F69zpl5UqA54KpzgFwbui/UFeA/prm+EbQ==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-0.38.1.tgz",
+      "integrity": "sha512-ceib9rvFIpUTe0/3crfmR/y4OTOQibj6OlHGedA5H/sh2d9ie+btQLP4Xe8I6UKZdzcy6IiLvmlRWR0YdABmZw==",
       "requires": {
-        "@material/elevation": "0.36.1",
-        "@material/ripple": "0.37.0",
+        "@material/elevation": "0.38.0",
+        "@material/ripple": "0.38.1",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.35.0"
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/card": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/card/-/card-0.37.0.tgz",
-      "integrity": "sha512-pBTomsmvPY07/Ecue74JvZjZ1k5uFo03X7jWU0ZYIULqdjq2PUQSDrz7KmZ6NVJhjOpquwsnqpZj1pnFLzpe9w==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/card/-/card-0.38.1.tgz",
+      "integrity": "sha512-IAJsjD6DNjCUqH7Kk4+Xbehs8VVIqtyFKk4hgAC9poiMWi1gHs9M0H5KRforMlb6lXDAJ9b5t/7QvQodC++Fbg==",
       "requires": {
-        "@material/elevation": "0.36.1",
-        "@material/ripple": "0.37.0",
+        "@material/elevation": "0.38.0",
+        "@material/ripple": "0.38.1",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0"
+        "@material/theme": "0.38.0"
       }
     },
     "@material/checkbox": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-0.37.0.tgz",
-      "integrity": "sha512-rQS1n63uVcKOTrrJ2S2NTq7MB3obGN/rD/tu5H62lXRoQcZq6MR16hU90ClX1DFpIqmJQAT9ONkx9by6FCmU9w==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-0.38.1.tgz",
+      "integrity": "sha512-YJYrE1JCFbGhSjkE3vv9o+u7JKzQx0B+feGsalZ7YDVfKfQyvgJOt5c0ILkKWshzI3QMTRUjzIQfYo8GlFACqg==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/ripple": "0.37.0",
+        "@material/ripple": "0.38.1",
         "@material/rtl": "0.36.0",
-        "@material/selection-control": "0.37.0",
-        "@material/theme": "0.35.0"
+        "@material/selection-control": "0.38.1",
+        "@material/theme": "0.38.0"
       }
     },
     "@material/chips": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-0.37.0.tgz",
-      "integrity": "sha512-16VL8f6VMLplHVStrI10JTJOVqVVXK9QI12BX+3LNLu44h/LUmxG4ovXIb0L3QTiBF8Nv5D6FK/PO/msRAs9YQ==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-0.38.1.tgz",
+      "integrity": "sha512-l6fAl5DNdT1b3Gu0nJsYtdg++M/srtu9KyVTShH2nvXvvWlnRi2yxXp3mZJ1H7HTMk4vtlcDPRtaxaUDKXxLwg==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/checkbox": "0.37.0",
-        "@material/ripple": "0.37.0",
-        "@material/typography": "0.35.0"
+        "@material/checkbox": "0.38.1",
+        "@material/ripple": "0.38.1",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/elevation": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-0.36.1.tgz",
-      "integrity": "sha512-kh7paJc3jc+6O6Op93j8S/eFqiA9KhSsT/gtQeVbEt2ebGweh4TTc/Smm0D/RPOzifPL1mRMAQY7SgFchlz1AQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-0.38.0.tgz",
+      "integrity": "sha512-uceP/4qL6U1cyY4mc/CHF6msceQwICAt2LD+hTAEKFTTFSLNsvZxqB+Oa7Yq7O5Wl9iBt2RAHtCiT5R/ACUa2Q==",
       "requires": {
         "@material/animation": "0.34.0",
-        "@material/theme": "0.35.0"
+        "@material/theme": "0.38.0"
       }
     },
     "@material/fab": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-0.37.0.tgz",
-      "integrity": "sha512-i/Fc6VZsxJ6jxY8JgCmfliDHF56BCsEOOVw7/rXIurP0gqyplF4LVETTerxyFGWXqx5owjbYoG8wlwaxNN/aFw==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-0.38.1.tgz",
+      "integrity": "sha512-4natB43w8KO5dQeT6FeC+IKV23W+2Otap9GQ1/sZBjEQf2bz4XvS2fQqW2RhJvNhQmNMEC6PiuYVFyh2t8Hw6A==",
       "requires": {
         "@material/animation": "0.34.0",
-        "@material/elevation": "0.36.1",
-        "@material/ripple": "0.37.0",
+        "@material/elevation": "0.38.0",
+        "@material/ripple": "0.38.1",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.35.0"
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/floating-label": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-0.37.1.tgz",
-      "integrity": "sha512-y/nH5zh56HvL5do9vZ84/ky70Cdd6/ws+IXXDPouUp9MFSP2jhXuuWDDns2vYFIZI/I58ldCtfPsn9bJTqmpTw==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-0.38.0.tgz",
+      "integrity": "sha512-ga+7ELYrkiRYMHqkLOnCKaQUvGowMYXqML3I7hBhs3eEchTjx42U7bfTSqbfdiNG1F9+cOcSOWTKug2VOkYlkg==",
       "requires": {
         "@material/base": "0.35.0",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.37.1"
-      },
-      "dependencies": {
-        "@material/typography": {
-          "version": "0.37.1",
-          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-0.37.1.tgz",
-          "integrity": "sha512-njbRrUwSte+Ag2ZsQxYCZVXqYphm7Wbe1iFCzljRAZEcZJUuKkz30rx3IK5CrmwoIpLxcE2Y/2WoAj8a2Ear0A=="
-        }
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/form-field": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-0.37.0.tgz",
-      "integrity": "sha512-ZpxKoT+UCzp8/aiyTAWrHWCMiqQ8o9aHYVBC8zxy3Gt1W4e5fvxAunG7K8wzs3ADOzhpcPZCABcFrnPtuH7L1Q==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-0.38.1.tgz",
+      "integrity": "sha512-pJaTRh3YvioU4hdIigy8hE+YibRt23kS40gPq5i6qRZyWX1LQcfxqsJBNqmFDz+LooLiKhSs3m9mAPNz7APNUg==",
       "requires": {
         "@material/base": "0.35.0",
         "@material/rtl": "0.36.0",
-        "@material/selection-control": "0.37.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.35.0"
+        "@material/selection-control": "0.38.1",
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/icon-toggle": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/icon-toggle/-/icon-toggle-0.37.0.tgz",
-      "integrity": "sha512-N+Yt1QcMPomiNsUFo3teTVYnkZkl2hoSmGEUZho/vEYQHyodYhJWEv/UpVkhKN0UspSf58E3sze2QYRt+byyVg==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/icon-toggle/-/icon-toggle-0.38.1.tgz",
+      "integrity": "sha512-kscaeuLahGXnEquIJ77Ey7XR4zfPNJnzNkSoSVWD5G5LdxfL5vAKE4Cbb/NEK6/kJ3eB0uDOTAFTrxCm7TEV8Q==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/ripple": "0.37.0",
-        "@material/theme": "0.35.0"
+        "@material/ripple": "0.38.1",
+        "@material/theme": "0.38.0"
       }
     },
     "@material/layout-grid": {
@@ -129,69 +122,69 @@
       "integrity": "sha512-LJ3LHCumfGftl1ihO0LW9JKsnR71nnlvpzhHdUlK6o1GPul+EEUUdOFN1zxI+Ik9iS++1na/Dg8f/1sdQUxj6w=="
     },
     "@material/line-ripple": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-0.35.0.tgz",
-      "integrity": "sha512-0w0kLYo2dGBiR2kgHxybifO7z4UxIYbL55EKOqkg+rG0dC+NkzFoURhjwoll6910EOlS//5UNo1N/u3to3uNjg==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-0.38.0.tgz",
+      "integrity": "sha512-HdfU0J1Q3CT2Z/H4aBEKGRTd7K33WhhQkieI4NGGyKSx4uwiRyr61i44Oo+YHK+fVqPjh+aMSjQU3wAfu3vSvA==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/theme": "0.35.0"
+        "@material/theme": "0.38.0"
       }
     },
     "@material/list": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/list/-/list-0.37.0.tgz",
-      "integrity": "sha512-ZkdwVxvMDdu9B6TLQyjxBLTpyi7yBT4JEGI52EM2VtEVXGu4Y7QEjApxZu0qh8gd43qqfeFbdLlp+yXjfU1d9g==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-0.38.1.tgz",
+      "integrity": "sha512-by19/KoEqAESGLTC8FuiClsHz7SUUCk9u7vWaQ23NSznMfabG/kBpf82WZfgJcUvCodNQyNSmFuxVkFttd6crg==",
       "requires": {
         "@material/base": "0.35.0",
-        "@material/ripple": "0.37.0",
+        "@material/ripple": "0.38.1",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.35.0"
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/menu": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-0.36.1.tgz",
-      "integrity": "sha512-Bc1Bga7QPaBTw1+d50hvFth6I4HirBknur1lfOm+VQnLrmmCeHRBtpjT1l2PAgiFHFWu+3SY5HanwynEdFgKYQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-0.38.0.tgz",
+      "integrity": "sha512-dq+ZoyxaBBk/J+TCQJ5GQM73GEYLiKJD+M+Ub1WMbgKUb7WQhQuhgVB51YJEcCL8grzEosnbK51SgnyuXODKKg==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/elevation": "0.36.1",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.35.0"
+        "@material/elevation": "0.38.0",
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/notched-outline": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-0.35.0.tgz",
-      "integrity": "sha512-VXng7P2E0FPbhmoe0afSnKmHocrwOxVHSaEnt46lZL0nT4O19JISprgCWrFHblbhq92SrppHdS73PHzxgfI9HQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-0.38.0.tgz",
+      "integrity": "sha512-XDTVXyQ2TR/9Qa66F1UYBSbf5f0IVFJFjiF8TXyIkoqrP6l7Wauj+UvJpinwCPk/6KoZtj29sh6ToGQiHdVIJA==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/theme": "0.35.0"
+        "@material/theme": "0.38.0"
       }
     },
     "@material/radio": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-0.37.0.tgz",
-      "integrity": "sha512-hEPp3HlhRn9Yt6B1fw1guz5QyIlUYjDrpvwgwPncyZ2SYqKhp/hb02/58amV3LHbFvgRFJnsSaBY5l5Hbmf3bw==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-0.38.1.tgz",
+      "integrity": "sha512-zvD7xlzsAusihP3EbRyzf0mH8dy1qCDLMpjZvlwKimgOJNlua87dlbW0c14PwKSoJaS87vFR4v5rMa6+94C0SA==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/ripple": "0.37.0",
-        "@material/selection-control": "0.37.0",
-        "@material/theme": "0.35.0"
+        "@material/ripple": "0.38.1",
+        "@material/selection-control": "0.38.1",
+        "@material/theme": "0.38.0"
       }
     },
     "@material/ripple": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.37.0.tgz",
-      "integrity": "sha512-ybK8w1UlzUn6UJLoCqM3steG9q4exVkR6kZdywy2dE+ddGLe0VRQ/TcJYSfZTIQ0sMyfu8io72iscVWY9dDWdg==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.38.1.tgz",
+      "integrity": "sha512-Y7fmJCEJMfJFkyDCEHkBR66tHqy4JAlG49rk0cI0/xdAFmAKyqUcpJiVwhF+pC8Fad90Wi3G93xu/ig7dvz1bA==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/theme": "0.35.0"
+        "@material/theme": "0.38.0"
       }
     },
     "@material/rtl": {
@@ -200,70 +193,50 @@
       "integrity": "sha512-uCMwWGdKG0ooYh1kVINz7vTgSY++9wnvU3kOqjRdfOY+PZHWSa/X/EqRdE9Q1pUFwYlQeU2PXE/Z2dTK/nlziw=="
     },
     "@material/select": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/select/-/select-0.37.0.tgz",
-      "integrity": "sha512-9WZS3cXdb5Xy/b0TWt9jNif+S6HvRSLwj6uT8+Ij8/G0q5yjN94yAWi3wMw7bAZyfek0u7ak7WAz/8SxkiUe8g==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-0.38.1.tgz",
+      "integrity": "sha512-42eaR3CkK6DU011BBUG10dG0MsTf01dGtGaJ4Mu4fA2y/XqY1Au9/fLVOWLHWVEPCJNNXytYyNY6D83u7joqZg==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/floating-label": "0.36.0",
-        "@material/line-ripple": "0.35.0",
-        "@material/notched-outline": "0.35.0",
-        "@material/ripple": "0.37.0",
+        "@material/floating-label": "0.38.0",
+        "@material/line-ripple": "0.38.0",
+        "@material/notched-outline": "0.38.0",
+        "@material/ripple": "0.38.1",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.35.0"
-      },
-      "dependencies": {
-        "@material/floating-label": {
-          "version": "0.36.0",
-          "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-0.36.0.tgz",
-          "integrity": "sha512-hou0x0zm4FMbO0Uy9qxN/iyQznWghput+/QXSfyBE9fHE91EDFlZKirUwzmszm4B+Z3guxo04KZu4N4h6byCsg==",
-          "requires": {
-            "@material/base": "0.35.0",
-            "@material/rtl": "0.36.0",
-            "@material/theme": "0.35.0",
-            "@material/typography": "0.35.0"
-          }
-        }
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/selection-control": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/selection-control/-/selection-control-0.37.0.tgz",
-      "integrity": "sha512-HG5jzNAVVu/ZbtQaiPzZreXovZJ0WpuiQHWMsfmJybjfhC/ZBT2xjvDZJEQXZLunYXeOJPKKh3In6E+U0w5XDg==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/selection-control/-/selection-control-0.38.1.tgz",
+      "integrity": "sha512-EUTHx323geAqbPXgMrtu9TCq/IstPma3eJtU50xdpuX/aOVviFIcBzDtK1LBc5czprcuo4wowdfIDvcD+lafxQ==",
       "requires": {
-        "@material/ripple": "0.37.0"
+        "@material/ripple": "0.38.1"
       }
     },
     "@material/slider": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-0.36.0.tgz",
-      "integrity": "sha512-WB4j62IzrQgToWrDwe5ssSX/7wUD2cvCNlVkehz0syjUMWLCDv3ZrWTJQhd3K6XE3TjSjtTa5JjhkuezAAr41A==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-0.38.0.tgz",
+      "integrity": "sha512-HF0XPteiS8IpT1xyGi1dYLd5CW3FxXlDKteNsuhroSFXON2CNH+voHdfT+jW1WfkWcDKSthmSTB1iabD8+9xDg==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0"
+        "@material/theme": "0.38.0"
       }
     },
     "@material/snackbar": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-0.35.0.tgz",
-      "integrity": "sha512-RrKz9Zg5o4tree3h+c+GQrWjTeCnImT7omyMGWge8wdsxu3snXNdLqzvqmeVsZMIB+jMk5VWye7fGjU9wsJT6Q==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-0.38.0.tgz",
+      "integrity": "sha512-YvQJTxcd8SkCejI2NiZtAiIzvA097zm0qLQr1bD8j3uAuuuenK3BllNKO8K9nPAmvLmOGS5GRaeRUfsmWcwzTA==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/rtl": "0.35.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.35.0"
-      },
-      "dependencies": {
-        "@material/rtl": {
-          "version": "0.35.0",
-          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-0.35.0.tgz",
-          "integrity": "sha512-Cn5xpwgVuB37NUTAPS+TMZ+XLJaztp7oDrv5y73zu0ZjTnf9HPAsS16ovauf8HQqMaZyAj9B3tvZHL05g4y5pA=="
-        }
+        "@material/rtl": "0.36.0",
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/switch": {
@@ -315,81 +288,43 @@
       }
     },
     "@material/textfield": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-0.37.1.tgz",
-      "integrity": "sha512-Pjuy1+FOFmLpId+Wm3ncrhJcPI+Fct5wpErFZO8/eMhtfRs41+LqlTSDSggcYg8AjNo20/8P0Y5RIo67rkaYHQ==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-0.38.1.tgz",
+      "integrity": "sha512-ymgDVc1W0ToMVnzfjlhATXHgVDST3zqMKfrI7u4eHkXm5v4eaH2SWlIUDBJDUAKtvcHq1BmAhzB3CcWweLw0qw==",
       "requires": {
         "@material/animation": "0.34.0",
         "@material/base": "0.35.0",
-        "@material/floating-label": "0.37.1",
-        "@material/line-ripple": "0.35.0",
-        "@material/notched-outline": "0.37.1",
-        "@material/ripple": "0.37.1",
+        "@material/floating-label": "0.38.0",
+        "@material/line-ripple": "0.38.0",
+        "@material/notched-outline": "0.38.0",
+        "@material/ripple": "0.38.1",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.37.1"
-      },
-      "dependencies": {
-        "@material/floating-label": {
-          "version": "0.37.1",
-          "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-0.37.1.tgz",
-          "integrity": "sha512-y/nH5zh56HvL5do9vZ84/ky70Cdd6/ws+IXXDPouUp9MFSP2jhXuuWDDns2vYFIZI/I58ldCtfPsn9bJTqmpTw==",
-          "requires": {
-            "@material/base": "0.35.0",
-            "@material/rtl": "0.36.0",
-            "@material/theme": "0.35.0",
-            "@material/typography": "0.37.1"
-          }
-        },
-        "@material/notched-outline": {
-          "version": "0.37.1",
-          "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-0.37.1.tgz",
-          "integrity": "sha512-IDaVgYWzzyYwOqjrhX8cdKFjBRnQvukwJNaBqlGv/Ikc+q7Q5UQLNGKQijYlCTR7lrzifIT3z6KpTFmYivbfDg==",
-          "requires": {
-            "@material/animation": "0.34.0",
-            "@material/base": "0.35.0",
-            "@material/theme": "0.35.0"
-          }
-        },
-        "@material/ripple": {
-          "version": "0.37.1",
-          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.37.1.tgz",
-          "integrity": "sha512-FSBZd8Qs7cFcfnVhGLAq4KnMteJQ6HnnEXYmpQxNFHxtkc4FpVh9AwwBsvzCzxbyuMqaKk9YsQubMjyhuuhQ9A==",
-          "requires": {
-            "@material/animation": "0.34.0",
-            "@material/base": "0.35.0",
-            "@material/theme": "0.35.0"
-          }
-        },
-        "@material/typography": {
-          "version": "0.37.1",
-          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-0.37.1.tgz",
-          "integrity": "sha512-njbRrUwSte+Ag2ZsQxYCZVXqYphm7Wbe1iFCzljRAZEcZJUuKkz30rx3IK5CrmwoIpLxcE2Y/2WoAj8a2Ear0A=="
-        }
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/theme": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-0.35.0.tgz",
-      "integrity": "sha512-jTjRDPKlWVCNnSs4RRe/eq9+F5lFBzxfbuI7klgCR6jTXRMB93jKKKO7k6chgo9l0oObhLh81ao6sq/eV0WFIw=="
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-0.38.0.tgz",
+      "integrity": "sha512-mP5+qgICPm/0dD3hKa/hMd8AHerkAaLJgEsvBwTXi+N/kpPo9LIrHg40DvUGPs5w6KD9PUuskb3WGBvYcToHvA=="
     },
     "@material/toolbar": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@material/toolbar/-/toolbar-0.37.0.tgz",
-      "integrity": "sha512-62rH9K+npoHlrevxkh2nMIB5d+6OLAMCD7uIgJfOuSi9xxIOmSOnGimSUT4uVIVub5uA4HXLgpBC0A1b3So0eg==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@material/toolbar/-/toolbar-0.38.1.tgz",
+      "integrity": "sha512-EkBC8UcO8DHuM8qPlmSome7w0k+qiwUsliB/orHVhg8zdC9Ikq1FhK6wTK9oKFsJHbJZS49JfaAXh8VhpzybSQ==",
       "requires": {
         "@material/base": "0.35.0",
-        "@material/elevation": "0.36.1",
-        "@material/ripple": "0.37.0",
+        "@material/elevation": "0.38.0",
+        "@material/ripple": "0.38.1",
         "@material/rtl": "0.36.0",
-        "@material/theme": "0.35.0",
-        "@material/typography": "0.35.0"
+        "@material/theme": "0.38.0",
+        "@material/typography": "0.38.0"
       }
     },
     "@material/typography": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-0.35.0.tgz",
-      "integrity": "sha512-7uXybSQToQCgB19RT0Pq47NkXSSojpbccVAObw/7fmfNUTcr3elNc8iPS/f1slYDTDEdyqM7hCreLcfZQK8ATQ=="
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-0.38.0.tgz",
+      "integrity": "sha512-g2wigBZXSXwrZtibt6sbPO1eM2IROdo9Jk7ffGIb7GuYGLD92hWWzxusaOg4W/rcsBkWMdfquydRL3Q4HFnS2g=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -2375,8 +2310,7 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "define-properties": {
       "version": "1.1.2",
@@ -2987,8 +2921,7 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -3096,6 +3029,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -11024,6 +10962,11 @@
       "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
+    "parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "parse-asn1": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
@@ -11905,6 +11848,48 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
       "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
       "dev": true
+    },
+    "quill": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.6.tgz",
+      "integrity": "sha512-K0mvhimWZN6s+9OQ249CH2IEPZ9JmkFuCQeHAOQax3EZ2nDJ3wfGh59mnlQaZV2i7u8eFarx6wAtvQKgShojug==",
+      "requires": {
+        "clone": "2.1.2",
+        "deep-equal": "1.0.1",
+        "eventemitter3": "2.0.3",
+        "extend": "3.0.1",
+        "parchment": "1.1.4",
+        "quill-delta": "3.6.3"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+        }
+      }
+    },
+    "quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "requires": {
+        "deep-equal": "1.0.1",
+        "extend": "3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        }
+      }
     },
     "randomatic": {
       "version": "3.0.0",


### PR DESCRIPTION
Updated to latest MDC Added fix to unset 'content' style - this workaround fixes list secondary text having additional spacing. This may be able to be removed with future MDC updates.