### PR TITLE
* Added new `reset(){}` method to JS components

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: git://github.com/rx/image_crop_presenter_plugin.git
-  revision: 40d7a1ac42d642490bc272d2a33f8786c25f5d6b
+  revision: fb11f3ed6523a0c11ad3f66727d83f1dee8a1154
   specs:
     image_crop_presenter_plugin (0.1.0)
 

--- a/app/demo/components/cards.pom
+++ b/app/demo/components/cards.pom
@@ -55,8 +55,8 @@ Voom::Presenters.define(:cards) do
               color: :white, position: :top
       end
       actions do
-        button 'Add to Calendar'
-        button icon: :event
+        button 'Add to Calendar', color: :secondary
+        button icon: :event, color: :secondary
       end
     end
 

--- a/app/demo/plugins/image_crop.pom
+++ b/app/demo/plugins/image_crop.pom
@@ -10,7 +10,9 @@ Voom::Presenters.define(:image_crop, namespace: :plugins) do
     title 'Drag and drop with cropper preview'
     grid do
       column 6 do
-        image_crop id: :event_image, image: 'https://cdn.mos.cms.futurecdn.net/4f6d31c116fdada59a5cb16d136e3068-970-80.jpg' do
+        image_crop id: :event_image,
+                   aspect_ratio: 1.0,
+                   image: 'https://cdn.mos.cms.futurecdn.net/4f6d31c116fdada59a5cb16d136e3068-970-80.jpg' do
         end
       end
       column 6 do

--- a/lib/voom/presenters/dsl/components/button.rb
+++ b/lib/voom/presenters/dsl/components/button.rb
@@ -15,9 +15,9 @@ module Voom
           def initialize(type: nil, **attribs_, &block)
             @button_type = h(type) || ((attribs_[:icon] && !attribs_[:text]) ? :icon : nil) || :flat
             super(type: :button, **attribs_, &block)
-            self.icon(attribs.delete(:icon)) if attribs.key?(:icon)
-            @text = attribs.delete(:text)
             @color = attribs.delete(:color)
+            self.icon(attribs.delete(:icon), color: color) if attribs.key?(:icon)
+            @text = attribs.delete(:text)
             @disabled = attribs.delete(:disabled) {false}
             @hidden = attribs.delete(:hidden) {false}
             @size = attribs.delete(:size)
@@ -29,9 +29,7 @@ module Voom
 
           def icon(icon = nil, **attribs, &block)
             return @icon if locked?
-            @icon = Components::Icon.new(parent: self, icon: icon,
-                                         **attribs, &block)
-
+            @icon = Components::Icon.new(parent: self, icon: icon, **attribs, &block)
           end
 
           def image(image = nil, **attribs, &block)

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -155,6 +155,9 @@ var VBaseComponent = function () {
         key: "hide",
         value: function hide() {}
     }, {
+        key: "reset",
+        value: function reset() {}
+    }, {
         key: "clearErrors",
         value: function clearErrors() {
             new __WEBPACK_IMPORTED_MODULE_0__events_errors__["a" /* VErrors */]().clearErrors();
@@ -1598,17 +1601,9 @@ var VBaseContainer = function (_VBaseComponent) {
                 }
             }
         }
