### PR TITLE
Decorate raised buttons with type="submit"

### DIFF
--- a/views/mdc/components/buttons/button.erb
+++ b/views/mdc/components/buttons/button.erb
@@ -16,6 +16,7 @@
           <%= 'v-menu-click' if comp.menu%>"
          <%= data_attributes %>
 <%= 'disabled' if comp.disabled %>
+<%= "type='#{eq(comp.button_type, :raised) ? 'submit' : 'button'}'" %>
 <%= erb :"components/event", :locals => {events: comp.events, parent_id: event_parent_id || comp.event_parent_id} unless comp.disabled %>>
   <%= erb :"components/icon", :locals => {comp: comp.icon, class_name: 'mdc-button__icon'} %>
   <%= erb :"components/image", :locals => {comp: comp.image} %>

--- a/views/mdc/components/buttons/icon.erb
+++ b/views/mdc/components/buttons/icon.erb
@@ -12,6 +12,7 @@
          <%= 'v-menu-click' if comp.menu%>"
         style = "<%= color_style(comp) %>"
         <%= 'disabled' if comp.disabled %>
+        <%= "type='#{eq(comp.button_type, :raised) ? 'submit' : 'button'}'" %>
         <%= erb :'components/event', :locals => {events: comp.events, parent_id: event_parent_id || comp.event_parent_id} unless comp.disabled %>>
   <%= erb :'components/icon', :locals => {comp: comp.icon} %>
   <%= comp.text %>

--- a/views/mdc/components/buttons/image.erb
+++ b/views/mdc/components/buttons/image.erb
@@ -15,6 +15,7 @@
           <%= 'v-menu-click' if comp.menu%>"
   style="background-image: url(<%= comp.image.url %>);"
   <%= 'disabled' if comp.disabled %>
+  <%= "type='#{eq(comp.button_type, :raised) ? 'submit' : 'button'}'" %>
   <%= erb :"components/event", :locals => {events: comp.events, parent_id: event_parent_id || comp.event_parent_id} unless comp.disabled %>>
   <%= erb :"components/icon", :locals => {comp: comp.icon, class_name: 'mdc-button__icon', position: [:right, :center]} %>
 </button>


### PR DESCRIPTION
Partially fixes #40:

* raised buttons are given `type="submit"`
* non-raised buttons are given `type="button"`