### PR TITLE
Fix Google Map height/width attribute support

### DIFF
--- a/lib/voom/presenters/dsl/components/google_map.rb
+++ b/lib/voom/presenters/dsl/components/google_map.rb
@@ -6,7 +6,7 @@ module Voom
       module Components
         class GoogleMap < Base
 
-          attr_reader :url, :google_api_key
+          attr_reader :url, :google_api_key, :height, :width
 
           def initialize(**attribs_, &block)
             super(type: :google_map, **attribs_, &block)

--- a/views/mdc/components/google_map.erb
+++ b/views/mdc/components/google_map.erb
@@ -1,5 +1,9 @@
 <% if comp %>
   <img id="<%= comp.id %>"
        class="v-google-map-image"
-       src="<%= comp.url %>" border="0" alt="">
+       src="<%= comp.url %>"
+       border="0"
+       height="<%= comp.height %>"
+       width="<%= comp.width %>"
+       alt="">
 <% end %>


### PR DESCRIPTION
These settings weren't working, updated to support map height
and width attributes.