### PR TITLE
Fix request params

### DIFF
--- a/app/demo/events/content_as_form.pom
+++ b/app/demo/events/content_as_form.pom
@@ -1,0 +1,307 @@
+Voom::Presenters.define(:response_content) do
+  helpers do
+    def params
+      return {} unless context[:id]
+
+      { tag: context[:id] }
+    end
+  end
+
+  content id: :response_content, **params do
+    text context[:content]
+  end
+end
+
+Voom::Presenters.define(:content_as_form) do
+  helpers Demo::Helpers::IndentedGrid
+
+  attach :top_nav
+  attach :events_drawer
+
+  attach :response_content
+
+  indented_grid do
+    card id: :form_1 do
+      title 'Form'
+      form do
+        text_field name: :text1 do
+          label 'Text 1'
+        end
+
+        checkbox name: :on, value: true, off_value: false, text: 'Checkbox'
+
+        blank
+
+        grid padding: :none do
+          column 12 do
+            button 'Submit, grid > column', type: :raised do
+              event :click do
+                posts '/_echo_'
+                replaces :response_content, :response_content,
+                         content: last_response,
+                         id: 1
+              end
+            end
+          end
+        end
+
+        content do
+          button 'Submit, content', type: :raised do
+            event :click do
+              posts '/_echo_'
+              replaces :response_content, :response_content,
+                       content: last_response,
+                       id: 2
+            end
+          end
+        end
+
+        button 'Submit', type: :raised do
+          event :click do
+            posts '/_echo_'
+            replaces :response_content, :response_content,
+                     content: last_response,
+                     id: 3
+          end
+        end
+      end
+    end
+  end
+
+  indented_grid do
+    card do
+      title 'Content'
+      content id: :content_1 do
+        text_field name: :text1 do
+          label 'Text 1'
+        end
+
+        checkbox name: :on, value: true, off_value: false, text: 'Checkbox'
+
+        blank
+
+        grid padding: :none do
+          column 12 do
+            button 'Submit, grid > column', type: :raised do
+              event :click do
+                posts '/_echo_'
+                replaces :response_content, :response_content,
+                         content: last_response,
+                         id: 1
+              end
+            end
+          end
+        end
+
+        content do
+          button 'Submit, content', type: :raised do
+            event :click do
+              posts '/_echo_'
+              replaces :response_content, :response_content,
+                       content: last_response,
+                       id: 2
+            end
+          end
+        end
+
+        button 'Submit', type: :raised do
+          event :click do
+            posts '/_echo_'
+            replaces :response_content, :response_content,
+                     content: last_response,
+                     id: 3
+          end
+        end
+      end
+    end
+  end
+
+  grid do
+    column 12 do
+      text_field id: :input_tag_extra, name: :whatever, tag: :test_input_tag do
+        value 'foo bar'
+      end
+    end
+  end
+
+  indented_grid do
+    card do
+      title 'Content with input_tag'
+      content id: :content_2, tag: :test_input_tag do
+        text_field name: :text1 do
+          label 'Text 1'
+        end
+
+        checkbox name: :on, value: true, off_value: false, text: 'Checkbox'
+
+        blank
+
+        grid padding: :none do
+          column 12 do
+            button 'Submit, grid > column', type: :raised do
+              event :click do
+                posts '/_echo_',
+                      input_tag: :test_input_tag
+                replaces :response_content, :response_content,
+                         content: last_response,
+                         id: 1
+              end
+            end
+          end
+        end
+
+        content do
+          button 'Submit, content', type: :raised do
+            event :click do
+              posts '/_echo_',
+                    input_tag: :test_input_tag
+              replaces :response_content, :response_content,
+                       content: last_response,
+                       id: 2
+            end
+          end
+        end
+
+        button 'Submit', type: :raised do
+          event :click do
+            posts '/_echo_',
+                  input_tag: :test_input_tag
+            replaces :response_content, :response_content,
+                     content: last_response,
+                     id: 3
+          end
+        end
+      end
+    end
+  end
+
+  indented_grid do
+    content id: :content_array do
+      card do
+        title 'Array'
+
+        content do
+          text_field name: 'inputs[]' do
+            value SecureRandom.hex
+          end
+
+          text_field name: 'inputs[]' do
+            value SecureRandom.hex
+          end
+
+          text_field name: 'inputs[]' do
+            value SecureRandom.hex
+          end
+
+          checkbox name: :on, value: true, off_value: false, text: 'Checkbox'
+
+          button :submit, type: :raised do
+            event :click do
+              posts '/_echo_'
+              replaces :response_content, :response_content,
+                       content: last_response,
+                       id: 1
+            end
+          end
+        end
+      end
+    end
+  end
+
+  # Dialog tests:
+  attach :dialog_a
+  attach :dialog_b
+  attach :dialog_c
+  attach :dialog_d
+
+  button 'dialog_a' do
+    event :click do
+      dialog :dialog_a
+    end
+  end
+
+  button 'dialog_b' do
+    event :click do
+      dialog :dialog_b
+    end
+  end
+
+  button 'dialog_c' do
+    event :click do
+      dialog :dialog_c
+    end
+  end
+
+  button 'dialog_d' do
+    event :click do
+      dialog :dialog_d
+    end
+  end
+end
+
+Voom::Presenters.define(:dialog_a) do
+  dialog id: :dialog_a do
+    form do
+      text_field name: :dialog_text_field do
+        value 'whatever'
+      end
+
+      button 'Submit', type: :raised do
+        event :click do
+          posts '/_echo_'
+        end
+      end
+    end
+  end
+end
+
+Voom::Presenters.define(:dialog_b) do
+  dialog id: :dialog_b do
+    content do
+      text_field name: :dialog_text_field do
+        value 'whatever'
+      end
+
+      button 'Submit, untagged content', type: :raised do
+        event :click do
+          posts '/_echo_'
+        end
+      end
+    end
+  end
+end
+
+Voom::Presenters.define(:dialog_c) do
+  dialog id: :dialog_c do
+    content tag: :some_dialog_tag do
+      text_field name: :dialog_text_field do
+        value 'whatever'
+      end
+    end
+
+    button 'Submit, input_tag', type: :raised do
+      event :click do
+        posts '/_echo_',
+              input_tag: :some_dialog_tag
+      end
+    end
+  end
+end
+
+Voom::Presenters.define(:dialog_d) do
+  dialog id: :dialog_d do
+    grid do
+      column 12 do
+        text_field name: :dialog_text_field do
+          value 'whatever'
+        end
+      end
+    end
+
+    button 'Submit, no viable container', type: :raised do
+      event :click do
+        posts '/_echo_'
+      end
+    end
+  end
+end

