### PR TITLE
Bugfix for dialog height/width, and documentation

### DIFF
--- a/app/demo/components/dialogs.pom
+++ b/app/demo/components/dialogs.pom
@@ -111,6 +111,12 @@ Voom::Presenters.define(:dialogs) do
             dialog :multi_form_dialog
           end
         end
+        body 'Dialog with height and width'
+        button 'Height/Width' do
+          event :click do
+            dialog :height_width_dialog
+          end
+        end
 
       end
       column 6 do
@@ -129,6 +135,11 @@ Voom::Presenters.define(:dialogs) do
       title "Dialog with Form"
       dlg_form
       dlg_form
+    end
+
+    dialog id: :height_width_dialog, height: '500px', width: '500px' do
+      title "Dialog with set dimensions"
+      body "MDC dialogs have default styles of max-width 560px (for 592px viewport or larger) and min-width 280px."
     end
 
 

--- a/views/mdc/components/dialog.erb
+++ b/views/mdc/components/dialog.erb
@@ -15,8 +15,8 @@
      aria-describedby="my-dialog-content">
   <div class="mdc-dialog__container">
     <div class="mdc-dialog__surface"
-         style="<%= "width: #{comp.width}" if comp.width %>
-           <%= "height: #{comp.height}" if comp.height %>">
+         style="<%= "width: #{comp.width.to_i.to_s == comp.width ? "#{comp.width}px" : comp.width}; " if comp.width %>
+                <%= "height: #{comp.height.to_i.to_s == comp.height ? "#{comp.height}px" : comp.height}; " if comp.height %>
       <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
       <% if comp.title %>
         <h2 class="mdc-dialog__title" id="my-dialog-title"><%= expand_text(comp.title.text) %></h2>


### PR DESCRIPTION
If you have both height and width, the style tag breaks because of no semicolon. I put in those and also defaulted the style to 'px' if an integer was input (previously you would have to put the unit into the pom)