### PR TITLE
Prevent Filewatcher Thread from dying if it sees an invalid .pom

### DIFF
--- a/lib/voom/railtie.rb
+++ b/lib/voom/railtie.rb
@@ -69,7 +69,12 @@ module Voom
         Thread.new(filewatcher) do |fw|
           fw.watch do |f|
             puts "Detected updated POM file: #{f}"
-            BOOT.call
+            begin
+              BOOT.call
+            rescue Exception => exc
+              puts exc.backtrace
+              puts exc.message
+            end
           end
         end
       } unless defined?(WATCH)


### PR DESCRIPTION
Currently, if you save a .pom with invalid Ruby in it, the
Thread that is watching this will die, and no poms will be
able to be rendered (the WebClient for presenters will just
quit). This change prevents the thread from dying, so you
can fix your .pom, and also prints a handy backtrace and message
so you can easily find your error.

This doesn't prevent the process from dying on first load if there is
invalid Ruby, but I think that's fine. 