--- a/public/wc.js
+++ b/public/wc.js
@@ -103,6 +103,11 @@ var VBaseComponent = function () {
         value: function clearErrors() {
             new __WEBPACK_IMPORTED_MODULE_0__events_errors__["a" /* VErrors */](this.root).clearErrors();
         }
+    }, {
+        key: 'respondTo',
+        value: function respondTo(method) {
+            return typeof this[method] === 'function';
+        }
     }]);
 
     return VBaseComponent;
@@ -678,6 +683,8 @@ function expandParams(results, o) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__utils_urls__ = __webpack_require__(19);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -710,6 +717,13 @@ var VBase = function (_VUrls) {
         value: function parentElement() {
             return this.root.getElementById(this.options.__parent_id__);
         }
+
+        /**
+         * taggedInputs retrieves all components matching this event's input_tag
+         * value.
+         * @return {NodeList}
+         */
+
     }, {
         key: 'taggedInputs',
         value: function taggedInputs() {
@@ -728,79 +742,127 @@ var VBase = function (_VUrls) {
 
             return inputs;
         }
+
+        /**
+         * inputs retrieves relevant elements for this event.
+         *
+         * 1. If an `input_tag` has been provided, all matching elements are
+         *    included.
+         * 2. If this component is an element, it is included.
+         * 3. If this component has inputs, its elements are included. If not,
+         *    the elements of the nearest content container are included.
+         * @return {Array<HTMLElement>}
+         */
+
+    }, {
+        key: 'inputs',
+        value: function inputs() {
+            var elements = [];
+
+            // Collect tagged elements, if applicable:
+            if (this.options.input_tag) {
+                elements = Array.from(this.taggedInputs());
+            }
+
+            var comp = this.component();
+
+            if (comp) {
+                // Include ourselves if we're a form component (but not a
+                // container):
+                if (comp.respondTo('prepareSubmit') && !comp.respondTo('inputs')) {
+                    elements.push(comp.element);
+                } else if (!comp.respondTo('inputs')) {
+                    // Defer to the component's closest content container if the
+                    // component itself does not respond to `inputs`:
+                    comp = this.closestContent();
+                }
+            }
+
+            if (comp && comp.respondTo('inputs')
+            // skip if we've previously grabbed elements via input_tag:
+            && comp.element.dataset.inputTag !== this.options.input_tag) {
+                var _elements;
+
+                elements = (_elements = elements).concat.apply(_elements, _toConsumableArray(comp.inputs()));
+            }
+
+            return elements;
+        }
+
+        /**
+         * inputComponents retrieves the Component for each of this event's
+         * relevant input elements.
+         * @return {Array<VBaseComponent>}
+         */
+
+    }, {
+        key: 'inputComponents',
+        value: function inputComponents() {
+            return this.inputs().filter(function (element) {
+                return element.vComponent;
+            }).map(function (element) {
+                return element.vComponent;
+            });
+        }
+
+        /**
+         * inputValues retrieves submit values for each of this event's relevant
+         * input elements.
+         * @return {Array}
+         */
+
     }, {
         key: 'inputValues',
         value: function inputValues() {
             var params = [];
 
-            // If tagged input is asked for, fetch all the matching tag elements
-            // and then call any bound components:
-            if (this.options.input_tag !== undefined) {
-                var inputs = Array.from(this.taggedInputs()).filter(function (input) {
-                    return input.vComponent;
-                }).map(function (input) {
-                    return input.vComponent;
-                }).filter(function (comp) {
-                    return typeof comp.prepareSubmit === 'function';
-                });
+            this.inputComponents().filter(function (comp) {
+                return comp.respondTo('prepareSubmit');
+            }).map(function (comp) {
+                return comp.prepareSubmit(params);
+            });
 
-                var _iteratorNormalCompletion = true;
-                var _didIteratorError = false;
-                var _iteratorError = undefined;
-
-                try {
-                    for (var _iterator = inputs[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                        var component = _step.value;
-
-                        component.prepareSubmit(params);
-                    }
-                } catch (err) {
-                    _didIteratorError = true;
-                    _iteratorError = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion && _iterator.return) {
-                            _iterator.return();
-                        }
-                    } finally {
-                        if (_didIteratorError) {
-                            throw _iteratorError;
-                        }
-                    }
-                }
-            }
-            var vComp = this.component();
-            if (vComp && typeof vComp.prepareSubmit === 'function') {
-                vComp.prepareSubmit(params);
-            }
             return params;
         }
     }, {
         key: 'component',
         value: function component() {
             var parent = this.parentElement();
+
             return parent ? parent.vComponent : null;
         }
     }, {
         key: 'validate',
         value: function validate() {
-            var errors = [];
             var comp = this.component();
+
             if (comp) {
-                errors = comp.validate();
+                return comp.validate();
             }
-            return errors;
+
+            return [];
         }
     }, {
-        key: 'closestContainer',
-        value: function closestContainer() {
+        key: 'closestContent',
+        value: function closestContent() {
+            var element = this.closestContentElement();
+
+            if (!element) {
+                return null;
+            }
+
+            return element.vComponent;
+        }
+    }, {
+        key: 'closestContentElement',
+        value: function closestContentElement() {
             var comp = this.component();
 
             if (!(comp && comp.element)) {
                 return null;
             }
 
-            return comp.element.closest('[data-is-container="true"]');
+            return comp.element.closest('.v-content');
         }
     }]);
 
