### PR TITLE
Fix duplication of parameters in POSTs

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -2578,11 +2578,6 @@ var VBase = function (_VUrls) {
                     }
                 }
             }
-            // Let input components push parameters
-            var vComp = this.component();
-            if (vComp && typeof vComp.prepareSubmit === 'function') {
-                vComp.prepareSubmit(params);
-            }
             return params;
         }
     }, {

--- a/views/mdc/assets/js/components/events/base.js
+++ b/views/mdc/assets/js/components/events/base.js
@@ -50,11 +50,6 @@ export class VBase extends VUrls {
                 component.prepareSubmit(params);
             }
         }
-        // Let input components push parameters
-        let vComp = this.component();
-        if (vComp && typeof vComp.prepareSubmit === 'function') {
-            vComp.prepareSubmit(params);
-        }
         return params;
     }
 


### PR DESCRIPTION
Fix duplication of parameters in POSTs from `prepareSubmit` being called twice. In events/base and base-container.