-        // Called whenever a container is about to be submitted.
-        // returns true on success
-        // returns on failure return an error object that can be processed by VErrors:
-        //    { email: ["email must be filled", "email must be from your domain"] }
-        //    { :page: ["must be filled"] }
-
     }, {
-        key: 'validate',
-        value: function validate(form, params) {
-            console.log('Form validate', form, params);
-            var errors = [];
+        key: 'reset',
+        value: function reset() {
             var _iteratorNormalCompletion4 = true;
             var _didIteratorError4 = false;
             var _iteratorError4 = undefined;
@@ -1617,11 +1612,8 @@ var VBaseContainer = function (_VBaseComponent) {
                 for (var _iterator4 = this.inputs()[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
                     var input = _step4.value;
 
-                    if (input.vComponent && input.vComponent.validate) {
-                        var result = input.vComponent.validate(form, params);
-                        if (result !== true) {
-                            errors.push(result);
-                        }
+                    if (input.vComponent && input.vComponent.reset) {
+                        input.vComponent.reset();
                     }
                 }
             } catch (err) {
@@ -1635,6 +1627,48 @@ var VBaseContainer = function (_VBaseComponent) {
                 } finally {
                     if (_didIteratorError4) {
                         throw _iteratorError4;
+                    }
+                }
+            }
+        }
+
+        // Called whenever a container is about to be submitted.
+        // returns true on success
+        // returns on failure return an error object that can be processed by VErrors:
+        //    { email: ["email must be filled", "email must be from your domain"] }
+        //    { :page: ["must be filled"] }
+
+    }, {
+        key: 'validate',
+        value: function validate(form, params) {
+            console.log('Form validate', form, params);
+            var errors = [];
+            var _iteratorNormalCompletion5 = true;
+            var _didIteratorError5 = false;
+            var _iteratorError5 = undefined;
+
+            try {
+                for (var _iterator5 = this.inputs()[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+                    var input = _step5.value;
+
+                    if (input.vComponent && input.vComponent.validate) {
+                        var result = input.vComponent.validate(form, params);
+                        if (result !== true) {
+                            errors.push(result);
+                        }
+                    }
+                }
+            } catch (err) {
+                _didIteratorError5 = true;
+                _iteratorError5 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion5 && _iterator5.return) {
+                        _iterator5.return();
+                    }
+                } finally {
+                    if (_didIteratorError5) {
+                        throw _iteratorError5;
                     }
                 }
             }
@@ -34192,6 +34226,9 @@ var VDialog = function (_VBaseContainer) {
             element.vComponent.clearErrors();
         });
 
+        dialog.listen('MDCDialog:opened', function () {
+            element.vComponent.reset();
+        });
         return _this;
     }
 
@@ -96812,6 +96849,8 @@ var VTypography = function (_eventHandlerMixin) {
 /* unused harmony export VPluginComponent */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -96878,6 +96917,13 @@ var VPluginComponent = function (_eventHandlerMixin) {
         value: function clear() {
             if (this.element.vPlugin && this.element.vPlugin.name) {
                 return this.element.vPlugin.clear();
+            }
+        }
+    }, {
+        key: 'reset',
+        value: function reset() {
+            if (this.element.vPlugin && _typeof(this.element.vPlugin.reset)) {
+                return this.element.vPlugin.reset();
             }
         }
     }, {

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -149,14 +149,11 @@ var VBaseComponent = function () {
             return true;
         }
     }, {
-        key: "show",
-        value: function show() {}
+        key: "onShow",
+        value: function onShow() {}
     }, {
-        key: "hide",
-        value: function hide() {}
-    }, {
-        key: "reset",
-        value: function reset() {}
+        key: "onHide",
+        value: function onHide() {}
     }, {
         key: "clearErrors",
         value: function clearErrors() {
@@ -1572,8 +1569,8 @@ var VBaseContainer = function (_VBaseComponent) {
             }
         }
     }, {
-        key: 'show',
-        value: function show() {
+        key: 'onShow',
+        value: function onShow() {
             var _iteratorNormalCompletion3 = true;
             var _didIteratorError3 = false;
             var _iteratorError3 = undefined;
@@ -1582,8 +1579,8 @@ var VBaseContainer = function (_VBaseComponent) {
                 for (var _iterator3 = this.inputs()[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
                     var input = _step3.value;
 
-                    if (input.vComponent && input.vComponent.show) {
-                        input.vComponent.show();
+                    if (input.vComponent && input.vComponent.onShow) {
+                        input.vComponent.onShow();
                     }
                 }
             } catch (err) {
@@ -1601,9 +1598,18 @@ var VBaseContainer = function (_VBaseComponent) {
                 }
             }
         }
+
+        // Called whenever a container is about to be submitted.
+        // returns true on success
+        // returns on failure return an error object that can be processed by VErrors:
+        //    { email: ["email must be filled", "email must be from your domain"] }
+        //    { :page: ["must be filled"] }
+
     }, {
-        key: 'reset',
-        value: function reset() {
+        key: 'validate',
+        value: function validate(form, params) {
+            console.log('Form validate', form, params);
+            var errors = [];
             var _iteratorNormalCompletion4 = true;
             var _didIteratorError4 = false;
             var _iteratorError4 = undefined;
@@ -1612,8 +1618,11 @@ var VBaseContainer = function (_VBaseComponent) {
                 for (var _iterator4 = this.inputs()[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
                     var input = _step4.value;
 
-                    if (input.vComponent && input.vComponent.reset) {
-                        input.vComponent.reset();
+                    if (input.vComponent && input.vComponent.validate) {
+                        var result = input.vComponent.validate(form, params);
+                        if (result !== true) {
+                            errors.push(result);
+                        }
                     }
                 }
             } catch (err) {
@@ -1627,48 +1636,6 @@ var VBaseContainer = function (_VBaseComponent) {
                 } finally {
                     if (_didIteratorError4) {
                         throw _iteratorError4;
-                    }
-                }
-            }
-        }
-
-        // Called whenever a container is about to be submitted.
-        // returns true on success
-        // returns on failure return an error object that can be processed by VErrors:
-        //    { email: ["email must be filled", "email must be from your domain"] }
-        //    { :page: ["must be filled"] }
-
-    }, {
-        key: 'validate',
-        value: function validate(form, params) {
-            console.log('Form validate', form, params);
-            var errors = [];
-            var _iteratorNormalCompletion5 = true;
-            var _didIteratorError5 = false;
-            var _iteratorError5 = undefined;
-
-            try {
-                for (var _iterator5 = this.inputs()[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-                    var input = _step5.value;
-
-                    if (input.vComponent && input.vComponent.validate) {
-                        var result = input.vComponent.validate(form, params);
-                        if (result !== true) {
-                            errors.push(result);
-                        }
-                    }
-                }
-            } catch (err) {
-                _didIteratorError5 = true;
-                _iteratorError5 = err;
-            } finally {
-                try {
-                    if (!_iteratorNormalCompletion5 && _iterator5.return) {
-                        _iterator5.return();
-                    }
-                } finally {
-                    if (_didIteratorError5) {
-                        throw _iteratorError5;
                     }
                 }
             }
@@ -11782,8 +11749,8 @@ var VTextField = function (_visibilityObserverMi) {
             return this.value() !== this.element.dataset.originalValue;
         }
     }, {
-        key: 'show',
-        value: function show() {
+        key: 'onShow',
+        value: function onShow() {
             this.mdcComponent.layout();
         }
     }, {
@@ -34227,7 +34194,7 @@ var VDialog = function (_VBaseContainer) {
         });
 
         dialog.listen('MDCDialog:opened', function () {
-            element.vComponent.reset();
+            element.vComponent.onShow();
         });
         return _this;
     }
@@ -40646,7 +40613,7 @@ var VToggleVisibility = function () {
                         elem.classList.toggle("v-hidden");
                     }
                     if (elem && elem.vComponent && elem.vComponent.show) {
-                        elem.classList.contains('v-hidden') ? elem.vComponent.hide() : elem.vComponent.show();
+                        elem.classList.contains('v-hidden') ? elem.vComponent.onHide() : elem.vComponent.onShow();
                     }
                     results.push({ action: 'toggle_visibility', statusCode: 200 });
                     resolve(results);
@@ -96920,10 +96887,10 @@ var VPluginComponent = function (_eventHandlerMixin) {
             }
         }
     }, {
-        key: 'reset',
-        value: function reset() {
-            if (this.element.vPlugin && _typeof(this.element.vPlugin.reset)) {
-                return this.element.vPlugin.reset();
+        key: 'onShow',
+        value: function onShow() {
+            if (this.element.vPlugin && _typeof(this.element.vPlugin.onShow)) {
+                return this.element.vPlugin.onShow();
             }
         }
     }, {

--- a/views/mdc/assets/js/components/base-component.js
+++ b/views/mdc/assets/js/components/base-component.js
@@ -9,9 +9,8 @@ export class VBaseComponent {
     validate(formData) {
         return true;
     }
-    show() {}
-    hide() {}
-    reset() {}
+    onShow() {}
+    onHide() {}
 
     clearErrors() {
         new VErrors().clearErrors();

--- a/views/mdc/assets/js/components/base-component.js
+++ b/views/mdc/assets/js/components/base-component.js
@@ -11,6 +11,7 @@ export class VBaseComponent {
     }
     show() {}
     hide() {}
+    reset() {}
 
     clearErrors() {
         new VErrors().clearErrors();

--- a/views/mdc/assets/js/components/base-container.js
+++ b/views/mdc/assets/js/components/base-container.js
@@ -34,6 +34,15 @@ export class VBaseContainer extends VBaseComponent {
             }
         }
     }
+
+    reset() {
+        for (const input of this.inputs()) {
+            if (input.vComponent && input.vComponent.reset) {
+                input.vComponent.reset();
+            }
+        }
+    }
+
     // Called whenever a container is about to be submitted.
     // returns true on success
     // returns on failure return an error object that can be processed by VErrors:

--- a/views/mdc/assets/js/components/base-container.js
+++ b/views/mdc/assets/js/components/base-container.js
@@ -27,18 +27,10 @@ export class VBaseContainer extends VBaseComponent {
         }
     }
 
-    show() {
+    onShow() {
         for (const input of this.inputs()) {
-            if (input.vComponent && input.vComponent.show) {
-                input.vComponent.show();
-            }
-        }
-    }
-
-    reset() {
-        for (const input of this.inputs()) {
-            if (input.vComponent && input.vComponent.reset) {
-                input.vComponent.reset();
+            if (input.vComponent && input.vComponent.onShow) {
+                input.vComponent.onShow();
             }
         }
     }

--- a/views/mdc/assets/js/components/dialogs.js
+++ b/views/mdc/assets/js/components/dialogs.js
@@ -26,6 +26,9 @@ export class VDialog extends VBaseContainer {
             element.vComponent.clearErrors();
         });
 
+        dialog.listen('MDCDialog:opened', function() {
+            element.vComponent.reset();
+        });
     }
 
     open() {

--- a/views/mdc/assets/js/components/dialogs.js
+++ b/views/mdc/assets/js/components/dialogs.js
@@ -27,7 +27,7 @@ export class VDialog extends VBaseContainer {
         });
 
         dialog.listen('MDCDialog:opened', function() {
-            element.vComponent.reset();
+            element.vComponent.onShow();
         });
     }
 

--- a/views/mdc/assets/js/components/events/toggle_visibility.js
+++ b/views/mdc/assets/js/components/events/toggle_visibility.js
@@ -38,7 +38,7 @@ export class VToggleVisibility  {
                     elem.classList.toggle("v-hidden");
                 }
                 if(elem && elem.vComponent && elem.vComponent.show){
-                    elem.classList.contains('v-hidden') ?  elem.vComponent.hide() : elem.vComponent.show();
+                    elem.classList.contains('v-hidden') ?  elem.vComponent.onHide() : elem.vComponent.onShow();
                 }
                 results.push({action:'toggle_visibility', statusCode: 200});
                 resolve(results);

--- a/views/mdc/assets/js/components/plugins.js
+++ b/views/mdc/assets/js/components/plugins.js
@@ -51,9 +51,9 @@ export class VPluginComponent extends eventHandlerMixin(VBaseComponent) {
         }
     }
 
-    reset() {
-        if (this.element.vPlugin && typeof this.element.vPlugin.reset) {
-            return this.element.vPlugin.reset();
+    onShow() {
+        if (this.element.vPlugin && typeof this.element.vPlugin.onShow) {
+            return this.element.vPlugin.onShow();
         }
     }
 

--- a/views/mdc/assets/js/components/plugins.js
+++ b/views/mdc/assets/js/components/plugins.js
@@ -51,6 +51,12 @@ export class VPluginComponent extends eventHandlerMixin(VBaseComponent) {
         }
     }
 
+    reset() {
+        if (this.element.vPlugin && typeof this.element.vPlugin.reset) {
+            return this.element.vPlugin.reset();
+        }
+    }
+
     initEventListener(eventName, eventHandler) {
         if (this.element.vPlugin && this.element.vPlugin.initEventListener) {
             this.element.vPlugin.initEventListener(eventName, eventHandler);

--- a/views/mdc/assets/js/components/text-fields.js
+++ b/views/mdc/assets/js/components/text-fields.js
@@ -87,7 +87,7 @@ export class VTextField extends visibilityObserverMixin(
         return this.value() !== this.element.dataset.originalValue;
     }
 
-    show() {
+    onShow() {
         this.mdcComponent.layout();
     }
 

--- a/views/mdc/components/buttons/icon.erb
+++ b/views/mdc/components/buttons/icon.erb
@@ -10,8 +10,6 @@
          <%= 'v-hidden' if comp.hidden %>
          <%=class_name%>
          <%= position_classes %>
-         <%= 'mdl-button--colored' if eq(comp.color, :primary) %>
-         <%= 'mdl-button--accent' if eq(comp.color, :secondary) %>
          <%= 'v-menu-click' if comp.menu%>"
         style = "<%= color_style(comp) %>"
         <%= 'disabled' if comp.disabled %>


### PR DESCRIPTION
* Default behavior is no-op
* BaseContainer calls `reset()` on all its components
* Added `MDCDialog:opened` event listener to VDialog that calls `reset` on itself
The cropper plugin is using this functionality to rebuild itself when being shown on a dialog
MDC Components that may need to recalc their layout when going from a hidden to visible state
can use this method to do such (ie. `mdcComponent.layout()`)