@@ -25305,30 +25367,30 @@ var VPosts = function (_VBase) {
                 });
             }
 
-            var FD = null;
-            var form = this.form();
-            if (form) {
-                FD = new FormData(form);
-            } else {
-                FD = new FormData();
-            }
-            // Add params from presenter
-            Object(__WEBPACK_IMPORTED_MODULE_2__action_parameter__["b" /* expandParams */])(results, this.params);
-            for (var name in this.params) {
-                FD.append(name, Object(__WEBPACK_IMPORTED_MODULE_3__encode__["a" /* encode */])(this.params[name]));
-            }
+            // Manually build the FormData.
+            // Passing in a <form> element (if available) would skip over
+            // unchecked toggle elements, which would be unexpected if the user
+            // has specified a value for the toggle's `off_value` attribute.
+            var formData = new FormData();
 
-            var inputValues = this.inputValues();
+            // NB: `inputValues` will appropriately handle `input_tag`.
             var _iteratorNormalCompletion = true;
             var _didIteratorError = false;
             var _iteratorError = undefined;
 
             try {
-                for (var _iterator = inputValues[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                    var input = _step.value;
+                for (var _iterator = this.inputValues()[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                    var _ref = _step.value;
 
-                    FD.append(input[0], input[1]);
+                    var _ref2 = _slicedToArray(_ref, 2);
+
+                    var name = _ref2[0];
+                    var value = _ref2[1];
+
+                    formData.append(name, value);
                 }
+
+                // Add params from presenter:
             } catch (err) {
                 _didIteratorError = true;
                 _iteratorError = err;
@@ -25344,17 +25406,89 @@ var VPosts = function (_VBase) {
                 }
             }
 
+            Object(__WEBPACK_IMPORTED_MODULE_2__action_parameter__["b" /* expandParams */])(results, this.params);
+
+            var _iteratorNormalCompletion2 = true;
+            var _didIteratorError2 = false;
+            var _iteratorError2 = undefined;
+
+            try {
+                for (var _iterator2 = Object.entries(this.params)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                    var _ref3 = _step2.value;
+
+                    var _ref4 = _slicedToArray(_ref3, 2);
+
+                    var _name = _ref4[0];
+                    var _value = _ref4[1];
+
+                    formData.append(_name, Object(__WEBPACK_IMPORTED_MODULE_3__encode__["a" /* encode */])(_value));
+                }
+
+                // log dupes:
+                // TODO: remove me (debug)
+            } catch (err) {
+                _didIteratorError2 = true;
+                _iteratorError2 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                        _iterator2.return();
+                    }
+                } finally {
+                    if (_didIteratorError2) {
+                        throw _iteratorError2;
+                    }
+                }
+            }
+
+            var _iteratorNormalCompletion3 = true;
+            var _didIteratorError3 = false;
+            var _iteratorError3 = undefined;
+
+            try {
+                for (var _iterator3 = formData[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                    var _ref5 = _step3.value;
+
+                    var _ref6 = _slicedToArray(_ref5, 2);
+
+                    var k = _ref6[0];
+                    var v = _ref6[1];
+
+                    console.log(k + ': ' + v);
+                }
+            } catch (err) {
+                _didIteratorError3 = true;
+                _iteratorError3 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                        _iterator3.return();
+                    }
+                } finally {
+                    if (_didIteratorError3) {
+                        throw _iteratorError3;
+                    }
+                }
+            }
+
+            var paramCount = Array.from(formData).length;
+
+            if (paramCount < 1) {
+                console.warn('Creating request with no data!' + ' Are you sure you\'ve hooked everything up correctly?');
+            }
+
             var httpRequest = new XMLHttpRequest();
             var url = this.url;
             var callHeaders = this.headers;
             var root = this.root;
