### PR TITLE
Fix Unprocessable error type reference

### DIFF
--- a/lib/voom/presenters/web_client/app.rb
+++ b/lib/voom/presenters/web_client/app.rb
@@ -140,7 +140,7 @@ module Voom
             layout = !(request.env['HTTP_X_NO_LAYOUT'] == 'true')
             response.headers['X-Frame-Options'] = 'ALLOWALL' if ENV['ALLOWALL_FRAME_OPTIONS']
             erb :web, layout: layout
-          rescue Errors::Unprocessable => e
+          rescue Presenters::Errors::Unprocessable => e
             content_type :json
             status 422
             JSON.dump({error: e.message})


### PR DESCRIPTION
`WebClient::App` can't see `Errors::Unprocessable`, so
user/client app errors are being obscured by the Presenters
error:

'Unable to autoload constant Errors::Unprocessable, expected
/rx/presenters/lib/voom/presenters/errors/unprocessable.rb
to define it'

This precedes the custom error with the `Presenters` module
reference, so it may be found by `WebClient::App`.