### PR TITLE
Fix `require_dependency` undefined error

### DIFF
--- a/lib/voom/presenters-engine.rb
+++ b/lib/voom/presenters-engine.rb
@@ -1,5 +1,5 @@
 if Rails.version =~ /^4/
-  require_dependency 'voom/presenters'
+  ActiveSupport::Dependencies.require_dependency 'voom/presenters'
 else
   require 'voom/presenters'
 end


### PR DESCRIPTION
Adding presenters to a new project initially generates
the error:

`undefined method 'require_dependency' for main:Object`

Scoping the method allows it to be found.