### PR TITLE
Fix vertical spacing for datetime component without message

### DIFF
--- a/views/mdc/components/datetime.erb
+++ b/views/mdc/components/datetime.erb
@@ -35,7 +35,9 @@
   <datalist id="<%= comp.id %>-list">
   </datalist>
 </div>
+<% if comp.error || comp.hint %>
 <p id="<%= comp.id %>-input-helper-text" class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent mdc-text-field-helper-text--validation-msg" aria-hidden="true">
   <%= comp.error || comp.hint %>
 </p>
+<% end %>
 <%= erb :"components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} %>


### PR DESCRIPTION
Add conditional display of the datetime error/hint element,
as it's creating uneven vertical spacing with an empty
paragraph tag when no hint or error is present.