+
             if (!httpRequest) {
                 throw new Error('Cannot talk to server! Please upgrade your browser to one that supports XMLHttpRequest.');
             }
 
             var snackbarCallback = function snackbarCallback(contentType, response) {
                 var snackbar = root.querySelector('.mdc-snackbar').vComponent;
-                if (contentType && contentType.indexOf('application/json') !== -1) {
+                if (contentType && contentType.includes('application/json')) {
                     var messages = JSON.parse(response).messages;
                     if (snackbar && messages && messages.snackbar) {
                         var message = messages.snackbar.join('<br/>');
@@ -25382,7 +25516,7 @@ var VPosts = function (_VBase) {
                             snackbarCallback(contentType, httpRequest.responseText);
                             resolve(results);
                             // Response is an html error page
-                        } else if (contentType && contentType.indexOf('text/html') !== -1) {
+                        } else if (contentType && contentType.includes('text/html')) {
                             root.open(contentType);
                             root.write(httpRequest.responseText);
                             root.close();
@@ -25412,70 +25546,70 @@ var VPosts = function (_VBase) {
 
                 var configHeaders = __WEBPACK_IMPORTED_MODULE_1__config__["a" /* default */].get('request.headers.POST', {});
 
-                var _iteratorNormalCompletion2 = true;
-                var _didIteratorError2 = false;
-                var _iteratorError2 = undefined;
+                var _iteratorNormalCompletion4 = true;
+                var _didIteratorError4 = false;
+                var _iteratorError4 = undefined;
 
                 try {
-                    for (var _iterator2 = Object.entries(configHeaders)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-                        var _ref = _step2.value;
+                    for (var _iterator4 = Object.entries(configHeaders)[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                        var _ref7 = _step4.value;
 
-                        var _ref2 = _slicedToArray(_ref, 2);
+                        var _ref8 = _slicedToArray(_ref7, 2);
 
-                        var key = _ref2[0];
-                        var value = _ref2[1];
+                        var key = _ref8[0];
+                        var _value2 = _ref8[1];
 
-                        httpRequest.setRequestHeader(key, value);
+                        httpRequest.setRequestHeader(key, _value2);
                     }
                 } catch (err) {
-                    _didIteratorError2 = true;
-                    _iteratorError2 = err;
+                    _didIteratorError4 = true;
+                    _iteratorError4 = err;
                 } finally {
                     try {
-                        if (!_iteratorNormalCompletion2 && _iterator2.return) {
-                            _iterator2.return();
+                        if (!_iteratorNormalCompletion4 && _iterator4.return) {
+                            _iterator4.return();
                         }
                     } finally {
-                        if (_didIteratorError2) {
-                            throw _iteratorError2;
+                        if (_didIteratorError4) {
+                            throw _iteratorError4;
                         }
                     }
                 }
 
                 if (callHeaders) {
-                    var _iteratorNormalCompletion3 = true;
-                    var _didIteratorError3 = false;
-                    var _iteratorError3 = undefined;
+                    var _iteratorNormalCompletion5 = true;
+                    var _didIteratorError5 = false;
+                    var _iteratorError5 = undefined;
 
                     try {
-                        for (var _iterator3 = Object.entries(callHeaders)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-                            var _ref3 = _step3.value;
+                        for (var _iterator5 = Object.entries(callHeaders)[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+                            var _ref9 = _step5.value;
 
-                            var _ref4 = _slicedToArray(_ref3, 2);
+                            var _ref10 = _slicedToArray(_ref9, 2);
 
-                            var _key = _ref4[0];
-                            var _value = _ref4[1];
+                            var _key = _ref10[0];
+                            var _value3 = _ref10[1];
 
-                            httpRequest.setRequestHeader(_key, _value);
+                            httpRequest.setRequestHeader(_key, _value3);
                         }
                     } catch (err) {
-                        _didIteratorError3 = true;
-                        _iteratorError3 = err;
+                        _didIteratorError5 = true;
+                        _iteratorError5 = err;
                     } finally {
                         try {
-                            if (!_iteratorNormalCompletion3 && _iterator3.return) {
-                                _iterator3.return();
+                            if (!_iteratorNormalCompletion5 && _iterator5.return) {
+                                _iterator5.return();
                             }
                         } finally {
-                            if (_didIteratorError3) {
-                                throw _iteratorError3;
+                            if (_didIteratorError5) {
+                                throw _iteratorError5;
                             }
                         }
                     }
                 }
 
                 // Send our FormData object; HTTP headers are set automatically
-                httpRequest.send(FD);
+                httpRequest.send(formData);
             });
         }
     }, {
@@ -25765,11 +25899,7 @@ var VPromptIfDirty = function (_VBase) {
             var _this2 = this;
 
             // We're in a dirty state if any dirtyable inputs are dirty:
-            var dirty = Array.from(this.inputs()).filter(function (input) {
-                return input.vComponent;
-            }).map(function (input) {
-                return input.vComponent;
-            }).filter(function (comp) {
+            var dirty = this.inputComponents().filter(function (comp) {
                 return comp.isDirty;
             }).map(function (comp) {
                 return comp.isDirty();
@@ -25804,37 +25934,6 @@ var VPromptIfDirty = function (_VBase) {
                     return resolve(results);
                 });
             });
-        }
-
-        /**
-         * inputs returns an array of Voom components.
-         * If an input_tag has been specified, the array contains input
-         * components tagged with the specified input_tag.
-         * Otherwise, the array contains the nearest container's input
-         * components.
-         * @throws Error if No input_tag is specified and a nearest container
-         *               cannot be found.
-         * @return {array} An array of input components
-         */
-
-    }, {
-        key: 'inputs',
-        value: function inputs() {
-            var container = this.closestContainer();
-            var inputTag = this.options.input_tag;
-
-            // A specified input_tag has priority over the nearest container:
-            if (inputTag) {
-                return this.taggedInputs();
-            }
-
-            // If no nearest container can be found, bail:
-            if (!(container && container.vComponent)) {
-                throw new Error('Unable to find a nearest container! Try using an input_tag.');
-            }
-
-            // Otherwise, use the nearest container's input elements:
-            return container.vComponent.inputs();
         }
     }]);
 

--- a/spec/integration/demo/00_index_spec.rb
+++ b/spec/integration/demo/00_index_spec.rb
@@ -2,7 +2,7 @@ require "watir_helper"
 
 describe "Demo Index", :integration do
   before do
-    goto "http://localhost:9292/index"
+    goto "#{host}/index"
   end
 
   it "has heading" do

--- a/spec/integration/demo/02_selectable_list_spec.rb
+++ b/spec/integration/demo/02_selectable_list_spec.rb
@@ -12,13 +12,13 @@ describe "Demo - Selectable List", :integration do
     select_all = checkbox(class_name: 'v-checkbox--select-control')
     # Select
     select_all.click
-    b.inputs(class_name: 'v-list-item--selectable-checkbox').each do |elem|
-      expect(elem.set?).to eq(true)
+    b.checkboxes(class_name: 'v-list-item--selectable-checkbox').each do |checkbox|
+      expect(checkbox.checked?).to eq(true)
     end
     # Deselect
     select_all.click
-    b.inputs(class_name: 'v-list-item--selectable-checkbox').each do |elem|
-      expect(elem.set?).to eq(false)
+    b.checkboxes(class_name: 'v-list-item--selectable-checkbox').each do |checkbox|
+      expect(checkbox.checked?).to eq(false)
     end
   end
 

--- a/spec/integration/demo/03_content_as_form_spec.rb
+++ b/spec/integration/demo/03_content_as_form_spec.rb
@@ -1,0 +1,109 @@
+require 'watir_helper'
+
+shared_examples 'displays all input parameters' do
+  before do
+    form.text_fields.each_with_index do |input, i|
+      input.set(values[i])
+    end
+    form.checkboxes.first.set(checkbox_value)
+  end
+
+  before :each do
+    submit_button.click
+    response_div.wait_until(&:present?)
+  end
+
+  it 'renders all input parameters to the page' do
+    expect(response_div.text).to include(checkbox_value.to_s)
+
+    values.each do |value|
+      expect(response_div.text).to include(value)
+    end
+  end
+end
+
+describe 'Content as Form', :integration do
+  before do
+    goto "#{host}/content_as_form"
+    Watir.default_timeout = 5
+  end
+
+  after do
+    print_js_errors
+  end
+
+  let(:response_div) { b.div(id: 'response_content', 'data-input-tag' => tag.to_s.succ) }
+  let(:submit_button) { form.buttons[tag] }
+  let(:values) { [SecureRandom.hex] }
+  let(:checkbox_value) { Random.rand > 0.50 }
+
+  context 'in a form block' do
+    let(:form) { div(id: 'form_1') }
+    let(:tag) { 0 }
+
+    it_behaves_like 'displays all input parameters'
+
+    context 'in a content block' do
+      let(:tag) { 1 }
+
+      it_behaves_like 'displays all input parameters'
+    end
+
+    context 'in a grid > column' do
+      let(:tag) { 2 }
+
+      it_behaves_like 'displays all input parameters'
+    end
+  end
+
+  context 'in an untagged content block' do
+    let(:form) { div(id: 'content_1') }
+    let(:tag) { 0 }
+
+    it_behaves_like 'displays all input parameters'
+
+    context 'in a content block' do
+      let(:tag) { 1 }
+
+      it 'does not render any parameters to the page' do
+        submit_button.click
+
+        response_div.wait_until(&:present?)
+        expect(response_div.text).to be_empty
+      end
+    end
+
+    context 'in a grid > column' do
+      let(:tag) { 2 }
+
+      it_behaves_like 'displays all input parameters'
+    end
+  end
+
+  context 'in a tagged content block' do
+    let(:form) { div(id: 'content_2') }
+    let(:tag) { 0 }
+
+    it_behaves_like 'displays all input parameters'
+
+    context 'in a content block' do
+      let(:tag) { 1 }
+
+      it_behaves_like 'displays all input parameters'
+    end
+
+    context 'in a grid > column' do
+      let(:tag) { 2 }
+
+      it_behaves_like 'displays all input parameters'
+    end
+  end
+
+  context 'with an array of values' do
+    let(:form) { div(id: 'content_array') }
+    let(:tag) { 0 }
+    let(:values) { Array.new(3) { SecureRandom.hex } }
+
+    it_behaves_like 'displays all input parameters'
+  end
+end

--- a/spec/support/integration/host.rb
+++ b/spec/support/integration/host.rb
@@ -1,12 +1,10 @@
 module Support
   module Host
-    HOSTS = ['localhost:9292']
+    HOSTS = %w[localhost:9292 localhost:9393].freeze
 
     def host
       ENV.fetch('INTEGRATION_HOST') do
-        host = HOSTS.select do |host|
-          check_for_server(host)
-        end.compact.first
+        host = HOSTS.find { |h| check_for_server(h) }
         host ? "http://#{host}" : nil
       end
     end

--- a/spec/support/integration/host.rb
+++ b/spec/support/integration/host.rb
@@ -1,6 +1,6 @@
 module Support
   module Host
-    HOSTS = %w[localhost:9292 localhost:9393].freeze
+    HOSTS = %w[127.0.0.1:9292 127.0.0.1:9393].freeze
 
     def host
       ENV.fetch('INTEGRATION_HOST') do
@@ -18,7 +18,7 @@ module Support
     end
 
     def check_for_server(host)
-      system("ps aux | grep [t]cp://#{host}")
+      system("ps aux | grep [t]cp://#{host} > /dev/null")
     end
 
   end

--- a/views/mdc/assets/js/components/base-component.js
+++ b/views/mdc/assets/js/components/base-component.js
@@ -21,6 +21,10 @@ export class VBaseComponent {
     clearErrors() {
         new VErrors(this.root).clearErrors();
     }
+
+    respondTo(method) {
+        return typeof this[method] === 'function';
+    }
 }
 
 export function hookupComponents(root, selector, VoomClass, MdcClass) {

--- a/views/mdc/assets/js/components/events/base.js
+++ b/views/mdc/assets/js/components/events/base.js
@@ -41,7 +41,7 @@ export class VBase extends VUrls {
 
         // If tagged input is asked for, fetch all the matching tag elements
         // and then call any bound components:
-        if (this.options.input_tag !== undefined) {
+        if (this.options.input_tag) {
             const inputs = Array.from(this.taggedInputs())
                 .filter((input) => input.vComponent)
                 .map((input) => input.vComponent)

--- a/views/mdc/assets/js/components/events/posts.js
+++ b/views/mdc/assets/js/components/events/posts.js
@@ -32,23 +32,30 @@ export class VPosts extends VBase {
             });
         }
 
-        var FD = null;
-        var form = this.form();
-        if (form) {
-            FD = new FormData(form);
-        }
-        else {
-            FD = new FormData();
-        }
-        // Add params from presenter
-        expandParams(results, this.params);
-        for (const name in this.params) {
-            FD.append(name, encode(this.params[name]));
+        // Manually build the FormData.
+        // Passing in a <form> element (if available) would skip over
+        // unchecked toggle elements, which would be unexpected if the user
+        // has specified a value for the toggle's `off_value` attribute.
+        const formData = new FormData();
+
+        // NB: `inputValues` will appropriately handle `input_tag`.
+        for (const [name, value] of this.inputValues()) {
+            formData.append(name, value);
         }
 
-        var inputValues = this.inputValues();
-        for (var input of inputValues) {
-            FD.append(input[0], input[1]);
+        // Add params from presenter:
+        expandParams(results, this.params);
+
+        for (const [name, value] of Object.entries(this.params)) {
+            formData.append(name, encode(value));
+        }
+
+        // log dupes:
+        // TODO: remove me (debug)
+        for (const [k, v] of formData) {
+            console.log(`${k}: ${v}`);
+        }
+
         }
 
         const httpRequest = new XMLHttpRequest();
@@ -135,7 +142,7 @@ export class VPosts extends VBase {
             }
 
             // Send our FormData object; HTTP headers are set automatically
-            httpRequest.send(FD);
+            httpRequest.send(formData);
         });
     }
 

--- a/views/mdc/assets/js/components/events/posts.js
+++ b/views/mdc/assets/js/components/events/posts.js
@@ -56,6 +56,13 @@ export class VPosts extends VBase {
             console.log(`${k}: ${v}`);
         }
 
+        const paramCount = Array.from(formData).length;
+
+        if (paramCount < 1) {
+            console.warn(
+                'Creating request with no data!'
+                + ' Are you sure you\'ve hooked everything up correctly?'
+            );
         }
 
         const httpRequest = new XMLHttpRequest();

--- a/views/mdc/assets/js/components/events/prompt_if_dirty.js
+++ b/views/mdc/assets/js/components/events/prompt_if_dirty.js
@@ -31,9 +31,7 @@ export class VPromptIfDirty extends VBase {
 
     call(results) {
         // We're in a dirty state if any dirtyable inputs are dirty:
-        const dirty = Array.from(this.inputs())
-            .filter((input) => input.vComponent)
-            .map((input) => input.vComponent)
+        const dirty = this.inputComponents()
             .filter((comp) => comp.isDirty)
             .map((comp) => comp.isDirty())
             .some(Boolean);
@@ -65,35 +63,5 @@ export class VPromptIfDirty extends VBase {
                 return resolve(results);
             });
         });
-    }
-
-    /**
-     * inputs returns an array of Voom components.
-     * If an input_tag has been specified, the array contains input
-     * components tagged with the specified input_tag.
-     * Otherwise, the array contains the nearest container's input
-     * components.
-     * @throws Error if No input_tag is specified and a nearest container
-     *               cannot be found.
-     * @return {array} An array of input components
-     */
-    inputs() {
-        const container = this.closestContainer();
-        const inputTag = this.options.input_tag;
-
-        // A specified input_tag has priority over the nearest container:
-        if (inputTag) {
-            return this.taggedInputs();
-        }
-
-        // If no nearest container can be found, bail:
-        if (!(container && container.vComponent)) {
-            throw new Error(
-                'Unable to find a nearest container! Try using an input_tag.'
-            );
-        }
-
-        // Otherwise, use the nearest container's input elements:
-        return container.vComponent.inputs();
     }
 }


### PR DESCRIPTION
Fix base Event and request FormData input collection logic.

* Ignore all falsey values for `input_tag`
  * Previously, only `undefined` input_tag values were ignored, which allowed `null` input_tag values to be considered (although with no side effects).
* The `FormData` objects passed to `XMLHttpRequest` instances are now constructed manually rather than via passing an `HTMLFormElement` instance into the `FormData` constructor
  * The native FormData constructor is problematic (for our use case) because it will ignore unchecked toggleable elements. This leads to different form data for `form` blocks vs. `content` blocks.
* The base event now gathers input values based on the following criteria:
  1. If an `input_tag` is provided, all matching elements are included.
  2. If the event's component is an element, it is included.
  3. If the event's component has inputs, they are included. If not, the elements of the nearest content container are included.
* Warn if user has created a situation yielding a request with no data
* Add demo page and integration test for the above
* Fix `/index` and `/selectable_list` integration tests
* Allow integration tests to be run with Shotgun