### PR TITLE
FAB position

### DIFF
--- a/views/mdc/assets/scss/components/fab.scss
+++ b/views/mdc/assets/scss/components/fab.scss
@@ -1,9 +1,20 @@
 @import "@material/fab/mdc-fab";
 
 .v-fab--absolute {
-  position: relative;
-  float: right;
-  //margin:  6px -40px -69px;
-  margin:  -46px -14px -69px;
+  position: absolute;
   z-index: 10;
+}
+
+$fab-positions: (
+  top: -3%,
+  right: -5%,
+  bottom: -5%,
+  left: -6%
+);
+
+@each $position, $offset in $fab-positions {
+  .mdc-fab.v-button-fab-position-#{$position} {
+    position: absolute;
+    #{$position}: #{$offset};
+  }
 }

--- a/views/mdc/components/button.erb
+++ b/views/mdc/components/button.erb
@@ -5,7 +5,7 @@
 %>
 <% if comp
      position_classes = comp.position.map {|p| "v-button-position-#{p}"}.join(' ')
-     class_name = "#{class_name} #{position_classes} #{comp.full_width ? 'v-button-full-width' : nil}"
+     class_name = "#{class_name} #{comp.full_width ? 'v-button-full-width' : nil}"
 %>
   <% if comp.menu %>
     <div class="mdc-menu-anchor" %>


### PR DESCRIPTION
Allow FAB's position to be controlled via normal button `position` attribute values.

* Remove `position_classes` from button sub-components 
* Generate FAB-specific position classes and adjust base FAB styles

I've excluded regenerated bundle files from this PR as they'd likely generate a conflict with #114.