### PR TITLE
Remove spaces around text area's value tag

### DIFF
--- a/views/mdc/components/text_area.erb
+++ b/views/mdc/components/text_area.erb
@@ -8,7 +8,7 @@
             name="<%= comp.name %>"
             class="mdc-text-field__input"
             rows="<%= comp.rows %>"
-            cols="<%= comp.cols %>"> <%= comp.value %> </textarea>
+            cols="<%= comp.cols %>"><%= comp.value %></textarea>
   <label for="<%= comp.id %>-input" class="mdc-floating-label"><%= expand_text(comp.label) %></label>
 </div>
 <% if comp.error || comp.hint %>


### PR DESCRIPTION
This fixes a bug which progressively pads text area values by one space character on each side when capturing and restoring a text area component's value.