### PR TITLE
Need to load plugins when they are registered

### DIFF
--- a/lib/voom/presenters/dsl/user_interface.rb
+++ b/lib/voom/presenters/dsl/user_interface.rb
@@ -107,6 +107,7 @@ module Voom
 
         def plugin(*plugin_names)
           @__plugins__.push(*plugin_names)
+          self.class.include_plugins(:DSLComponents, :DSLHelpers, plugins: plugin_names)
         end
 
         private


### PR DESCRIPTION
initialize_plugins is only called when the UserInterface is
instantiated, at which point it has an empty array of plugins.
Afterwards they are collected, but not loaded.  We need to load each
plugin as it is registered so its dsl is available.