### PR TITLE
Fix rich text area label positioning

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -12691,14 +12691,16 @@ i:focus.v-datetime--clear {
 
 .v-rich-text-area-container {
   position: relative;
-  width: 100%;
-  padding-top: 30px; }
+  width: 100%; }
   .v-rich-text-area-container > label {
-    top: 0px; }
-  .v-rich-text-area-container .ql-toolbar.ql-snow {
-    border-color: rgba(0, 0, 0, 0.24);
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px; }
+    display: block;
+    margin-top: 16px; }
+  .v-rich-text-area-container .ql-toolbar {
+    margin-top: 16px; }
+    .v-rich-text-area-container .ql-toolbar.ql-snow {
+      border-color: rgba(0, 0, 0, 0.24);
+      border-top-left-radius: 4px;
+      border-top-right-radius: 4px; }
   .v-rich-text-area-container .v-rich-text-area {
     height: 350px; }
     .v-rich-text-area-container .v-rich-text-area.ql-snow {

--- a/views/mdc/assets/scss/components/rich-text-area.scss
+++ b/views/mdc/assets/scss/components/rich-text-area.scss
@@ -1,11 +1,13 @@
 .v-rich-text-area-container {
   position: relative;
   width: 100%;
-  padding-top: 30px;
   > label {
-    top: 0px;
+    display: block;
+    margin-top: 16px;
   }
   .ql-toolbar {
+    margin-top: 16px;
+
     &.ql-snow {
       border-color: $v-input-border-color;
       border-top-left-radius: $v-input-border-radius;
@@ -29,7 +31,6 @@
     .v-rich-text-area {
       &.ql-snow {
         border-color: $v-input-hover-border-color;
-     ;
       }
     }
   }

--- a/views/mdc/components/rich_text_area.erb
+++ b/views/mdc/components/rich_text_area.erb
@@ -2,7 +2,7 @@
      <% if comp.tag %>
      data-input-tag="<%= comp.tag %>"
      <% end %>>
-  <label class="mdc-floating-label" for="<%= comp.id %>"><%= expand_text(comp.label) %></label>
+  <label for="<%= comp.id %>"><%= expand_text(comp.label) %></label>
   <div class="v-rich-text-area"
        id="<%= comp.id %>"
        style="<%= 'width:100%;' if comp.full_width %>


### PR DESCRIPTION
The component wasn't spacing evenly in relation to other
elements. Remove the float from the label and let it
render in the normal flow, while giving it margin in
common with our other components.