### PR TITLE
Fix request params II

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -60,14 +60,14 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 155);
+/******/ 	return __webpack_require__(__webpack_require__.s = 150);
 /******/ })
 /************************************************************************/
 /******/ ([
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var core = __webpack_require__(21);
 var hide = __webpack_require__(14);
 var redefine = __webpack_require__(15);
@@ -123,22 +123,12 @@ module.exports = function (it) {
 
 /***/ }),
 /* 2 */
-/***/ (function(module, exports) {
-
-// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
-var global = module.exports = typeof window != 'undefined' && window.Math == Math ? window : typeof self != 'undefined' && self.Math == Math ? self
-// eslint-disable-next-line no-new-func
-: Function('return this')();
-if (typeof __g == 'number') __g = global; // eslint-disable-line no-undef
-
-/***/ }),
-/* 3 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseComponent; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = hookupComponents;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_errors__ = __webpack_require__(105);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_errors__ = __webpack_require__(102);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -199,6 +189,16 @@ function hookupComponents(root, selector, VoomClass, MdcClass) {
 }
 
 /***/ }),
+/* 3 */
+/***/ (function(module, exports) {
+
+// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+var global = module.exports = typeof window != 'undefined' && window.Math == Math ? window : typeof self != 'undefined' && self.Math == Math ? self
+// eslint-disable-next-line no-new-func
+: Function('return this')();
+if (typeof __g == 'number') __g = global; // eslint-disable-line no-undef
+
+/***/ }),
 /* 4 */
 /***/ (function(module, exports) {
 
@@ -224,9 +224,9 @@ module.exports = function (it) {
 /* 6 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var store = __webpack_require__(51)('wks');
+var store = __webpack_require__(56)('wks');
 var uid = __webpack_require__(36);
-var _Symbol = __webpack_require__(2).Symbol;
+var _Symbol = __webpack_require__(3).Symbol;
 var USE_SYMBOL = typeof _Symbol == 'function';
 
 var $exports = module.exports = function (name) {
@@ -239,17 +239,6 @@ $exports.store = store;
 /* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// 7.1.15 ToLength
-var toInteger = __webpack_require__(24);
-var min = Math.min;
-module.exports = function (it) {
-  return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991
-};
-
-/***/ }),
-/* 8 */
-/***/ (function(module, exports, __webpack_require__) {
-
 // Thank's IE8 for his funny defineProperty
 module.exports = !__webpack_require__(4)(function () {
   return Object.defineProperty({}, 'a', { get: function get() {
@@ -258,15 +247,15 @@ module.exports = !__webpack_require__(4)(function () {
 });
 
 /***/ }),
-/* 9 */
+/* 8 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var anObject = __webpack_require__(1);
-var IE8_DOM_DEFINE = __webpack_require__(108);
-var toPrimitive = __webpack_require__(26);
+var IE8_DOM_DEFINE = __webpack_require__(105);
+var toPrimitive = __webpack_require__(25);
 var dP = Object.defineProperty;
 
-exports.f = __webpack_require__(8) ? Object.defineProperty : function defineProperty(O, P, Attributes) {
+exports.f = __webpack_require__(7) ? Object.defineProperty : function defineProperty(O, P, Attributes) {
   anObject(O);
   P = toPrimitive(P, true);
   anObject(Attributes);
@@ -279,17 +268,18 @@ exports.f = __webpack_require__(8) ? Object.defineProperty : function defineProp
 };
 
 /***/ }),
-/* 10 */
+/* 9 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// 7.1.13 ToObject(argument)
-var defined = __webpack_require__(27);
+// 7.1.15 ToLength
+var toInteger = __webpack_require__(27);
+var min = Math.min;
 module.exports = function (it) {
-  return Object(defined(it));
+  return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991
 };
 
 /***/ }),
-/* 11 */
+/* 10 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -333,6 +323,16 @@ var eventHandlerMixin = function eventHandlerMixin(Base) {
 };
 
 /***/ }),
+/* 11 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// 7.1.13 ToObject(argument)
+var defined = __webpack_require__(26);
+module.exports = function (it) {
+  return Object(defined(it));
+};
+
+/***/ }),
 /* 12 */
 /***/ (function(module, exports) {
 
@@ -372,9 +372,9 @@ module.exports = function (it) {
 /* 14 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var dP = __webpack_require__(9);
+var dP = __webpack_require__(8);
 var createDesc = __webpack_require__(35);
-module.exports = __webpack_require__(8) ? function (object, key, value) {
+module.exports = __webpack_require__(7) ? function (object, key, value) {
   return dP.f(object, key, createDesc(1, value));
 } : function (object, key, value) {
   object[key] = value;
@@ -385,12 +385,12 @@ module.exports = __webpack_require__(8) ? function (object, key, value) {
 /* 15 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var hide = __webpack_require__(14);
 var has = __webpack_require__(17);
 var SRC = __webpack_require__(36)('src');
-var $toString = __webpack_require__(166);
 var TO_STRING = 'toString';
+var $toString = Function[TO_STRING];
 var TPL = ('' + $toString).split(TO_STRING);
 
 __webpack_require__(21).inspectSource = function (it) {
@@ -423,7 +423,7 @@ __webpack_require__(21).inspectSource = function (it) {
 
 var $export = __webpack_require__(0);
 var fails = __webpack_require__(4);
-var defined = __webpack_require__(27);
+var defined = __webpack_require__(26);
 var quot = /"/g;
 // B.2.3.2.1 CreateHTML(string, tag, attribute, value)
 var createHTML = function createHTML(string, tag, attribute, value) {
@@ -455,8 +455,8 @@ module.exports = function (it, key) {
 /***/ (function(module, exports, __webpack_require__) {
 
 // to indexed object, toObject with fallback for non-array-like ES3 strings
-var IObject = __webpack_require__(52);
-var defined = __webpack_require__(27);
+var IObject = __webpack_require__(50);
+var defined = __webpack_require__(26);
 module.exports = function (it) {
   return IObject(defined(it));
 };
@@ -465,15 +465,15 @@ module.exports = function (it) {
 /* 19 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var pIE = __webpack_require__(53);
+var pIE = __webpack_require__(51);
 var createDesc = __webpack_require__(35);
 var toIObject = __webpack_require__(18);
-var toPrimitive = __webpack_require__(26);
+var toPrimitive = __webpack_require__(25);
 var has = __webpack_require__(17);
-var IE8_DOM_DEFINE = __webpack_require__(108);
+var IE8_DOM_DEFINE = __webpack_require__(105);
 var gOPD = Object.getOwnPropertyDescriptor;
 
-exports.f = __webpack_require__(8) ? gOPD : function getOwnPropertyDescriptor(O, P) {
+exports.f = __webpack_require__(7) ? gOPD : function getOwnPropertyDescriptor(O, P) {
   O = toIObject(O);
   P = toPrimitive(P, true);
   if (IE8_DOM_DEFINE) try {
@@ -488,8 +488,8 @@ exports.f = __webpack_require__(8) ? gOPD : function getOwnPropertyDescriptor(O,
 
 // 19.1.2.9 / 15.2.3.2 Object.getPrototypeOf(O)
 var has = __webpack_require__(17);
-var toObject = __webpack_require__(10);
-var IE_PROTO = __webpack_require__(80)('IE_PROTO');
+var toObject = __webpack_require__(11);
+var IE_PROTO = __webpack_require__(78)('IE_PROTO');
 var ObjectProto = Object.prototype;
 
 module.exports = Object.getPrototypeOf || function (O) {
@@ -504,7 +504,7 @@ module.exports = Object.getPrototypeOf || function (O) {
 /* 21 */
 /***/ (function(module, exports) {
 
-var core = module.exports = { version: '2.6.5' };
+var core = module.exports = { version: '2.5.7' };
 if (typeof __e == 'number') __e = core; // eslint-disable-line no-undef
 
 /***/ }),
@@ -547,17 +547,6 @@ module.exports = function (it) {
 
 /***/ }),
 /* 24 */
-/***/ (function(module, exports) {
-
-// 7.1.4 ToInteger
-var ceil = Math.ceil;
-var floor = Math.floor;
-module.exports = function (it) {
-  return isNaN(it = +it) ? 0 : (it > 0 ? floor : ceil)(it);
-};
-
-/***/ }),
-/* 25 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -573,7 +562,7 @@ module.exports = function (method, arg) {
 };
 
 /***/ }),
-/* 26 */
+/* 25 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.1.1 ToPrimitive(input [, PreferredType])
@@ -590,13 +579,24 @@ module.exports = function (it, S) {
 };
 
 /***/ }),
-/* 27 */
+/* 26 */
 /***/ (function(module, exports) {
 
 // 7.2.1 RequireObjectCoercible(argument)
 module.exports = function (it) {
   if (it == undefined) throw TypeError("Can't call method on  " + it);
   return it;
+};
+
+/***/ }),
+/* 27 */
+/***/ (function(module, exports) {
+
+// 7.1.4 ToInteger
+var ceil = Math.ceil;
+var floor = Math.floor;
+module.exports = function (it) {
+  return isNaN(it = +it) ? 0 : (it > 0 ? floor : ceil)(it);
 };
 
 /***/ }),
@@ -628,10 +628,10 @@ module.exports = function (KEY, exec) {
 // 5 -> Array#find
 // 6 -> Array#findIndex
 var ctx = __webpack_require__(22);
-var IObject = __webpack_require__(52);
-var toObject = __webpack_require__(10);
-var toLength = __webpack_require__(7);
-var asc = __webpack_require__(96);
+var IObject = __webpack_require__(50);
+var toObject = __webpack_require__(11);
+var toLength = __webpack_require__(9);
+var asc = __webpack_require__(95);
 module.exports = function (TYPE, $create) {
   var IS_MAP = TYPE == 1;
   var IS_FILTER = TYPE == 2;
@@ -679,44 +679,44 @@ module.exports = function (TYPE, $create) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-if (__webpack_require__(8)) {
-  var LIBRARY = __webpack_require__(32);
-  var global = __webpack_require__(2);
+if (__webpack_require__(7)) {
+  var LIBRARY = __webpack_require__(33);
+  var global = __webpack_require__(3);
   var fails = __webpack_require__(4);
   var $export = __webpack_require__(0);
-  var $typed = __webpack_require__(69);
-  var $buffer = __webpack_require__(104);
+  var $typed = __webpack_require__(67);
+  var $buffer = __webpack_require__(101);
   var ctx = __webpack_require__(22);
   var anInstance = __webpack_require__(42);
   var propertyDesc = __webpack_require__(35);
   var hide = __webpack_require__(14);
   var redefineAll = __webpack_require__(44);
-  var toInteger = __webpack_require__(24);
-  var toLength = __webpack_require__(7);
-  var toIndex = __webpack_require__(136);
+  var toInteger = __webpack_require__(27);
+  var toLength = __webpack_require__(9);
+  var toIndex = __webpack_require__(131);
   var toAbsoluteIndex = __webpack_require__(38);
-  var toPrimitive = __webpack_require__(26);
+  var toPrimitive = __webpack_require__(25);
   var has = __webpack_require__(17);
-  var classof = __webpack_require__(48);
+  var classof = __webpack_require__(52);
   var isObject = __webpack_require__(5);
-  var toObject = __webpack_require__(10);
-  var isArrayIter = __webpack_require__(93);
+  var toObject = __webpack_require__(11);
+  var isArrayIter = __webpack_require__(92);
   var create = __webpack_require__(39);
   var getPrototypeOf = __webpack_require__(20);
   var gOPN = __webpack_require__(40).f;
-  var getIterFn = __webpack_require__(95);
+  var getIterFn = __webpack_require__(94);
   var uid = __webpack_require__(36);
   var wks = __webpack_require__(6);
   var createArrayMethod = __webpack_require__(29);
-  var createArrayIncludes = __webpack_require__(59);
-  var speciesConstructor = __webpack_require__(55);
-  var ArrayIterators = __webpack_require__(98);
-  var Iterators = __webpack_require__(50);
-  var $iterDetect = __webpack_require__(64);
+  var createArrayIncludes = __webpack_require__(57);
+  var speciesConstructor = __webpack_require__(64);
+  var ArrayIterators = __webpack_require__(97);
+  var Iterators = __webpack_require__(48);
+  var $iterDetect = __webpack_require__(61);
   var setSpecies = __webpack_require__(41);
-  var arrayFill = __webpack_require__(97);
-  var arrayCopyWithin = __webpack_require__(125);
-  var $DP = __webpack_require__(9);
+  var arrayFill = __webpack_require__(96);
+  var arrayCopyWithin = __webpack_require__(121);
+  var $DP = __webpack_require__(8);
   var $GOPD = __webpack_require__(19);
   var dP = $DP.f;
   var gOPD = $GOPD.f;
@@ -1165,10 +1165,10 @@ if (__webpack_require__(8)) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var Map = __webpack_require__(131);
+var Map = __webpack_require__(126);
 var $export = __webpack_require__(0);
-var shared = __webpack_require__(51)('metadata');
-var store = shared.store || (shared.store = new (__webpack_require__(134))());
+var shared = __webpack_require__(56)('metadata');
+var store = shared.store || (shared.store = new (__webpack_require__(129))());
 
 var getOrCreateMetadataMap = function getOrCreateMetadataMap(target, targetKey, create) {
   var targetMetadata = store.get(target);
@@ -1221,12 +1221,6 @@ module.exports = {
 
 /***/ }),
 /* 32 */
-/***/ (function(module, exports) {
-
-module.exports = false;
-
-/***/ }),
-/* 33 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -1234,7 +1228,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 var META = __webpack_require__(36)('meta');
 var isObject = __webpack_require__(5);
 var has = __webpack_require__(17);
-var setDesc = __webpack_require__(9).f;
+var setDesc = __webpack_require__(8).f;
 var id = 0;
 var isExtensible = Object.isExtensible || function () {
   return true;
@@ -1286,6 +1280,12 @@ var meta = module.exports = {
 };
 
 /***/ }),
+/* 33 */
+/***/ (function(module, exports) {
+
+module.exports = false;
+
+/***/ }),
 /* 34 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -1325,8 +1325,8 @@ module.exports = function (key) {
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.14 / 15.2.3.14 Object.keys(O)
-var $keys = __webpack_require__(110);
-var enumBugKeys = __webpack_require__(81);
+var $keys = __webpack_require__(107);
+var enumBugKeys = __webpack_require__(79);
 
 module.exports = Object.keys || function keys(O) {
   return $keys(O, enumBugKeys);
@@ -1336,7 +1336,7 @@ module.exports = Object.keys || function keys(O) {
 /* 38 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toInteger = __webpack_require__(24);
+var toInteger = __webpack_require__(27);
 var max = Math.max;
 var min = Math.min;
 module.exports = function (index, length) {
@@ -1350,22 +1350,22 @@ module.exports = function (index, length) {
 
 // 19.1.2.2 / 15.2.3.5 Object.create(O [, Properties])
 var anObject = __webpack_require__(1);
-var dPs = __webpack_require__(111);
-var enumBugKeys = __webpack_require__(81);
-var IE_PROTO = __webpack_require__(80)('IE_PROTO');
+var dPs = __webpack_require__(108);
+var enumBugKeys = __webpack_require__(79);
+var IE_PROTO = __webpack_require__(78)('IE_PROTO');
 var Empty = function Empty() {/* empty */};
 var PROTOTYPE = 'prototype';
 
 // Create object with fake `null` prototype: use iframe Object with cleared prototype
 var _createDict = function createDict() {
   // Thrash, waste and sodomy: IE GC bug
-  var iframe = __webpack_require__(78)('iframe');
+  var iframe = __webpack_require__(76)('iframe');
   var i = enumBugKeys.length;
   var lt = '<';
   var gt = '>';
   var iframeDocument;
   iframe.style.display = 'none';
-  __webpack_require__(82).appendChild(iframe);
+  __webpack_require__(80).appendChild(iframe);
   iframe.src = 'javascript:'; // eslint-disable-line no-script-url
   // createDict = iframe.contentWindow.Object;
   // html.removeChild(iframe);
@@ -1396,8 +1396,8 @@ module.exports = Object.create || function create(O, Properties) {
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.7 / 15.2.3.4 Object.getOwnPropertyNames(O)
-var $keys = __webpack_require__(110);
-var hiddenKeys = __webpack_require__(81).concat('length', 'prototype');
+var $keys = __webpack_require__(107);
+var hiddenKeys = __webpack_require__(79).concat('length', 'prototype');
 
 exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
   return $keys(O, hiddenKeys);
@@ -1410,9 +1410,9 @@ exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
 "use strict";
 
 
-var global = __webpack_require__(2);
-var dP = __webpack_require__(9);
-var DESCRIPTORS = __webpack_require__(8);
+var global = __webpack_require__(3);
+var dP = __webpack_require__(8);
+var DESCRIPTORS = __webpack_require__(7);
 var SPECIES = __webpack_require__(6)('species');
 
 module.exports = function (KEY) {
@@ -1440,11 +1440,11 @@ module.exports = function (it, Constructor, name, forbiddenField) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var ctx = __webpack_require__(22);
-var call = __webpack_require__(123);
-var isArrayIter = __webpack_require__(93);
+var call = __webpack_require__(119);
+var isArrayIter = __webpack_require__(92);
 var anObject = __webpack_require__(1);
-var toLength = __webpack_require__(7);
-var getIterFn = __webpack_require__(95);
+var toLength = __webpack_require__(9);
+var getIterFn = __webpack_require__(94);
 var BREAK = {};
 var RETURN = {};
 var exports = module.exports = function (iterable, entries, fn, that, ITERATOR) {
@@ -1480,21 +1480,11 @@ module.exports = function (target, src, safe) {
 
 /***/ }),
 /* 45 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var isObject = __webpack_require__(5);
-module.exports = function (it, TYPE) {
-  if (!isObject(it) || it._t !== TYPE) throw TypeError('Incompatible receiver, ' + TYPE + ' required!');
-  return it;
-};
-
-/***/ }),
-/* 46 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseContainer; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -1676,10 +1666,10 @@ var VBaseContainer = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 47 */
+/* 46 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var def = __webpack_require__(9).f;
+var def = __webpack_require__(8).f;
 var has = __webpack_require__(17);
 var TAG = __webpack_require__(6)('toStringTag');
 
@@ -1688,7 +1678,75 @@ module.exports = function (it, tag, stat) {
 };
 
 /***/ }),
+/* 47 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var $export = __webpack_require__(0);
+var defined = __webpack_require__(26);
+var fails = __webpack_require__(4);
+var spaces = __webpack_require__(82);
+var space = '[' + spaces + ']';
+var non = '\u200B\x85';
+var ltrim = RegExp('^' + space + space + '*');
+var rtrim = RegExp(space + space + '*$');
+
+var exporter = function exporter(KEY, exec, ALIAS) {
+  var exp = {};
+  var FORCE = fails(function () {
+    return !!spaces[KEY]() || non[KEY]() != non;
+  });
+  var fn = exp[KEY] = FORCE ? exec(trim) : spaces[KEY];
+  if (ALIAS) exp[ALIAS] = fn;
+  $export($export.P + $export.F * FORCE, 'String', exp);
+};
+
+// 1 -> String#trimLeft
+// 2 -> String#trimRight
+// 3 -> String#trim
+var trim = exporter.trim = function (string, TYPE) {
+  string = String(defined(string));
+  if (TYPE & 1) string = string.replace(ltrim, '');
+  if (TYPE & 2) string = string.replace(rtrim, '');
+  return string;
+};
+
+module.exports = exporter;
+
+/***/ }),
 /* 48 */
+/***/ (function(module, exports) {
+
+module.exports = {};
+
+/***/ }),
+/* 49 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var isObject = __webpack_require__(5);
+module.exports = function (it, TYPE) {
+  if (!isObject(it) || it._t !== TYPE) throw TypeError('Incompatible receiver, ' + TYPE + ' required!');
+  return it;
+};
+
+/***/ }),
+/* 50 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// fallback for non-array-like ES3 and non-enumerable old V8 strings
+var cof = __webpack_require__(23);
+// eslint-disable-next-line no-prototype-builtins
+module.exports = Object('z').propertyIsEnumerable(0) ? Object : function (it) {
+  return cof(it) == 'String' ? it.split('') : Object(it);
+};
+
+/***/ }),
+/* 51 */
+/***/ (function(module, exports) {
+
+exports.f = {}.propertyIsEnumerable;
+
+/***/ }),
+/* 52 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // getting tag from 19.1.3.6 Object.prototype.toString()
@@ -1718,116 +1776,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 49 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var $export = __webpack_require__(0);
-var defined = __webpack_require__(27);
-var fails = __webpack_require__(4);
-var spaces = __webpack_require__(84);
-var space = '[' + spaces + ']';
-var non = '\u200B\x85';
-var ltrim = RegExp('^' + space + space + '*');
-var rtrim = RegExp(space + space + '*$');
-
-var exporter = function exporter(KEY, exec, ALIAS) {
-  var exp = {};
-  var FORCE = fails(function () {
-    return !!spaces[KEY]() || non[KEY]() != non;
-  });
-  var fn = exp[KEY] = FORCE ? exec(trim) : spaces[KEY];
-  if (ALIAS) exp[ALIAS] = fn;
-  $export($export.P + $export.F * FORCE, 'String', exp);
-};
-
-// 1 -> String#trimLeft
-// 2 -> String#trimRight
-// 3 -> String#trim
-var trim = exporter.trim = function (string, TYPE) {
-  string = String(defined(string));
-  if (TYPE & 1) string = string.replace(ltrim, '');
-  if (TYPE & 2) string = string.replace(rtrim, '');
-  return string;
-};
-
-module.exports = exporter;
-
-/***/ }),
-/* 50 */
-/***/ (function(module, exports) {
-
-module.exports = {};
-
-/***/ }),
-/* 51 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var core = __webpack_require__(21);
-var global = __webpack_require__(2);
-var SHARED = '__core-js_shared__';
-var store = global[SHARED] || (global[SHARED] = {});
-
-(module.exports = function (key, value) {
-  return store[key] || (store[key] = value !== undefined ? value : {});
-})('versions', []).push({
-  version: core.version,
-  mode: __webpack_require__(32) ? 'pure' : 'global',
-  copyright: '© 2019 Denis Pushkarev (zloirock.ru)'
-});
-
-/***/ }),
-/* 52 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// fallback for non-array-like ES3 and non-enumerable old V8 strings
-var cof = __webpack_require__(23);
-// eslint-disable-next-line no-prototype-builtins
-module.exports = Object('z').propertyIsEnumerable(0) ? Object : function (it) {
-  return cof(it) == 'String' ? it.split('') : Object(it);
-};
-
-/***/ }),
 /* 53 */
-/***/ (function(module, exports) {
-
-exports.f = {}.propertyIsEnumerable;
-
-/***/ }),
-/* 54 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-// 21.2.5.3 get RegExp.prototype.flags
-
-var anObject = __webpack_require__(1);
-module.exports = function () {
-  var that = anObject(this);
-  var result = '';
-  if (that.global) result += 'g';
-  if (that.ignoreCase) result += 'i';
-  if (that.multiline) result += 'm';
-  if (that.unicode) result += 'u';
-  if (that.sticky) result += 'y';
-  return result;
-};
-
-/***/ }),
-/* 55 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// 7.3.20 SpeciesConstructor(O, defaultConstructor)
-var anObject = __webpack_require__(1);
-var aFunction = __webpack_require__(13);
-var SPECIES = __webpack_require__(6)('species');
-module.exports = function (O, D) {
-  var C = anObject(O).constructor;
-  var S;
-  return C === undefined || (S = anObject(C)[SPECIES]) == undefined ? D : aFunction(S);
-};
-
-/***/ }),
-/* 56 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -1993,7 +1942,7 @@ var MDCTopAppBarAdapter = function () {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCTopAppBarAdapter);
 
 /***/ }),
-/* 57 */
+/* 54 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -2050,11 +1999,11 @@ var strings = {
 
 
 /***/ }),
-/* 58 */
+/* 55 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(160);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(155);
 
 
 /* harmony default export */ __webpack_exports__["a"] = (new __WEBPACK_IMPORTED_MODULE_0__utils_config__["a" /* default */]({
@@ -2082,13 +2031,30 @@ var strings = {
 }));
 
 /***/ }),
-/* 59 */
+/* 56 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var core = __webpack_require__(21);
+var global = __webpack_require__(3);
+var SHARED = '__core-js_shared__';
+var store = global[SHARED] || (global[SHARED] = {});
+
+(module.exports = function (key, value) {
+  return store[key] || (store[key] = value !== undefined ? value : {});
+})('versions', []).push({
+  version: core.version,
+  mode: __webpack_require__(33) ? 'pure' : 'global',
+  copyright: '© 2018 Denis Pushkarev (zloirock.ru)'
+});
+
+/***/ }),
+/* 57 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // false -> Array#indexOf
 // true  -> Array#includes
 var toIObject = __webpack_require__(18);
-var toLength = __webpack_require__(7);
+var toLength = __webpack_require__(9);
 var toAbsoluteIndex = __webpack_require__(38);
 module.exports = function (IS_INCLUDES) {
   return function ($this, el, fromIndex) {
@@ -2112,13 +2078,13 @@ module.exports = function (IS_INCLUDES) {
 };
 
 /***/ }),
-/* 60 */
+/* 58 */
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 /***/ }),
-/* 61 */
+/* 59 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.2.2 IsArray(argument)
@@ -2128,27 +2094,7 @@ module.exports = Array.isArray || function isArray(arg) {
 };
 
 /***/ }),
-/* 62 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var toInteger = __webpack_require__(24);
-var defined = __webpack_require__(27);
-// true  -> String#at
-// false -> String#codePointAt
-module.exports = function (TO_STRING) {
-  return function (that, pos) {
-    var s = String(defined(that));
-    var i = toInteger(pos);
-    var l = s.length;
-    var a, b;
-    if (i < 0 || i >= l) return TO_STRING ? '' : undefined;
-    a = s.charCodeAt(i);
-    return a < 0xd800 || a > 0xdbff || i + 1 === l || (b = s.charCodeAt(i + 1)) < 0xdc00 || b > 0xdfff ? TO_STRING ? s.charAt(i) : a : TO_STRING ? s.slice(i, i + 2) : (a - 0xd800 << 10) + (b - 0xdc00) + 0x10000;
-  };
-};
-
-/***/ }),
-/* 63 */
+/* 60 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.2.8 IsRegExp(argument)
@@ -2161,7 +2107,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 64 */
+/* 61 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var ITERATOR = __webpack_require__(6)('iterator');
@@ -2196,123 +2142,50 @@ module.exports = function (exec, skipClosing) {
 };
 
 /***/ }),
-/* 65 */
+/* 62 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
+// 21.2.5.3 get RegExp.prototype.flags
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
-var classof = __webpack_require__(48);
-var builtinExec = RegExp.prototype.exec;
-
-// `RegExpExec` abstract operation
-// https://tc39.github.io/ecma262/#sec-regexpexec
-module.exports = function (R, S) {
-  var exec = R.exec;
-  if (typeof exec === 'function') {
-    var result = exec.call(R, S);
-    if ((typeof result === 'undefined' ? 'undefined' : _typeof(result)) !== 'object') {
-      throw new TypeError('RegExp exec method returned something other than an Object or null');
-    }
-    return result;
-  }
-  if (classof(R) !== 'RegExp') {
-    throw new TypeError('RegExp#exec called on incompatible receiver');
-  }
-  return builtinExec.call(R, S);
+var anObject = __webpack_require__(1);
+module.exports = function () {
+  var that = anObject(this);
+  var result = '';
+  if (that.global) result += 'g';
+  if (that.ignoreCase) result += 'i';
+  if (that.multiline) result += 'm';
+  if (that.unicode) result += 'u';
+  if (that.sticky) result += 'y';
+  return result;
 };
 
 /***/ }),
-/* 66 */
+/* 63 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-__webpack_require__(127);
-var redefine = __webpack_require__(15);
 var hide = __webpack_require__(14);
+var redefine = __webpack_require__(15);
 var fails = __webpack_require__(4);
-var defined = __webpack_require__(27);
+var defined = __webpack_require__(26);
 var wks = __webpack_require__(6);
-var regexpExec = __webpack_require__(99);
-
-var SPECIES = wks('species');
-
-var REPLACE_SUPPORTS_NAMED_GROUPS = !fails(function () {
-  // #replace needs built-in support for named groups.
-  // #match works fine because it just return the exec results, even if it has
-  // a "grops" property.
-  var re = /./;
-  re.exec = function () {
-    var result = [];
-    result.groups = { a: '7' };
-    return result;
-  };
-  return ''.replace(re, '$<a>') !== '7';
-});
-
-var SPLIT_WORKS_WITH_OVERWRITTEN_EXEC = function () {
-  // Chrome 51 has a buggy "split" implementation when RegExp#exec !== nativeExec
-  var re = /(?:)/;
-  var originalExec = re.exec;
-  re.exec = function () {
-    return originalExec.apply(this, arguments);
-  };
-  var result = 'ab'.split(re);
-  return result.length === 2 && result[0] === 'a' && result[1] === 'b';
-}();
 
 module.exports = function (KEY, length, exec) {
   var SYMBOL = wks(KEY);
-
-  var DELEGATES_TO_SYMBOL = !fails(function () {
-    // String methods call symbol-named RegEp methods
+  var fns = exec(defined, SYMBOL, ''[KEY]);
+  var strfn = fns[0];
+  var rxfn = fns[1];
+  if (fails(function () {
     var O = {};
     O[SYMBOL] = function () {
       return 7;
     };
     return ''[KEY](O) != 7;
-  });
-
-  var DELEGATES_TO_EXEC = DELEGATES_TO_SYMBOL ? !fails(function () {
-    // Symbol-named RegExp methods call .exec
-    var execCalled = false;
-    var re = /a/;
-    re.exec = function () {
-      execCalled = true;return null;
-    };
-    if (KEY === 'split') {
-      // RegExp[@@split] doesn't call the regex's exec method, but first creates
-      // a new one. We need to return the patched regex when creating the new one.
-      re.constructor = {};
-      re.constructor[SPECIES] = function () {
-        return re;
-      };
-    }
-    re[SYMBOL]('');
-    return !execCalled;
-  }) : undefined;
-
-  if (!DELEGATES_TO_SYMBOL || !DELEGATES_TO_EXEC || KEY === 'replace' && !REPLACE_SUPPORTS_NAMED_GROUPS || KEY === 'split' && !SPLIT_WORKS_WITH_OVERWRITTEN_EXEC) {
-    var nativeRegExpMethod = /./[SYMBOL];
-    var fns = exec(defined, SYMBOL, ''[KEY], function maybeCallNative(nativeMethod, regexp, str, arg2, forceStringMethod) {
-      if (regexp.exec === regexpExec) {
-        if (DELEGATES_TO_SYMBOL && !forceStringMethod) {
-          // The native String method already delegates to @@method (this
-          // polyfilled function), leasing to infinite recursion.
-          // We avoid it by directly calling the native @@method method.
-          return { done: true, value: nativeRegExpMethod.call(regexp, str, arg2) };
-        }
-        return { done: true, value: nativeMethod.call(str, regexp, arg2) };
-      }
-      return { done: false };
-    });
-    var strfn = fns[0];
-    var rxfn = fns[1];
-
+  })) {
     redefine(String.prototype, KEY, strfn);
     hide(RegExp.prototype, SYMBOL, length == 2
     // 21.2.5.8 RegExp.prototype[@@replace](string, replaceValue)
@@ -2329,33 +2202,47 @@ module.exports = function (KEY, length, exec) {
 };
 
 /***/ }),
-/* 67 */
+/* 64 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var global = __webpack_require__(2);
+// 7.3.20 SpeciesConstructor(O, defaultConstructor)
+var anObject = __webpack_require__(1);
+var aFunction = __webpack_require__(13);
+var SPECIES = __webpack_require__(6)('species');
+module.exports = function (O, D) {
+  var C = anObject(O).constructor;
+  var S;
+  return C === undefined || (S = anObject(C)[SPECIES]) == undefined ? D : aFunction(S);
+};
+
+/***/ }),
+/* 65 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var global = __webpack_require__(3);
 var navigator = global.navigator;
 
 module.exports = navigator && navigator.userAgent || '';
 
 /***/ }),
-/* 68 */
+/* 66 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var $export = __webpack_require__(0);
 var redefine = __webpack_require__(15);
 var redefineAll = __webpack_require__(44);
-var meta = __webpack_require__(33);
+var meta = __webpack_require__(32);
 var forOf = __webpack_require__(43);
 var anInstance = __webpack_require__(42);
 var isObject = __webpack_require__(5);
 var fails = __webpack_require__(4);
-var $iterDetect = __webpack_require__(64);
-var setToStringTag = __webpack_require__(47);
-var inheritIfRequired = __webpack_require__(85);
+var $iterDetect = __webpack_require__(61);
+var setToStringTag = __webpack_require__(46);
+var inheritIfRequired = __webpack_require__(83);
 
 module.exports = function (NAME, wrapper, methods, common, IS_MAP, IS_WEAK) {
   var Base = global[NAME];
@@ -2436,10 +2323,10 @@ module.exports = function (NAME, wrapper, methods, common, IS_MAP, IS_WEAK) {
 };
 
 /***/ }),
-/* 69 */
+/* 67 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var hide = __webpack_require__(14);
 var uid = __webpack_require__(36);
 var TYPED = uid('typed_array');
@@ -2467,23 +2354,23 @@ module.exports = {
 };
 
 /***/ }),
-/* 70 */
+/* 68 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 // Forced replacement prototype accessors methods
 
-module.exports = __webpack_require__(32) || !__webpack_require__(4)(function () {
+module.exports = __webpack_require__(33) || !__webpack_require__(4)(function () {
   var K = Math.random();
   // In FF throws only define methods
   // eslint-disable-next-line no-undef, no-useless-call
   __defineSetter__.call(null, K, function () {/* empty */});
-  delete __webpack_require__(2)[K];
+  delete __webpack_require__(3)[K];
 });
 
 /***/ }),
-/* 71 */
+/* 69 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2503,7 +2390,7 @@ module.exports = function (COLLECTION) {
 };
 
 /***/ }),
-/* 72 */
+/* 70 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2538,7 +2425,7 @@ module.exports = function (COLLECTION) {
 };
 
 /***/ }),
-/* 73 */
+/* 71 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -2597,13 +2484,13 @@ function expandParams(results, o) {
 }
 
 /***/ }),
-/* 74 */
+/* 72 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__errors__ = __webpack_require__(105);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__utils_urls__ = __webpack_require__(148);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__errors__ = __webpack_require__(102);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__utils_urls__ = __webpack_require__(143);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -2665,8 +2552,7 @@ var VBase = function (_VUrls) {
         }
 
         /**
-         * inputs retrieves relevant input elements for this event. The resulting
-         * array of elements is guaranteed to be unique.
+         * inputs retrieves relevant input elements for this event.
          *
          * - If an `input_tag` has been provided, all matching tagged elements are
          *   included.
@@ -2724,15 +2610,7 @@ var VBase = function (_VUrls) {
             });
 
             // Deduplicate:
-            var uniques = Array.from(new Set(elements));
-
-            if (uniques.length > 0) {
-                console.table(uniques.map(function (e) {
-                    return e.id;
-                }));
-            }
-
-            return uniques;
+            return Array.from(new Set(elements));
         }
 
         /**
@@ -2816,13 +2694,13 @@ var VBase = function (_VUrls) {
 }(__WEBPACK_IMPORTED_MODULE_1__utils_urls__["a" /* VUrls */]);
 
 /***/ }),
-/* 75 */
+/* 73 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(57);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(56);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(107);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(54);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(53);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(104);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -2970,13 +2848,13 @@ var MDCTopAppBarBaseFoundation = function (_MDCFoundation) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCTopAppBarBaseFoundation);
 
 /***/ }),
-/* 76 */
+/* 74 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseToggle; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -3043,7 +2921,7 @@ var VBaseToggle = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 77 */
+/* 75 */
 /***/ (function(module, exports) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -3070,11 +2948,11 @@ try {
 module.exports = g;
 
 /***/ }),
-/* 78 */
+/* 76 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(5);
-var document = __webpack_require__(2).document;
+var document = __webpack_require__(3).document;
 // typeof document.createElement is 'object' in old IE
 var is = isObject(document) && isObject(document.createElement);
 module.exports = function (it) {
@@ -3082,45 +2960,45 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 79 */
+/* 77 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var core = __webpack_require__(21);
-var LIBRARY = __webpack_require__(32);
-var wksExt = __webpack_require__(109);
-var defineProperty = __webpack_require__(9).f;
+var LIBRARY = __webpack_require__(33);
+var wksExt = __webpack_require__(106);
+var defineProperty = __webpack_require__(8).f;
 module.exports = function (name) {
   var $Symbol = core.Symbol || (core.Symbol = LIBRARY ? {} : global.Symbol || {});
   if (name.charAt(0) != '_' && !(name in $Symbol)) defineProperty($Symbol, name, { value: wksExt.f(name) });
 };
 
 /***/ }),
-/* 80 */
+/* 78 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var shared = __webpack_require__(51)('keys');
+var shared = __webpack_require__(56)('keys');
 var uid = __webpack_require__(36);
 module.exports = function (key) {
   return shared[key] || (shared[key] = uid(key));
 };
 
 /***/ }),
-/* 81 */
+/* 79 */
 /***/ (function(module, exports) {
 
 // IE 8- don't enum bug keys
 module.exports = 'constructor,hasOwnProperty,isPrototypeOf,propertyIsEnumerable,toLocaleString,toString,valueOf'.split(',');
 
 /***/ }),
-/* 82 */
+/* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var document = __webpack_require__(2).document;
+var document = __webpack_require__(3).document;
 module.exports = document && document.documentElement;
 
 /***/ }),
-/* 83 */
+/* 81 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // Works with __proto__ only. Old v8 can't work with null proto objects.
@@ -3151,17 +3029,17 @@ module.exports = {
 };
 
 /***/ }),
-/* 84 */
+/* 82 */
 /***/ (function(module, exports) {
 
 module.exports = '\t\n\x0B\f\r \xA0\u1680\u180E\u2000\u2001\u2002\u2003' + '\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF';
 
 /***/ }),
-/* 85 */
+/* 83 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(5);
-var setPrototypeOf = __webpack_require__(83).set;
+var setPrototypeOf = __webpack_require__(81).set;
 module.exports = function (that, target, C) {
   var S = target.constructor;
   var P;
@@ -3171,14 +3049,14 @@ module.exports = function (that, target, C) {
 };
 
 /***/ }),
-/* 86 */
+/* 84 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var toInteger = __webpack_require__(24);
-var defined = __webpack_require__(27);
+var toInteger = __webpack_require__(27);
+var defined = __webpack_require__(26);
 
 module.exports = function repeat(count) {
   var str = String(defined(this));
@@ -3191,7 +3069,7 @@ module.exports = function repeat(count) {
 };
 
 /***/ }),
-/* 87 */
+/* 85 */
 /***/ (function(module, exports) {
 
 // 20.2.2.28 Math.sign(x)
@@ -3201,7 +3079,7 @@ module.exports = Math.sign || function sign(x) {
 };
 
 /***/ }),
-/* 88 */
+/* 86 */
 /***/ (function(module, exports) {
 
 // 20.2.2.14 Math.expm1(x)
@@ -3215,19 +3093,39 @@ module.exports = !$expm1
 } : $expm1;
 
 /***/ }),
-/* 89 */
+/* 87 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var toInteger = __webpack_require__(27);
+var defined = __webpack_require__(26);
+// true  -> String#at
+// false -> String#codePointAt
+module.exports = function (TO_STRING) {
+  return function (that, pos) {
+    var s = String(defined(that));
+    var i = toInteger(pos);
+    var l = s.length;
+    var a, b;
+    if (i < 0 || i >= l) return TO_STRING ? '' : undefined;
+    a = s.charCodeAt(i);
+    return a < 0xd800 || a > 0xdbff || i + 1 === l || (b = s.charCodeAt(i + 1)) < 0xdc00 || b > 0xdfff ? TO_STRING ? s.charAt(i) : a : TO_STRING ? s.slice(i, i + 2) : (a - 0xd800 << 10) + (b - 0xdc00) + 0x10000;
+  };
+};
+
+/***/ }),
+/* 88 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var LIBRARY = __webpack_require__(32);
+var LIBRARY = __webpack_require__(33);
 var $export = __webpack_require__(0);
 var redefine = __webpack_require__(15);
 var hide = __webpack_require__(14);
-var Iterators = __webpack_require__(50);
-var $iterCreate = __webpack_require__(90);
-var setToStringTag = __webpack_require__(47);
+var Iterators = __webpack_require__(48);
+var $iterCreate = __webpack_require__(89);
+var setToStringTag = __webpack_require__(46);
 var getPrototypeOf = __webpack_require__(20);
 var ITERATOR = __webpack_require__(6)('iterator');
 var BUGGY = !([].keys && 'next' in [].keys()); // Safari has buggy iterators w/o `next`
@@ -3303,7 +3201,7 @@ module.exports = function (Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCE
 };
 
 /***/ }),
-/* 90 */
+/* 89 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -3311,7 +3209,7 @@ module.exports = function (Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCE
 
 var create = __webpack_require__(39);
 var descriptor = __webpack_require__(35);
-var setToStringTag = __webpack_require__(47);
+var setToStringTag = __webpack_require__(46);
 var IteratorPrototype = {};
 
 // 25.1.2.1.1 %IteratorPrototype%[@@iterator]()
@@ -3325,12 +3223,12 @@ module.exports = function (Constructor, NAME, next) {
 };
 
 /***/ }),
-/* 91 */
+/* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // helper for String#{startsWith, endsWith, includes}
-var isRegExp = __webpack_require__(63);
-var defined = __webpack_require__(27);
+var isRegExp = __webpack_require__(60);
+var defined = __webpack_require__(26);
 
 module.exports = function (that, searchString, NAME) {
   if (isRegExp(searchString)) throw TypeError('String#' + NAME + " doesn't accept regex!");
@@ -3338,7 +3236,7 @@ module.exports = function (that, searchString, NAME) {
 };
 
 /***/ }),
-/* 92 */
+/* 91 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var MATCH = __webpack_require__(6)('match');
@@ -3355,11 +3253,11 @@ module.exports = function (KEY) {
 };
 
 /***/ }),
-/* 93 */
+/* 92 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // check on default Array iterator
-var Iterators = __webpack_require__(50);
+var Iterators = __webpack_require__(48);
 var ITERATOR = __webpack_require__(6)('iterator');
 var ArrayProto = Array.prototype;
 
@@ -3368,13 +3266,13 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 94 */
+/* 93 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var $defineProperty = __webpack_require__(9);
+var $defineProperty = __webpack_require__(8);
 var createDesc = __webpack_require__(35);
 
 module.exports = function (object, index, value) {
@@ -3382,38 +3280,38 @@ module.exports = function (object, index, value) {
 };
 
 /***/ }),
-/* 95 */
+/* 94 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var classof = __webpack_require__(48);
+var classof = __webpack_require__(52);
 var ITERATOR = __webpack_require__(6)('iterator');
-var Iterators = __webpack_require__(50);
+var Iterators = __webpack_require__(48);
 module.exports = __webpack_require__(21).getIteratorMethod = function (it) {
   if (it != undefined) return it[ITERATOR] || it['@@iterator'] || Iterators[classof(it)];
 };
 
 /***/ }),
-/* 96 */
+/* 95 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 9.4.2.3 ArraySpeciesCreate(originalArray, length)
-var speciesConstructor = __webpack_require__(255);
+var speciesConstructor = __webpack_require__(250);
 
 module.exports = function (original, length) {
   return new (speciesConstructor(original))(length);
 };
 
 /***/ }),
-/* 97 */
+/* 96 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 // 22.1.3.6 Array.prototype.fill(value, start = 0, end = this.length)
 
 
-var toObject = __webpack_require__(10);
+var toObject = __webpack_require__(11);
 var toAbsoluteIndex = __webpack_require__(38);
-var toLength = __webpack_require__(7);
+var toLength = __webpack_require__(9);
 module.exports = function fill(value /* , start = 0, end = @length */) {
   var O = toObject(this);
   var length = toLength(O.length);
@@ -3427,22 +3325,22 @@ module.exports = function fill(value /* , start = 0, end = @length */) {
 };
 
 /***/ }),
-/* 98 */
+/* 97 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var addToUnscopables = __webpack_require__(34);
-var step = __webpack_require__(126);
-var Iterators = __webpack_require__(50);
+var step = __webpack_require__(122);
+var Iterators = __webpack_require__(48);
 var toIObject = __webpack_require__(18);
 
 // 22.1.3.4 Array.prototype.entries()
 // 22.1.3.13 Array.prototype.keys()
 // 22.1.3.29 Array.prototype.values()
 // 22.1.3.30 Array.prototype[@@iterator]()
-module.exports = __webpack_require__(89)(Array, 'Array', function (iterated, kind) {
+module.exports = __webpack_require__(88)(Array, 'Array', function (iterated, kind) {
   this._t = toIObject(iterated); // target
   this._i = 0; // next index
   this._k = kind; // kind
@@ -3468,93 +3366,14 @@ addToUnscopables('values');
 addToUnscopables('entries');
 
 /***/ }),
-/* 99 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var regexpFlags = __webpack_require__(54);
-
-var nativeExec = RegExp.prototype.exec;
-// This always refers to the native implementation, because the
-// String#replace polyfill uses ./fix-regexp-well-known-symbol-logic.js,
-// which loads this file before patching the method.
-var nativeReplace = String.prototype.replace;
-
-var patchedExec = nativeExec;
-
-var LAST_INDEX = 'lastIndex';
-
-var UPDATES_LAST_INDEX_WRONG = function () {
-  var re1 = /a/,
-      re2 = /b*/g;
-  nativeExec.call(re1, 'a');
-  nativeExec.call(re2, 'a');
-  return re1[LAST_INDEX] !== 0 || re2[LAST_INDEX] !== 0;
-}();
-
-// nonparticipating capturing group, copied from es5-shim's String#split patch.
-var NPCG_INCLUDED = /()??/.exec('')[1] !== undefined;
-
-var PATCH = UPDATES_LAST_INDEX_WRONG || NPCG_INCLUDED;
-
-if (PATCH) {
-  patchedExec = function exec(str) {
-    var re = this;
-    var lastIndex, reCopy, match, i;
-
-    if (NPCG_INCLUDED) {
-      reCopy = new RegExp('^' + re.source + '$(?!\\s)', regexpFlags.call(re));
-    }
-    if (UPDATES_LAST_INDEX_WRONG) lastIndex = re[LAST_INDEX];
-
-    match = nativeExec.call(re, str);
-
-    if (UPDATES_LAST_INDEX_WRONG && match) {
-      re[LAST_INDEX] = re.global ? match.index + match[0].length : lastIndex;
-    }
-    if (NPCG_INCLUDED && match && match.length > 1) {
-      // Fix browsers whose `exec` methods don't consistently return `undefined`
-      // for NPCG, like IE8. NOTE: This doesn' work for /(.?)?/
-      // eslint-disable-next-line no-loop-func
-      nativeReplace.call(match[0], reCopy, function () {
-        for (i = 1; i < arguments.length - 2; i++) {
-          if (arguments[i] === undefined) match[i] = undefined;
-        }
-      });
-    }
-
-    return match;
-  };
-}
-
-module.exports = patchedExec;
-
-/***/ }),
-/* 100 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var at = __webpack_require__(62)(true);
-
-// `AdvanceStringIndex` abstract operation
-// https://tc39.github.io/ecma262/#sec-advancestringindex
-module.exports = function (S, index, unicode) {
-  return index + (unicode ? at(S, index).length : 1);
-};
-
-/***/ }),
-/* 101 */
+/* 98 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var ctx = __webpack_require__(22);
-var invoke = __webpack_require__(116);
-var html = __webpack_require__(82);
-var cel = __webpack_require__(78);
-var global = __webpack_require__(2);
+var invoke = __webpack_require__(112);
+var html = __webpack_require__(80);
+var cel = __webpack_require__(76);
+var global = __webpack_require__(3);
 var process = global.process;
 var setTask = global.setImmediate;
 var clearTask = global.clearImmediate;
@@ -3637,11 +3456,11 @@ module.exports = {
 };
 
 /***/ }),
-/* 102 */
+/* 99 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var global = __webpack_require__(2);
-var macrotask = __webpack_require__(101).set;
+var global = __webpack_require__(3);
+var macrotask = __webpack_require__(98).set;
 var Observer = global.MutationObserver || global.WebKitMutationObserver;
 var process = global.process;
 var Promise = global.Promise;
@@ -3710,7 +3529,7 @@ module.exports = function () {
 };
 
 /***/ }),
-/* 103 */
+/* 100 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -3735,27 +3554,27 @@ module.exports.f = function (C) {
 };
 
 /***/ }),
-/* 104 */
+/* 101 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var global = __webpack_require__(2);
-var DESCRIPTORS = __webpack_require__(8);
-var LIBRARY = __webpack_require__(32);
-var $typed = __webpack_require__(69);
+var global = __webpack_require__(3);
+var DESCRIPTORS = __webpack_require__(7);
+var LIBRARY = __webpack_require__(33);
+var $typed = __webpack_require__(67);
 var hide = __webpack_require__(14);
 var redefineAll = __webpack_require__(44);
 var fails = __webpack_require__(4);
 var anInstance = __webpack_require__(42);
-var toInteger = __webpack_require__(24);
-var toLength = __webpack_require__(7);
-var toIndex = __webpack_require__(136);
+var toInteger = __webpack_require__(27);
+var toLength = __webpack_require__(9);
+var toIndex = __webpack_require__(131);
 var gOPN = __webpack_require__(40).f;
-var dP = __webpack_require__(9).f;
-var arrayFill = __webpack_require__(97);
-var setToStringTag = __webpack_require__(47);
+var dP = __webpack_require__(8).f;
+var arrayFill = __webpack_require__(96);
+var setToStringTag = __webpack_require__(46);
 var ARRAY_BUFFER = 'ArrayBuffer';
 var DATA_VIEW = 'DataView';
 var PROTOTYPE = 'prototype';
@@ -4022,7 +3841,7 @@ exports[ARRAY_BUFFER] = $ArrayBuffer;
 exports[DATA_VIEW] = $DataView;
 
 /***/ }),
-/* 105 */
+/* 102 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4240,7 +4059,7 @@ var VErrors = function () {
 }();
 
 /***/ }),
-/* 106 */
+/* 103 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4302,7 +4121,7 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 };
 
 /***/ }),
-/* 107 */
+/* 104 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4411,29 +4230,29 @@ var MDCFoundation = function () {
 /* harmony default export */ __webpack_exports__["a"] = (MDCFoundation);
 
 /***/ }),
-/* 108 */
+/* 105 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = !__webpack_require__(8) && !__webpack_require__(4)(function () {
-  return Object.defineProperty(__webpack_require__(78)('div'), 'a', { get: function get() {
+module.exports = !__webpack_require__(7) && !__webpack_require__(4)(function () {
+  return Object.defineProperty(__webpack_require__(76)('div'), 'a', { get: function get() {
       return 7;
     } }).a != 7;
 });
 
 /***/ }),
-/* 109 */
+/* 106 */
 /***/ (function(module, exports, __webpack_require__) {
 
 exports.f = __webpack_require__(6);
 
 /***/ }),
-/* 110 */
+/* 107 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var has = __webpack_require__(17);
 var toIObject = __webpack_require__(18);
-var arrayIndexOf = __webpack_require__(59)(false);
-var IE_PROTO = __webpack_require__(80)('IE_PROTO');
+var arrayIndexOf = __webpack_require__(57)(false);
+var IE_PROTO = __webpack_require__(78)('IE_PROTO');
 
 module.exports = function (object, names) {
   var O = toIObject(object);
@@ -4451,14 +4270,14 @@ module.exports = function (object, names) {
 };
 
 /***/ }),
-/* 111 */
+/* 108 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var dP = __webpack_require__(9);
+var dP = __webpack_require__(8);
 var anObject = __webpack_require__(1);
 var getKeys = __webpack_require__(37);
 
-module.exports = __webpack_require__(8) ? Object.defineProperties : function defineProperties(O, Properties) {
+module.exports = __webpack_require__(7) ? Object.defineProperties : function defineProperties(O, Properties) {
   anObject(O);
   var keys = getKeys(Properties);
   var length = keys.length;
@@ -4470,7 +4289,7 @@ module.exports = __webpack_require__(8) ? Object.defineProperties : function def
 };
 
 /***/ }),
-/* 112 */
+/* 109 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -4495,7 +4314,7 @@ module.exports.f = function getOwnPropertyNames(it) {
 };
 
 /***/ }),
-/* 113 */
+/* 110 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -4503,10 +4322,10 @@ module.exports.f = function getOwnPropertyNames(it) {
 // 19.1.2.1 Object.assign(target, source, ...)
 
 var getKeys = __webpack_require__(37);
-var gOPS = __webpack_require__(60);
-var pIE = __webpack_require__(53);
-var toObject = __webpack_require__(10);
-var IObject = __webpack_require__(52);
+var gOPS = __webpack_require__(58);
+var pIE = __webpack_require__(51);
+var toObject = __webpack_require__(11);
+var IObject = __webpack_require__(50);
 var $assign = Object.assign;
 
 // should work with symbols and should have deterministic property order (V8 bug)
@@ -4541,17 +4360,7 @@ module.exports = !$assign || __webpack_require__(4)(function () {
 } : $assign;
 
 /***/ }),
-/* 114 */
-/***/ (function(module, exports) {
-
-// 7.2.9 SameValue(x, y)
-module.exports = Object.is || function is(x, y) {
-  // eslint-disable-next-line no-self-compare
-  return x === y ? x !== 0 || 1 / x === 1 / y : x != x && y != y;
-};
-
-/***/ }),
-/* 115 */
+/* 111 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -4559,7 +4368,7 @@ module.exports = Object.is || function is(x, y) {
 
 var aFunction = __webpack_require__(13);
 var isObject = __webpack_require__(5);
-var invoke = __webpack_require__(116);
+var invoke = __webpack_require__(112);
 var arraySlice = [].slice;
 var factories = {};
 
@@ -4584,7 +4393,7 @@ module.exports = Function.bind || function bind(that /* , ...args */) {
 };
 
 /***/ }),
-/* 116 */
+/* 112 */
 /***/ (function(module, exports) {
 
 // fast apply, http://jsperf.lnkit.com/fast-apply/5
@@ -4605,12 +4414,12 @@ module.exports = function (fn, args, that) {
 };
 
 /***/ }),
-/* 117 */
+/* 113 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var $parseInt = __webpack_require__(2).parseInt;
-var $trim = __webpack_require__(49).trim;
-var ws = __webpack_require__(84);
+var $parseInt = __webpack_require__(3).parseInt;
+var $trim = __webpack_require__(47).trim;
+var ws = __webpack_require__(82);
 var hex = /^[-+]?0[xX]/;
 
 module.exports = $parseInt(ws + '08') !== 8 || $parseInt(ws + '0x16') !== 22 ? function parseInt(str, radix) {
@@ -4619,20 +4428,20 @@ module.exports = $parseInt(ws + '08') !== 8 || $parseInt(ws + '0x16') !== 22 ? f
 } : $parseInt;
 
 /***/ }),
-/* 118 */
+/* 114 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var $parseFloat = __webpack_require__(2).parseFloat;
-var $trim = __webpack_require__(49).trim;
+var $parseFloat = __webpack_require__(3).parseFloat;
+var $trim = __webpack_require__(47).trim;
 
-module.exports = 1 / $parseFloat(__webpack_require__(84) + '-0') !== -Infinity ? function parseFloat(str) {
+module.exports = 1 / $parseFloat(__webpack_require__(82) + '-0') !== -Infinity ? function parseFloat(str) {
   var string = $trim(String(str), 3);
   var result = $parseFloat(string);
   return result === 0 && string.charAt(0) == '-' ? -0 : result;
 } : $parseFloat;
 
 /***/ }),
-/* 119 */
+/* 115 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var cof = __webpack_require__(23);
@@ -4642,7 +4451,7 @@ module.exports = function (it, msg) {
 };
 
 /***/ }),
-/* 120 */
+/* 116 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.3 Number.isInteger(number)
@@ -4653,7 +4462,7 @@ module.exports = function isInteger(it) {
 };
 
 /***/ }),
-/* 121 */
+/* 117 */
 /***/ (function(module, exports) {
 
 // 20.2.2.20 Math.log1p(x)
@@ -4662,11 +4471,11 @@ module.exports = Math.log1p || function log1p(x) {
 };
 
 /***/ }),
-/* 122 */
+/* 118 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.16 Math.fround(x)
-var sign = __webpack_require__(87);
+var sign = __webpack_require__(85);
 var pow = Math.pow;
 var EPSILON = pow(2, -52);
 var EPSILON32 = pow(2, -23);
@@ -4690,7 +4499,7 @@ module.exports = Math.fround || function fround(x) {
 };
 
 /***/ }),
-/* 123 */
+/* 119 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // call something on iterator step with safe closing on error
@@ -4707,13 +4516,13 @@ module.exports = function (iterator, fn, value, entries) {
 };
 
 /***/ }),
-/* 124 */
+/* 120 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var aFunction = __webpack_require__(13);
-var toObject = __webpack_require__(10);
-var IObject = __webpack_require__(52);
-var toLength = __webpack_require__(7);
+var toObject = __webpack_require__(11);
+var IObject = __webpack_require__(50);
+var toLength = __webpack_require__(9);
 
 module.exports = function (that, callbackfn, aLen, memo, isRight) {
   aFunction(callbackfn);
@@ -4741,16 +4550,16 @@ module.exports = function (that, callbackfn, aLen, memo, isRight) {
 };
 
 /***/ }),
-/* 125 */
+/* 121 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 // 22.1.3.3 Array.prototype.copyWithin(target, start, end = this.length)
 
 
-var toObject = __webpack_require__(10);
+var toObject = __webpack_require__(11);
 var toAbsoluteIndex = __webpack_require__(38);
-var toLength = __webpack_require__(7);
+var toLength = __webpack_require__(9);
 
 module.exports = [].copyWithin || function copyWithin(target /* = 0 */, start /* = 0, end = @length */) {
   var O = toObject(this);
@@ -4773,7 +4582,7 @@ module.exports = [].copyWithin || function copyWithin(target /* = 0 */, start /*
 };
 
 /***/ }),
-/* 126 */
+/* 122 */
 /***/ (function(module, exports) {
 
 module.exports = function (done, value) {
@@ -4781,33 +4590,17 @@ module.exports = function (done, value) {
 };
 
 /***/ }),
-/* 127 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var regexpExec = __webpack_require__(99);
-__webpack_require__(0)({
-  target: 'RegExp',
-  proto: true,
-  forced: regexpExec !== /./.exec
-}, {
-  exec: regexpExec
-});
-
-/***/ }),
-/* 128 */
+/* 123 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 21.2.5.3 get RegExp.prototype.flags()
-if (__webpack_require__(8) && /./g.flags != 'g') __webpack_require__(9).f(RegExp.prototype, 'flags', {
+if (__webpack_require__(7) && /./g.flags != 'g') __webpack_require__(8).f(RegExp.prototype, 'flags', {
   configurable: true,
-  get: __webpack_require__(54)
+  get: __webpack_require__(62)
 });
 
 /***/ }),
-/* 129 */
+/* 124 */
 /***/ (function(module, exports) {
 
 module.exports = function (exec) {
@@ -4819,12 +4612,12 @@ module.exports = function (exec) {
 };
 
 /***/ }),
-/* 130 */
+/* 125 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
-var newPromiseCapability = __webpack_require__(103);
+var newPromiseCapability = __webpack_require__(100);
 
 module.exports = function (C, x) {
   anObject(C);
@@ -4836,18 +4629,18 @@ module.exports = function (C, x) {
 };
 
 /***/ }),
-/* 131 */
+/* 126 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var strong = __webpack_require__(132);
-var validate = __webpack_require__(45);
+var strong = __webpack_require__(127);
+var validate = __webpack_require__(49);
 var MAP = 'Map';
 
 // 23.1 Map Objects
-module.exports = __webpack_require__(68)(MAP, function (get) {
+module.exports = __webpack_require__(66)(MAP, function (get) {
   return function Map() {
     return get(this, arguments.length > 0 ? arguments[0] : undefined);
   };
@@ -4864,24 +4657,24 @@ module.exports = __webpack_require__(68)(MAP, function (get) {
 }, strong, true);
 
 /***/ }),
-/* 132 */
+/* 127 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var dP = __webpack_require__(9).f;
+var dP = __webpack_require__(8).f;
 var create = __webpack_require__(39);
 var redefineAll = __webpack_require__(44);
 var ctx = __webpack_require__(22);
 var anInstance = __webpack_require__(42);
 var forOf = __webpack_require__(43);
-var $iterDefine = __webpack_require__(89);
-var step = __webpack_require__(126);
+var $iterDefine = __webpack_require__(88);
+var step = __webpack_require__(122);
 var setSpecies = __webpack_require__(41);
-var DESCRIPTORS = __webpack_require__(8);
-var fastKey = __webpack_require__(33).fastKey;
-var validate = __webpack_require__(45);
+var DESCRIPTORS = __webpack_require__(7);
+var fastKey = __webpack_require__(32).fastKey;
+var validate = __webpack_require__(49);
 var SIZE = DESCRIPTORS ? '_s' : 'size';
 
 var getEntry = function getEntry(that, key) {
@@ -5018,18 +4811,18 @@ module.exports = {
 };
 
 /***/ }),
-/* 133 */
+/* 128 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var strong = __webpack_require__(132);
-var validate = __webpack_require__(45);
+var strong = __webpack_require__(127);
+var validate = __webpack_require__(49);
 var SET = 'Set';
 
 // 23.2 Set Objects
-module.exports = __webpack_require__(68)(SET, function (get) {
+module.exports = __webpack_require__(66)(SET, function (get) {
   return function Set() {
     return get(this, arguments.length > 0 ? arguments[0] : undefined);
   };
@@ -5041,26 +4834,25 @@ module.exports = __webpack_require__(68)(SET, function (get) {
 }, strong);
 
 /***/ }),
-/* 134 */
+/* 129 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var global = __webpack_require__(2);
 var each = __webpack_require__(29)(0);
 var redefine = __webpack_require__(15);
-var meta = __webpack_require__(33);
-var assign = __webpack_require__(113);
-var weak = __webpack_require__(135);
+var meta = __webpack_require__(32);
+var assign = __webpack_require__(110);
+var weak = __webpack_require__(130);
 var isObject = __webpack_require__(5);
-var validate = __webpack_require__(45);
-var NATIVE_WEAK_MAP = __webpack_require__(45);
-var IS_IE11 = !global.ActiveXObject && 'ActiveXObject' in global;
+var fails = __webpack_require__(4);
+var validate = __webpack_require__(49);
 var WEAK_MAP = 'WeakMap';
 var getWeak = meta.getWeak;
 var isExtensible = Object.isExtensible;
 var uncaughtFrozenStore = weak.ufstore;
+var tmp = {};
 var InternalMap;
 
 var wrapper = function wrapper(get) {
@@ -5085,10 +4877,12 @@ var methods = {
 };
 
 // 23.3 WeakMap Objects
-var $WeakMap = module.exports = __webpack_require__(68)(WEAK_MAP, wrapper, methods, weak, true, true);
+var $WeakMap = module.exports = __webpack_require__(66)(WEAK_MAP, wrapper, methods, weak, true, true);
 
 // IE11 WeakMap frozen keys fix
-if (NATIVE_WEAK_MAP && IS_IE11) {
+if (fails(function () {
+  return new $WeakMap().set((Object.freeze || Object)(tmp), 7).get(tmp) != 7;
+})) {
   InternalMap = weak.getConstructor(wrapper, WEAK_MAP);
   assign(InternalMap.prototype, methods);
   meta.NEED = true;
@@ -5108,21 +4902,21 @@ if (NATIVE_WEAK_MAP && IS_IE11) {
 }
 
 /***/ }),
-/* 135 */
+/* 130 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var redefineAll = __webpack_require__(44);
-var getWeak = __webpack_require__(33).getWeak;
+var getWeak = __webpack_require__(32).getWeak;
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
 var anInstance = __webpack_require__(42);
 var forOf = __webpack_require__(43);
 var createArrayMethod = __webpack_require__(29);
 var $has = __webpack_require__(17);
-var validate = __webpack_require__(45);
+var validate = __webpack_require__(49);
 var arrayFind = createArrayMethod(5);
 var arrayFindIndex = createArrayMethod(6);
 var id = 0;
@@ -5198,12 +4992,12 @@ module.exports = {
 };
 
 /***/ }),
-/* 136 */
+/* 131 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/ecma262/#sec-toindex
-var toInteger = __webpack_require__(24);
-var toLength = __webpack_require__(7);
+var toInteger = __webpack_require__(27);
+var toLength = __webpack_require__(9);
 module.exports = function (it) {
   if (it === undefined) return 0;
   var number = toInteger(it);
@@ -5213,14 +5007,14 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 137 */
+/* 132 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // all object keys, includes non-enumerable and symbols
 var gOPN = __webpack_require__(40);
-var gOPS = __webpack_require__(60);
+var gOPS = __webpack_require__(58);
 var anObject = __webpack_require__(1);
-var Reflect = __webpack_require__(2).Reflect;
+var Reflect = __webpack_require__(3).Reflect;
 module.exports = Reflect && Reflect.ownKeys || function ownKeys(it) {
   var keys = gOPN.f(anObject(it));
   var getSymbols = gOPS.f;
@@ -5228,16 +5022,16 @@ module.exports = Reflect && Reflect.ownKeys || function ownKeys(it) {
 };
 
 /***/ }),
-/* 138 */
+/* 133 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 // https://tc39.github.io/proposal-flatMap/#sec-FlattenIntoArray
 
-var isArray = __webpack_require__(61);
+var isArray = __webpack_require__(59);
 var isObject = __webpack_require__(5);
-var toLength = __webpack_require__(7);
+var toLength = __webpack_require__(9);
 var ctx = __webpack_require__(22);
 var IS_CONCAT_SPREADABLE = __webpack_require__(6)('isConcatSpreadable');
 
@@ -5274,13 +5068,13 @@ function flattenIntoArray(target, original, source, sourceLen, start, depth, map
 module.exports = flattenIntoArray;
 
 /***/ }),
-/* 139 */
+/* 134 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-string-pad-start-end
-var toLength = __webpack_require__(7);
-var repeat = __webpack_require__(86);
-var defined = __webpack_require__(27);
+var toLength = __webpack_require__(9);
+var repeat = __webpack_require__(84);
+var defined = __webpack_require__(26);
 
 module.exports = function (that, maxLength, fillString, left) {
   var S = String(defined(that));
@@ -5295,12 +5089,12 @@ module.exports = function (that, maxLength, fillString, left) {
 };
 
 /***/ }),
-/* 140 */
+/* 135 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var getKeys = __webpack_require__(37);
 var toIObject = __webpack_require__(18);
-var isEnum = __webpack_require__(53).f;
+var isEnum = __webpack_require__(51).f;
 module.exports = function (isEntries) {
   return function (it) {
     var O = toIObject(it);
@@ -5318,12 +5112,12 @@ module.exports = function (isEntries) {
 };
 
 /***/ }),
-/* 141 */
+/* 136 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
-var classof = __webpack_require__(48);
-var from = __webpack_require__(142);
+var classof = __webpack_require__(52);
+var from = __webpack_require__(137);
 module.exports = function (NAME) {
   return function toJSON() {
     if (classof(this) != NAME) throw TypeError(NAME + "#toJSON isn't generic");
@@ -5332,7 +5126,7 @@ module.exports = function (NAME) {
 };
 
 /***/ }),
-/* 142 */
+/* 137 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var forOf = __webpack_require__(43);
@@ -5344,7 +5138,7 @@ module.exports = function (iter, ITERATOR) {
 };
 
 /***/ }),
-/* 143 */
+/* 138 */
 /***/ (function(module, exports) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -5365,43 +5159,43 @@ module.exports = Math.scale || function scale(x, inLow, inHigh, outLow, outHigh)
 };
 
 /***/ }),
-/* 144 */
+/* 139 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony export (immutable) */ __webpack_exports__["initialize"] = initialize;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(365);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(367);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(369);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(146);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(147);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(383);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(384);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(386);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(394);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(396);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(397);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(399);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(400);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(401);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(402);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(404);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(406);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(408);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(414);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(415);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(417);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(419);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(420);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(421);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(422);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(424);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(425);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(426);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(428);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(429);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__plugins__ = __webpack_require__(430);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(360);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(362);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(364);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(141);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(142);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(378);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(379);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(381);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(389);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(391);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(392);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(394);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(395);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(396);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(397);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(399);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(401);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(403);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(409);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(410);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(412);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(414);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(415);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(416);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(417);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(419);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(420);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(421);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(423);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(424);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__plugins__ = __webpack_require__(425);
 
 
 
@@ -5473,7 +5267,7 @@ function initialize(root, setRoot) {
 }
 
 /***/ }),
-/* 145 */
+/* 140 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -11884,17 +11678,17 @@ function initialize(root, setRoot) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 146 */
+/* 141 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["b"] = initTextFields;
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VTextField; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_textfield__ = __webpack_require__(145);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_textfield__ = __webpack_require__(140);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_textfield__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(106);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(103);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -12062,25 +11856,25 @@ var VTextField = function (_visibilityObserverMi) {
 }(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 147 */
+/* 142 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VEvents; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = initEvents;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(371);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(372);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(374);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(149);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(105);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(375);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(376);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(377);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(378);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(379);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(380);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_plugin__ = __webpack_require__(381);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__root_document__ = __webpack_require__(382);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(366);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(367);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(369);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(144);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(102);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(370);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(371);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(372);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(373);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(374);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(375);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_plugin__ = __webpack_require__(376);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__root_document__ = __webpack_require__(377);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -12264,7 +12058,7 @@ function fireAfterLoad(e) {
 }
 
 /***/ }),
-/* 148 */
+/* 143 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -12387,7 +12181,7 @@ var VUrls = function () {
 }();
 
 /***/ }),
-/* 149 */
+/* 144 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -12447,11 +12241,11 @@ var VDialog = function () {
 }();
 
 /***/ }),
-/* 150 */
+/* 145 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__foundation__ = __webpack_require__(107);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__foundation__ = __webpack_require__(104);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -12625,7 +12419,7 @@ var MDCComponent = function () {
 /* harmony default export */ __webpack_exports__["a"] = (MDCComponent);
 
 /***/ }),
-/* 151 */
+/* 146 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -12806,7 +12600,7 @@ var MDCRippleAdapter = function () {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCRippleAdapter);
 
 /***/ }),
-/* 152 */
+/* 147 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -12987,7 +12781,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 
 
 /***/ }),
-/* 153 */
+/* 148 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -17342,7 +17136,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 154 */
+/* 149 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -20925,20 +20719,20 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 155 */
+/* 150 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(156);
+module.exports = __webpack_require__(151);
 
 
 /***/ }),
-/* 156 */
+/* 151 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_compatibility__ = __webpack_require__(157);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(58);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_compatibility__ = __webpack_require__(152);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(55);
 
 
 
@@ -20954,11 +20748,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
     document.documentElement.classList.remove('incompatible-browser');
 
-    __webpack_require__(161);
-    __webpack_require__(162);
-    __webpack_require__(163);
+    __webpack_require__(156);
+    __webpack_require__(157);
+    __webpack_require__(158);
 
-    __webpack_require__(144).initialize(document, true);
+    __webpack_require__(139).initialize(document, true);
 
     // Focus first valid input control
     var focusable = document.querySelectorAll('.v-focusable');
@@ -20972,13 +20766,13 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 /***/ }),
-/* 157 */
+/* 152 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser__ = __webpack_require__(158);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser__ = __webpack_require__(153);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_detect_browser__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(58);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(55);
 
 
 
@@ -20990,7 +20784,7 @@ var isCompatible = browser && incompatibleList.indexOf(name) < 0;
 /* harmony default export */ __webpack_exports__["a"] = (isCompatible);
 
 /***/ }),
-/* 158 */
+/* 153 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(process) {function detect() {
@@ -21074,10 +20868,10 @@ module.exports = {
   getNodeVersion: getNodeVersion,
   parseUserAgent: parseUserAgent
 };
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(159)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(154)))
 
 /***/ }),
-/* 159 */
+/* 154 */
 /***/ (function(module, exports) {
 
 // shim for using process in browser
@@ -21267,7 +21061,7 @@ process.umask = function () {
 };
 
 /***/ }),
-/* 160 */
+/* 155 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -21369,7 +21163,7 @@ var VConfig = function () {
 /* harmony default export */ __webpack_exports__["a"] = (VConfig);
 
 /***/ }),
-/* 161 */
+/* 156 */
 /***/ (function(module, exports) {
 
 ;(function() {
@@ -25371,7 +25165,7 @@ componentHandler.register({
 
 
 /***/ }),
-/* 162 */
+/* 157 */
 /***/ (function(module, exports) {
 
 /*
@@ -26486,17 +26280,17 @@ componentHandler.register({
 /******/]);
 
 /***/ }),
-/* 163 */
+/* 158 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 /* WEBPACK VAR INJECTION */(function(global) {
 
-__webpack_require__(164);
+__webpack_require__(159);
 
-__webpack_require__(361);
+__webpack_require__(356);
 
-__webpack_require__(362);
+__webpack_require__(357);
 
 if (global._babelPolyfill) {
   throw new Error("only one instance of babel-polyfill is allowed");
@@ -26518,13 +26312,19 @@ define(String.prototype, "padRight", "".padEnd);
 "pop,reverse,shift,keys,values,entries,indexOf,every,some,forEach,map,filter,find,findIndex,includes,join,slice,concat,push,splice,unshift,sort,lastIndexOf,reduce,reduceRight,copyWithin,fill".split(",").forEach(function (key) {
   [][key] && define(Array, key, Function.call.bind([][key]));
 });
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(77)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(75)))
 
 /***/ }),
-/* 164 */
+/* 159 */
 /***/ (function(module, exports, __webpack_require__) {
 
+__webpack_require__(160);
+__webpack_require__(162);
+__webpack_require__(163);
+__webpack_require__(164);
 __webpack_require__(165);
+__webpack_require__(166);
+__webpack_require__(167);
 __webpack_require__(168);
 __webpack_require__(169);
 __webpack_require__(170);
@@ -26534,7 +26334,6 @@ __webpack_require__(173);
 __webpack_require__(174);
 __webpack_require__(175);
 __webpack_require__(176);
-__webpack_require__(177);
 __webpack_require__(178);
 __webpack_require__(179);
 __webpack_require__(180);
@@ -26596,20 +26395,20 @@ __webpack_require__(235);
 __webpack_require__(236);
 __webpack_require__(237);
 __webpack_require__(238);
-__webpack_require__(239);
 __webpack_require__(240);
 __webpack_require__(241);
-__webpack_require__(242);
 __webpack_require__(243);
+__webpack_require__(244);
 __webpack_require__(245);
 __webpack_require__(246);
+__webpack_require__(247);
 __webpack_require__(248);
 __webpack_require__(249);
-__webpack_require__(250);
 __webpack_require__(251);
 __webpack_require__(252);
 __webpack_require__(253);
 __webpack_require__(254);
+__webpack_require__(255);
 __webpack_require__(256);
 __webpack_require__(257);
 __webpack_require__(258);
@@ -26618,24 +26417,23 @@ __webpack_require__(260);
 __webpack_require__(261);
 __webpack_require__(262);
 __webpack_require__(263);
+__webpack_require__(97);
 __webpack_require__(264);
 __webpack_require__(265);
+__webpack_require__(123);
 __webpack_require__(266);
 __webpack_require__(267);
 __webpack_require__(268);
-__webpack_require__(98);
 __webpack_require__(269);
-__webpack_require__(127);
 __webpack_require__(270);
+__webpack_require__(126);
 __webpack_require__(128);
+__webpack_require__(129);
 __webpack_require__(271);
 __webpack_require__(272);
 __webpack_require__(273);
 __webpack_require__(274);
 __webpack_require__(275);
-__webpack_require__(131);
-__webpack_require__(133);
-__webpack_require__(134);
 __webpack_require__(276);
 __webpack_require__(277);
 __webpack_require__(278);
@@ -26716,15 +26514,10 @@ __webpack_require__(352);
 __webpack_require__(353);
 __webpack_require__(354);
 __webpack_require__(355);
-__webpack_require__(356);
-__webpack_require__(357);
-__webpack_require__(358);
-__webpack_require__(359);
-__webpack_require__(360);
 module.exports = __webpack_require__(21);
 
 /***/ }),
-/* 165 */
+/* 160 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -26733,30 +26526,30 @@ module.exports = __webpack_require__(21);
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var has = __webpack_require__(17);
-var DESCRIPTORS = __webpack_require__(8);
+var DESCRIPTORS = __webpack_require__(7);
 var $export = __webpack_require__(0);
 var redefine = __webpack_require__(15);
-var META = __webpack_require__(33).KEY;
+var META = __webpack_require__(32).KEY;
 var $fails = __webpack_require__(4);
-var shared = __webpack_require__(51);
-var setToStringTag = __webpack_require__(47);
+var shared = __webpack_require__(56);
+var setToStringTag = __webpack_require__(46);
 var uid = __webpack_require__(36);
 var wks = __webpack_require__(6);
-var wksExt = __webpack_require__(109);
-var wksDefine = __webpack_require__(79);
-var enumKeys = __webpack_require__(167);
-var isArray = __webpack_require__(61);
+var wksExt = __webpack_require__(106);
+var wksDefine = __webpack_require__(77);
+var enumKeys = __webpack_require__(161);
+var isArray = __webpack_require__(59);
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
 var toIObject = __webpack_require__(18);
-var toPrimitive = __webpack_require__(26);
+var toPrimitive = __webpack_require__(25);
 var createDesc = __webpack_require__(35);
 var _create = __webpack_require__(39);
-var gOPNExt = __webpack_require__(112);
+var gOPNExt = __webpack_require__(109);
 var $GOPD = __webpack_require__(19);
-var $DP = __webpack_require__(9);
+var $DP = __webpack_require__(8);
 var $keys = __webpack_require__(37);
 var gOPD = $GOPD.f;
 var dP = $DP.f;
@@ -26884,10 +26677,10 @@ if (!USE_NATIVE) {
   $GOPD.f = $getOwnPropertyDescriptor;
   $DP.f = $defineProperty;
   __webpack_require__(40).f = gOPNExt.f = $getOwnPropertyNames;
-  __webpack_require__(53).f = $propertyIsEnumerable;
-  __webpack_require__(60).f = $getOwnPropertySymbols;
+  __webpack_require__(51).f = $propertyIsEnumerable;
+  __webpack_require__(58).f = $getOwnPropertySymbols;
 
-  if (DESCRIPTORS && !__webpack_require__(32)) {
+  if (DESCRIPTORS && !__webpack_require__(33)) {
     redefine(ObjectProto, 'propertyIsEnumerable', $propertyIsEnumerable, true);
   }
 
@@ -26974,19 +26767,13 @@ setToStringTag(Math, 'Math', true);
 setToStringTag(global.JSON, 'JSON', true);
 
 /***/ }),
-/* 166 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(51)('native-function-to-string', Function.toString);
-
-/***/ }),
-/* 167 */
+/* 161 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // all enumerable object keys, includes symbols
 var getKeys = __webpack_require__(37);
-var gOPS = __webpack_require__(60);
-var pIE = __webpack_require__(53);
+var gOPS = __webpack_require__(58);
+var pIE = __webpack_require__(51);
 module.exports = function (it) {
   var result = getKeys(it);
   var getSymbols = gOPS.f;
@@ -27002,7 +26789,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 168 */
+/* 162 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -27010,23 +26797,23 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Object', { create: __webpack_require__(39) });
 
 /***/ }),
-/* 169 */
+/* 163 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
 // 19.1.2.4 / 15.2.3.6 Object.defineProperty(O, P, Attributes)
-$export($export.S + $export.F * !__webpack_require__(8), 'Object', { defineProperty: __webpack_require__(9).f });
+$export($export.S + $export.F * !__webpack_require__(7), 'Object', { defineProperty: __webpack_require__(8).f });
 
 /***/ }),
-/* 170 */
+/* 164 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
 // 19.1.2.3 / 15.2.3.7 Object.defineProperties(O, Properties)
-$export($export.S + $export.F * !__webpack_require__(8), 'Object', { defineProperties: __webpack_require__(111) });
+$export($export.S + $export.F * !__webpack_require__(7), 'Object', { defineProperties: __webpack_require__(108) });
 
 /***/ }),
-/* 171 */
+/* 165 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.6 Object.getOwnPropertyDescriptor(O, P)
@@ -27040,11 +26827,11 @@ __webpack_require__(28)('getOwnPropertyDescriptor', function () {
 });
 
 /***/ }),
-/* 172 */
+/* 166 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.9 Object.getPrototypeOf(O)
-var toObject = __webpack_require__(10);
+var toObject = __webpack_require__(11);
 var $getPrototypeOf = __webpack_require__(20);
 
 __webpack_require__(28)('getPrototypeOf', function () {
@@ -27054,11 +26841,11 @@ __webpack_require__(28)('getPrototypeOf', function () {
 });
 
 /***/ }),
-/* 173 */
+/* 167 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.14 Object.keys(O)
-var toObject = __webpack_require__(10);
+var toObject = __webpack_require__(11);
 var $keys = __webpack_require__(37);
 
 __webpack_require__(28)('keys', function () {
@@ -27068,21 +26855,21 @@ __webpack_require__(28)('keys', function () {
 });
 
 /***/ }),
-/* 174 */
+/* 168 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.7 Object.getOwnPropertyNames(O)
 __webpack_require__(28)('getOwnPropertyNames', function () {
-  return __webpack_require__(112).f;
+  return __webpack_require__(109).f;
 });
 
 /***/ }),
-/* 175 */
+/* 169 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.5 Object.freeze(O)
 var isObject = __webpack_require__(5);
-var meta = __webpack_require__(33).onFreeze;
+var meta = __webpack_require__(32).onFreeze;
 
 __webpack_require__(28)('freeze', function ($freeze) {
   return function freeze(it) {
@@ -27091,12 +26878,12 @@ __webpack_require__(28)('freeze', function ($freeze) {
 });
 
 /***/ }),
-/* 176 */
+/* 170 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.17 Object.seal(O)
 var isObject = __webpack_require__(5);
-var meta = __webpack_require__(33).onFreeze;
+var meta = __webpack_require__(32).onFreeze;
 
 __webpack_require__(28)('seal', function ($seal) {
   return function seal(it) {
@@ -27105,12 +26892,12 @@ __webpack_require__(28)('seal', function ($seal) {
 });
 
 /***/ }),
-/* 177 */
+/* 171 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.15 Object.preventExtensions(O)
 var isObject = __webpack_require__(5);
-var meta = __webpack_require__(33).onFreeze;
+var meta = __webpack_require__(32).onFreeze;
 
 __webpack_require__(28)('preventExtensions', function ($preventExtensions) {
   return function preventExtensions(it) {
@@ -27119,7 +26906,7 @@ __webpack_require__(28)('preventExtensions', function ($preventExtensions) {
 });
 
 /***/ }),
-/* 178 */
+/* 172 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.12 Object.isFrozen(O)
@@ -27132,7 +26919,7 @@ __webpack_require__(28)('isFrozen', function ($isFrozen) {
 });
 
 /***/ }),
-/* 179 */
+/* 173 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.13 Object.isSealed(O)
@@ -27145,7 +26932,7 @@ __webpack_require__(28)('isSealed', function ($isSealed) {
 });
 
 /***/ }),
-/* 180 */
+/* 174 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.11 Object.isExtensible(O)
@@ -27158,39 +26945,49 @@ __webpack_require__(28)('isExtensible', function ($isExtensible) {
 });
 
 /***/ }),
-/* 181 */
+/* 175 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.1 Object.assign(target, source)
 var $export = __webpack_require__(0);
 
-$export($export.S + $export.F, 'Object', { assign: __webpack_require__(113) });
+$export($export.S + $export.F, 'Object', { assign: __webpack_require__(110) });
 
 /***/ }),
-/* 182 */
+/* 176 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.10 Object.is(value1, value2)
 var $export = __webpack_require__(0);
-$export($export.S, 'Object', { is: __webpack_require__(114) });
+$export($export.S, 'Object', { is: __webpack_require__(177) });
 
 /***/ }),
-/* 183 */
+/* 177 */
+/***/ (function(module, exports) {
+
+// 7.2.9 SameValue(x, y)
+module.exports = Object.is || function is(x, y) {
+  // eslint-disable-next-line no-self-compare
+  return x === y ? x !== 0 || 1 / x === 1 / y : x != x && y != y;
+};
+
+/***/ }),
+/* 178 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.19 Object.setPrototypeOf(O, proto)
 var $export = __webpack_require__(0);
-$export($export.S, 'Object', { setPrototypeOf: __webpack_require__(83).set });
+$export($export.S, 'Object', { setPrototypeOf: __webpack_require__(81).set });
 
 /***/ }),
-/* 184 */
+/* 179 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 // 19.1.3.6 Object.prototype.toString()
 
-var classof = __webpack_require__(48);
+var classof = __webpack_require__(52);
 var test = {};
 test[__webpack_require__(6)('toStringTag')] = 'z';
 if (test + '' != '[object z]') {
@@ -27200,25 +26997,25 @@ if (test + '' != '[object z]') {
 }
 
 /***/ }),
-/* 185 */
+/* 180 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.2.3.2 / 15.3.4.5 Function.prototype.bind(thisArg, args...)
 var $export = __webpack_require__(0);
 
-$export($export.P, 'Function', { bind: __webpack_require__(115) });
+$export($export.P, 'Function', { bind: __webpack_require__(111) });
 
 /***/ }),
-/* 186 */
+/* 181 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var dP = __webpack_require__(9).f;
+var dP = __webpack_require__(8).f;
 var FProto = Function.prototype;
 var nameRE = /^\s*function ([^ (]*)/;
 var NAME = 'name';
 
 // 19.2.4.2 name
-NAME in FProto || __webpack_require__(8) && dP(FProto, NAME, {
+NAME in FProto || __webpack_require__(7) && dP(FProto, NAME, {
   configurable: true,
   get: function get() {
     try {
@@ -27230,7 +27027,7 @@ NAME in FProto || __webpack_require__(8) && dP(FProto, NAME, {
 });
 
 /***/ }),
-/* 187 */
+/* 182 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -27241,7 +27038,7 @@ var getPrototypeOf = __webpack_require__(20);
 var HAS_INSTANCE = __webpack_require__(6)('hasInstance');
 var FunctionProto = Function.prototype;
 // 19.2.3.6 Function.prototype[@@hasInstance](V)
-if (!(HAS_INSTANCE in FunctionProto)) __webpack_require__(9).f(FunctionProto, HAS_INSTANCE, { value: function value(O) {
+if (!(HAS_INSTANCE in FunctionProto)) __webpack_require__(8).f(FunctionProto, HAS_INSTANCE, { value: function value(O) {
     if (typeof this != 'function' || !isObject(O)) return false;
     if (!isObject(this.prototype)) return O instanceof this;
     // for environment w/o native `@@hasInstance` logic enough `instanceof`, but add this:
@@ -27251,40 +27048,40 @@ if (!(HAS_INSTANCE in FunctionProto)) __webpack_require__(9).f(FunctionProto, HA
   } });
 
 /***/ }),
-/* 188 */
+/* 183 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $parseInt = __webpack_require__(117);
+var $parseInt = __webpack_require__(113);
 // 18.2.5 parseInt(string, radix)
 $export($export.G + $export.F * (parseInt != $parseInt), { parseInt: $parseInt });
 
 /***/ }),
-/* 189 */
+/* 184 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $parseFloat = __webpack_require__(118);
+var $parseFloat = __webpack_require__(114);
 // 18.2.4 parseFloat(string)
 $export($export.G + $export.F * (parseFloat != $parseFloat), { parseFloat: $parseFloat });
 
 /***/ }),
-/* 190 */
+/* 185 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var has = __webpack_require__(17);
 var cof = __webpack_require__(23);
-var inheritIfRequired = __webpack_require__(85);
-var toPrimitive = __webpack_require__(26);
+var inheritIfRequired = __webpack_require__(83);
+var toPrimitive = __webpack_require__(25);
 var fails = __webpack_require__(4);
 var gOPN = __webpack_require__(40).f;
 var gOPD = __webpack_require__(19).f;
-var dP = __webpack_require__(9).f;
-var $trim = __webpack_require__(49).trim;
+var dP = __webpack_require__(8).f;
+var $trim = __webpack_require__(47).trim;
 var NUMBER = 'Number';
 var $Number = global[NUMBER];
 var Base = $Number;
@@ -27332,7 +27129,7 @@ if (!$Number(' 0o1') || !$Number('0b1') || $Number('+0x1')) {
       proto.valueOf.call(that);
     }) : cof(that) != NUMBER) ? inheritIfRequired(new Base(toNumber(it)), that, $Number) : toNumber(it);
   };
-  for (var keys = __webpack_require__(8) ? gOPN(Base) : (
+  for (var keys = __webpack_require__(7) ? gOPN(Base) : (
   // ES3:
   'MAX_VALUE,MIN_VALUE,NaN,NEGATIVE_INFINITY,POSITIVE_INFINITY,' +
   // ES6 (in case, if modules with ES6 Number statics required before):
@@ -27347,16 +27144,16 @@ if (!$Number(' 0o1') || !$Number('0b1') || $Number('+0x1')) {
 }
 
 /***/ }),
-/* 191 */
+/* 186 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var toInteger = __webpack_require__(24);
-var aNumberValue = __webpack_require__(119);
-var repeat = __webpack_require__(86);
+var toInteger = __webpack_require__(27);
+var aNumberValue = __webpack_require__(115);
+var repeat = __webpack_require__(84);
 var $toFixed = 1.0.toFixed;
 var floor = Math.floor;
 var data = [0, 0, 0, 0, 0, 0];
@@ -27463,7 +27260,7 @@ $export($export.P + $export.F * (!!$toFixed && (0.00008.toFixed(3) !== '0.000' |
 });
 
 /***/ }),
-/* 192 */
+/* 187 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -27471,7 +27268,7 @@ $export($export.P + $export.F * (!!$toFixed && (0.00008.toFixed(3) !== '0.000' |
 
 var $export = __webpack_require__(0);
 var $fails = __webpack_require__(4);
-var aNumberValue = __webpack_require__(119);
+var aNumberValue = __webpack_require__(115);
 var $toPrecision = 1.0.toPrecision;
 
 $export($export.P + $export.F * ($fails(function () {
@@ -27488,7 +27285,7 @@ $export($export.P + $export.F * ($fails(function () {
 });
 
 /***/ }),
-/* 193 */
+/* 188 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.1 Number.EPSILON
@@ -27497,12 +27294,12 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { EPSILON: Math.pow(2, -52) });
 
 /***/ }),
-/* 194 */
+/* 189 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.2 Number.isFinite(number)
 var $export = __webpack_require__(0);
-var _isFinite = __webpack_require__(2).isFinite;
+var _isFinite = __webpack_require__(3).isFinite;
 
 $export($export.S, 'Number', {
   isFinite: function isFinite(it) {
@@ -27511,16 +27308,16 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
-/* 195 */
+/* 190 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.3 Number.isInteger(number)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Number', { isInteger: __webpack_require__(120) });
+$export($export.S, 'Number', { isInteger: __webpack_require__(116) });
 
 /***/ }),
-/* 196 */
+/* 191 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.4 Number.isNaN(number)
@@ -27534,12 +27331,12 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
-/* 197 */
+/* 192 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.5 Number.isSafeInteger(number)
 var $export = __webpack_require__(0);
-var isInteger = __webpack_require__(120);
+var isInteger = __webpack_require__(116);
 var abs = Math.abs;
 
 $export($export.S, 'Number', {
@@ -27549,7 +27346,7 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
-/* 198 */
+/* 193 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.6 Number.MAX_SAFE_INTEGER
@@ -27558,7 +27355,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { MAX_SAFE_INTEGER: 0x1fffffffffffff });
 
 /***/ }),
-/* 199 */
+/* 194 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.10 Number.MIN_SAFE_INTEGER
@@ -27567,30 +27364,30 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { MIN_SAFE_INTEGER: -0x1fffffffffffff });
 
 /***/ }),
-/* 200 */
+/* 195 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $parseFloat = __webpack_require__(118);
+var $parseFloat = __webpack_require__(114);
 // 20.1.2.12 Number.parseFloat(string)
 $export($export.S + $export.F * (Number.parseFloat != $parseFloat), 'Number', { parseFloat: $parseFloat });
 
 /***/ }),
-/* 201 */
+/* 196 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $parseInt = __webpack_require__(117);
+var $parseInt = __webpack_require__(113);
 // 20.1.2.13 Number.parseInt(string, radix)
 $export($export.S + $export.F * (Number.parseInt != $parseInt), 'Number', { parseInt: $parseInt });
 
 /***/ }),
-/* 202 */
+/* 197 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.3 Math.acosh(x)
 var $export = __webpack_require__(0);
-var log1p = __webpack_require__(121);
+var log1p = __webpack_require__(117);
 var sqrt = Math.sqrt;
 var $acosh = Math.acosh;
 
@@ -27605,7 +27402,7 @@ $export($export.S + $export.F * !($acosh
 });
 
 /***/ }),
-/* 203 */
+/* 198 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.5 Math.asinh(x)
@@ -27620,7 +27417,7 @@ function asinh(x) {
 $export($export.S + $export.F * !($asinh && 1 / $asinh(0) > 0), 'Math', { asinh: asinh });
 
 /***/ }),
-/* 204 */
+/* 199 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.7 Math.atanh(x)
@@ -27635,12 +27432,12 @@ $export($export.S + $export.F * !($atanh && 1 / $atanh(-0) < 0), 'Math', {
 });
 
 /***/ }),
-/* 205 */
+/* 200 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.9 Math.cbrt(x)
 var $export = __webpack_require__(0);
-var sign = __webpack_require__(87);
+var sign = __webpack_require__(85);
 
 $export($export.S, 'Math', {
   cbrt: function cbrt(x) {
@@ -27649,7 +27446,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 206 */
+/* 201 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.11 Math.clz32(x)
@@ -27662,7 +27459,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 207 */
+/* 202 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.12 Math.cosh(x)
@@ -27676,26 +27473,26 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 208 */
+/* 203 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.14 Math.expm1(x)
 var $export = __webpack_require__(0);
-var $expm1 = __webpack_require__(88);
+var $expm1 = __webpack_require__(86);
 
 $export($export.S + $export.F * ($expm1 != Math.expm1), 'Math', { expm1: $expm1 });
 
 /***/ }),
-/* 209 */
+/* 204 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.16 Math.fround(x)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Math', { fround: __webpack_require__(122) });
+$export($export.S, 'Math', { fround: __webpack_require__(118) });
 
 /***/ }),
-/* 210 */
+/* 205 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.17 Math.hypot([value1[, value2[, … ]]])
@@ -27726,7 +27523,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 211 */
+/* 206 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.18 Math.imul(x, y)
@@ -27748,7 +27545,7 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-/* 212 */
+/* 207 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.21 Math.log10(x)
@@ -27761,16 +27558,16 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 213 */
+/* 208 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.20 Math.log1p(x)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Math', { log1p: __webpack_require__(121) });
+$export($export.S, 'Math', { log1p: __webpack_require__(117) });
 
 /***/ }),
-/* 214 */
+/* 209 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.22 Math.log2(x)
@@ -27783,21 +27580,21 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 215 */
+/* 210 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.28 Math.sign(x)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Math', { sign: __webpack_require__(87) });
+$export($export.S, 'Math', { sign: __webpack_require__(85) });
 
 /***/ }),
-/* 216 */
+/* 211 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.30 Math.sinh(x)
 var $export = __webpack_require__(0);
-var expm1 = __webpack_require__(88);
+var expm1 = __webpack_require__(86);
 var exp = Math.exp;
 
 // V8 near Chromium 38 has a problem with very small numbers
@@ -27810,12 +27607,12 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-/* 217 */
+/* 212 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.33 Math.tanh(x)
 var $export = __webpack_require__(0);
-var expm1 = __webpack_require__(88);
+var expm1 = __webpack_require__(86);
 var exp = Math.exp;
 
 $export($export.S, 'Math', {
@@ -27827,7 +27624,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 218 */
+/* 213 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.34 Math.trunc(x)
@@ -27840,7 +27637,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 219 */
+/* 214 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -27866,12 +27663,12 @@ $export($export.S + $export.F * (!!$fromCodePoint && $fromCodePoint.length != 1)
 });
 
 /***/ }),
-/* 220 */
+/* 215 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
 var toIObject = __webpack_require__(18);
-var toLength = __webpack_require__(7);
+var toLength = __webpack_require__(9);
 
 $export($export.S, 'String', {
   // 21.1.2.4 String.raw(callSite, ...substitutions)
@@ -27889,30 +27686,30 @@ $export($export.S, 'String', {
 });
 
 /***/ }),
-/* 221 */
+/* 216 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 // 21.1.3.25 String.prototype.trim()
 
-__webpack_require__(49)('trim', function ($trim) {
+__webpack_require__(47)('trim', function ($trim) {
   return function trim() {
     return $trim(this, 3);
   };
 });
 
 /***/ }),
-/* 222 */
+/* 217 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var $at = __webpack_require__(62)(true);
+var $at = __webpack_require__(87)(true);
 
 // 21.1.3.27 String.prototype[@@iterator]()
-__webpack_require__(89)(String, 'String', function (iterated) {
+__webpack_require__(88)(String, 'String', function (iterated) {
   this._t = String(iterated); // target
   this._i = 0; // next index
   // 21.1.5.2.1 %StringIteratorPrototype%.next()
@@ -27927,14 +27724,14 @@ __webpack_require__(89)(String, 'String', function (iterated) {
 });
 
 /***/ }),
-/* 223 */
+/* 218 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var $at = __webpack_require__(62)(false);
+var $at = __webpack_require__(87)(false);
 $export($export.P, 'String', {
   // 21.1.3.3 String.prototype.codePointAt(pos)
   codePointAt: function codePointAt(pos) {
@@ -27943,7 +27740,7 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
-/* 224 */
+/* 219 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -27951,12 +27748,12 @@ $export($export.P, 'String', {
 
 
 var $export = __webpack_require__(0);
-var toLength = __webpack_require__(7);
-var context = __webpack_require__(91);
+var toLength = __webpack_require__(9);
+var context = __webpack_require__(90);
 var ENDS_WITH = 'endsWith';
 var $endsWith = ''[ENDS_WITH];
 
-$export($export.P + $export.F * __webpack_require__(92)(ENDS_WITH), 'String', {
+$export($export.P + $export.F * __webpack_require__(91)(ENDS_WITH), 'String', {
   endsWith: function endsWith(searchString /* , endPosition = @length */) {
     var that = context(this, searchString, ENDS_WITH);
     var endPosition = arguments.length > 1 ? arguments[1] : undefined;
@@ -27968,7 +27765,7 @@ $export($export.P + $export.F * __webpack_require__(92)(ENDS_WITH), 'String', {
 });
 
 /***/ }),
-/* 225 */
+/* 220 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -27976,28 +27773,28 @@ $export($export.P + $export.F * __webpack_require__(92)(ENDS_WITH), 'String', {
 
 
 var $export = __webpack_require__(0);
-var context = __webpack_require__(91);
+var context = __webpack_require__(90);
 var INCLUDES = 'includes';
 
-$export($export.P + $export.F * __webpack_require__(92)(INCLUDES), 'String', {
+$export($export.P + $export.F * __webpack_require__(91)(INCLUDES), 'String', {
   includes: function includes(searchString /* , position = 0 */) {
     return !!~context(this, searchString, INCLUDES).indexOf(searchString, arguments.length > 1 ? arguments[1] : undefined);
   }
 });
 
 /***/ }),
-/* 226 */
+/* 221 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
 
 $export($export.P, 'String', {
   // 21.1.3.13 String.prototype.repeat(count)
-  repeat: __webpack_require__(86)
+  repeat: __webpack_require__(84)
 });
 
 /***/ }),
-/* 227 */
+/* 222 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28005,12 +27802,12 @@ $export($export.P, 'String', {
 
 
 var $export = __webpack_require__(0);
-var toLength = __webpack_require__(7);
-var context = __webpack_require__(91);
+var toLength = __webpack_require__(9);
+var context = __webpack_require__(90);
 var STARTS_WITH = 'startsWith';
 var $startsWith = ''[STARTS_WITH];
 
-$export($export.P + $export.F * __webpack_require__(92)(STARTS_WITH), 'String', {
+$export($export.P + $export.F * __webpack_require__(91)(STARTS_WITH), 'String', {
   startsWith: function startsWith(searchString /* , position = 0 */) {
     var that = context(this, searchString, STARTS_WITH);
     var index = toLength(Math.min(arguments.length > 1 ? arguments[1] : undefined, that.length));
@@ -28020,7 +27817,7 @@ $export($export.P + $export.F * __webpack_require__(92)(STARTS_WITH), 'String', 
 });
 
 /***/ }),
-/* 228 */
+/* 223 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28034,7 +27831,7 @@ __webpack_require__(16)('anchor', function (createHTML) {
 });
 
 /***/ }),
-/* 229 */
+/* 224 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28048,7 +27845,7 @@ __webpack_require__(16)('big', function (createHTML) {
 });
 
 /***/ }),
-/* 230 */
+/* 225 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28062,7 +27859,7 @@ __webpack_require__(16)('blink', function (createHTML) {
 });
 
 /***/ }),
-/* 231 */
+/* 226 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28076,7 +27873,7 @@ __webpack_require__(16)('bold', function (createHTML) {
 });
 
 /***/ }),
-/* 232 */
+/* 227 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28090,7 +27887,7 @@ __webpack_require__(16)('fixed', function (createHTML) {
 });
 
 /***/ }),
-/* 233 */
+/* 228 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28104,7 +27901,7 @@ __webpack_require__(16)('fontcolor', function (createHTML) {
 });
 
 /***/ }),
-/* 234 */
+/* 229 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28118,7 +27915,7 @@ __webpack_require__(16)('fontsize', function (createHTML) {
 });
 
 /***/ }),
-/* 235 */
+/* 230 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28132,7 +27929,7 @@ __webpack_require__(16)('italics', function (createHTML) {
 });
 
 /***/ }),
-/* 236 */
+/* 231 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28146,7 +27943,7 @@ __webpack_require__(16)('link', function (createHTML) {
 });
 
 /***/ }),
-/* 237 */
+/* 232 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28160,7 +27957,7 @@ __webpack_require__(16)('small', function (createHTML) {
 });
 
 /***/ }),
-/* 238 */
+/* 233 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28174,7 +27971,7 @@ __webpack_require__(16)('strike', function (createHTML) {
 });
 
 /***/ }),
-/* 239 */
+/* 234 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28188,7 +27985,7 @@ __webpack_require__(16)('sub', function (createHTML) {
 });
 
 /***/ }),
-/* 240 */
+/* 235 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28202,7 +27999,7 @@ __webpack_require__(16)('sup', function (createHTML) {
 });
 
 /***/ }),
-/* 241 */
+/* 236 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.3.3.1 / 15.9.4.4 Date.now()
@@ -28213,15 +28010,15 @@ $export($export.S, 'Date', { now: function now() {
   } });
 
 /***/ }),
-/* 242 */
+/* 237 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var toObject = __webpack_require__(10);
-var toPrimitive = __webpack_require__(26);
+var toObject = __webpack_require__(11);
+var toPrimitive = __webpack_require__(25);
 
 $export($export.P + $export.F * __webpack_require__(4)(function () {
   return new Date(NaN).toJSON() !== null || Date.prototype.toJSON.call({ toISOString: function toISOString() {
@@ -28237,12 +28034,12 @@ $export($export.P + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-/* 243 */
+/* 238 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.3.4.36 / 15.9.5.43 Date.prototype.toISOString()
 var $export = __webpack_require__(0);
-var toISOString = __webpack_require__(244);
+var toISOString = __webpack_require__(239);
 
 // PhantomJS / old WebKit has a broken implementations
 $export($export.P + $export.F * (Date.prototype.toISOString !== toISOString), 'Date', {
@@ -28250,7 +28047,7 @@ $export($export.P + $export.F * (Date.prototype.toISOString !== toISOString), 'D
 });
 
 /***/ }),
-/* 244 */
+/* 239 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28280,7 +28077,7 @@ module.exports = fails(function () {
 } : $toISOString;
 
 /***/ }),
-/* 245 */
+/* 240 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var DateProto = Date.prototype;
@@ -28297,23 +28094,23 @@ if (new Date(NaN) + '' != INVALID_DATE) {
 }
 
 /***/ }),
-/* 246 */
+/* 241 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var TO_PRIMITIVE = __webpack_require__(6)('toPrimitive');
 var proto = Date.prototype;
 
-if (!(TO_PRIMITIVE in proto)) __webpack_require__(14)(proto, TO_PRIMITIVE, __webpack_require__(247));
+if (!(TO_PRIMITIVE in proto)) __webpack_require__(14)(proto, TO_PRIMITIVE, __webpack_require__(242));
 
 /***/ }),
-/* 247 */
+/* 242 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var anObject = __webpack_require__(1);
-var toPrimitive = __webpack_require__(26);
+var toPrimitive = __webpack_require__(25);
 var NUMBER = 'number';
 
 module.exports = function (hint) {
@@ -28322,16 +28119,16 @@ module.exports = function (hint) {
 };
 
 /***/ }),
-/* 248 */
+/* 243 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.2.2 / 15.4.3.2 Array.isArray(arg)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Array', { isArray: __webpack_require__(61) });
+$export($export.S, 'Array', { isArray: __webpack_require__(59) });
 
 /***/ }),
-/* 249 */
+/* 244 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28339,14 +28136,14 @@ $export($export.S, 'Array', { isArray: __webpack_require__(61) });
 
 var ctx = __webpack_require__(22);
 var $export = __webpack_require__(0);
-var toObject = __webpack_require__(10);
-var call = __webpack_require__(123);
-var isArrayIter = __webpack_require__(93);
-var toLength = __webpack_require__(7);
-var createProperty = __webpack_require__(94);
-var getIterFn = __webpack_require__(95);
+var toObject = __webpack_require__(11);
+var call = __webpack_require__(119);
+var isArrayIter = __webpack_require__(92);
+var toLength = __webpack_require__(9);
+var createProperty = __webpack_require__(93);
+var getIterFn = __webpack_require__(94);
 
-$export($export.S + $export.F * !__webpack_require__(64)(function (iter) {
+$export($export.S + $export.F * !__webpack_require__(61)(function (iter) {
   Array.from(iter);
 }), 'Array', {
   // 22.1.2.1 Array.from(arrayLike, mapfn = undefined, thisArg = undefined)
@@ -28377,14 +28174,14 @@ $export($export.S + $export.F * !__webpack_require__(64)(function (iter) {
 });
 
 /***/ }),
-/* 250 */
+/* 245 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var createProperty = __webpack_require__(94);
+var createProperty = __webpack_require__(93);
 
 // WebKit Array.of isn't generic
 $export($export.S + $export.F * __webpack_require__(4)(function () {
@@ -28404,7 +28201,7 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-/* 251 */
+/* 246 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28416,24 +28213,24 @@ var toIObject = __webpack_require__(18);
 var arrayJoin = [].join;
 
 // fallback for not array-like strings
-$export($export.P + $export.F * (__webpack_require__(52) != Object || !__webpack_require__(25)(arrayJoin)), 'Array', {
+$export($export.P + $export.F * (__webpack_require__(50) != Object || !__webpack_require__(24)(arrayJoin)), 'Array', {
   join: function join(separator) {
     return arrayJoin.call(toIObject(this), separator === undefined ? ',' : separator);
   }
 });
 
 /***/ }),
-/* 252 */
+/* 247 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var html = __webpack_require__(82);
+var html = __webpack_require__(80);
 var cof = __webpack_require__(23);
 var toAbsoluteIndex = __webpack_require__(38);
-var toLength = __webpack_require__(7);
+var toLength = __webpack_require__(9);
 var arraySlice = [].slice;
 
 // fallback for not array-like ES3 strings and DOM objects
@@ -28457,7 +28254,7 @@ $export($export.P + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-/* 253 */
+/* 248 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28465,7 +28262,7 @@ $export($export.P + $export.F * __webpack_require__(4)(function () {
 
 var $export = __webpack_require__(0);
 var aFunction = __webpack_require__(13);
-var toObject = __webpack_require__(10);
+var toObject = __webpack_require__(11);
 var fails = __webpack_require__(4);
 var $sort = [].sort;
 var test = [1, 2, 3];
@@ -28477,7 +28274,7 @@ $export($export.P + $export.F * (fails(function () {
   // V8 bug
   test.sort(null);
   // Old WebKit
-}) || !__webpack_require__(25)($sort)), 'Array', {
+}) || !__webpack_require__(24)($sort)), 'Array', {
   // 22.1.3.25 Array.prototype.sort(comparefn)
   sort: function sort(comparefn) {
     return comparefn === undefined ? $sort.call(toObject(this)) : $sort.call(toObject(this), aFunction(comparefn));
@@ -28485,7 +28282,7 @@ $export($export.P + $export.F * (fails(function () {
 });
 
 /***/ }),
-/* 254 */
+/* 249 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28493,7 +28290,7 @@ $export($export.P + $export.F * (fails(function () {
 
 var $export = __webpack_require__(0);
 var $forEach = __webpack_require__(29)(0);
-var STRICT = __webpack_require__(25)([].forEach, true);
+var STRICT = __webpack_require__(24)([].forEach, true);
 
 $export($export.P + $export.F * !STRICT, 'Array', {
   // 22.1.3.10 / 15.4.4.18 Array.prototype.forEach(callbackfn [, thisArg])
@@ -28503,11 +28300,11 @@ $export($export.P + $export.F * !STRICT, 'Array', {
 });
 
 /***/ }),
-/* 255 */
+/* 250 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(5);
-var isArray = __webpack_require__(61);
+var isArray = __webpack_require__(59);
 var SPECIES = __webpack_require__(6)('species');
 
 module.exports = function (original) {
@@ -28524,7 +28321,7 @@ module.exports = function (original) {
 };
 
 /***/ }),
-/* 256 */
+/* 251 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28533,10 +28330,95 @@ module.exports = function (original) {
 var $export = __webpack_require__(0);
 var $map = __webpack_require__(29)(1);
 
-$export($export.P + $export.F * !__webpack_require__(25)([].map, true), 'Array', {
+$export($export.P + $export.F * !__webpack_require__(24)([].map, true), 'Array', {
   // 22.1.3.15 / 15.4.4.19 Array.prototype.map(callbackfn [, thisArg])
   map: function map(callbackfn /* , thisArg */) {
     return $map(this, callbackfn, arguments[1]);
+  }
+});
+
+/***/ }),
+/* 252 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var $export = __webpack_require__(0);
+var $filter = __webpack_require__(29)(2);
+
+$export($export.P + $export.F * !__webpack_require__(24)([].filter, true), 'Array', {
+  // 22.1.3.7 / 15.4.4.20 Array.prototype.filter(callbackfn [, thisArg])
+  filter: function filter(callbackfn /* , thisArg */) {
+    return $filter(this, callbackfn, arguments[1]);
+  }
+});
+
+/***/ }),
+/* 253 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var $export = __webpack_require__(0);
+var $some = __webpack_require__(29)(3);
+
+$export($export.P + $export.F * !__webpack_require__(24)([].some, true), 'Array', {
+  // 22.1.3.23 / 15.4.4.17 Array.prototype.some(callbackfn [, thisArg])
+  some: function some(callbackfn /* , thisArg */) {
+    return $some(this, callbackfn, arguments[1]);
+  }
+});
+
+/***/ }),
+/* 254 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var $export = __webpack_require__(0);
+var $every = __webpack_require__(29)(4);
+
+$export($export.P + $export.F * !__webpack_require__(24)([].every, true), 'Array', {
+  // 22.1.3.5 / 15.4.4.16 Array.prototype.every(callbackfn [, thisArg])
+  every: function every(callbackfn /* , thisArg */) {
+    return $every(this, callbackfn, arguments[1]);
+  }
+});
+
+/***/ }),
+/* 255 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var $export = __webpack_require__(0);
+var $reduce = __webpack_require__(120);
+
+$export($export.P + $export.F * !__webpack_require__(24)([].reduce, true), 'Array', {
+  // 22.1.3.18 / 15.4.4.21 Array.prototype.reduce(callbackfn [, initialValue])
+  reduce: function reduce(callbackfn /* , initialValue */) {
+    return $reduce(this, callbackfn, arguments.length, arguments[1], false);
+  }
+});
+
+/***/ }),
+/* 256 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var $export = __webpack_require__(0);
+var $reduce = __webpack_require__(120);
+
+$export($export.P + $export.F * !__webpack_require__(24)([].reduceRight, true), 'Array', {
+  // 22.1.3.19 / 15.4.4.22 Array.prototype.reduceRight(callbackfn [, initialValue])
+  reduceRight: function reduceRight(callbackfn /* , initialValue */) {
+    return $reduce(this, callbackfn, arguments.length, arguments[1], true);
   }
 });
 
@@ -28548,12 +28430,16 @@ $export($export.P + $export.F * !__webpack_require__(25)([].map, true), 'Array',
 
 
 var $export = __webpack_require__(0);
-var $filter = __webpack_require__(29)(2);
+var $indexOf = __webpack_require__(57)(false);
+var $native = [].indexOf;
+var NEGATIVE_ZERO = !!$native && 1 / [1].indexOf(1, -0) < 0;
 
-$export($export.P + $export.F * !__webpack_require__(25)([].filter, true), 'Array', {
-  // 22.1.3.7 / 15.4.4.20 Array.prototype.filter(callbackfn [, thisArg])
-  filter: function filter(callbackfn /* , thisArg */) {
-    return $filter(this, callbackfn, arguments[1]);
+$export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(24)($native)), 'Array', {
+  // 22.1.3.11 / 15.4.4.14 Array.prototype.indexOf(searchElement [, fromIndex])
+  indexOf: function indexOf(searchElement /* , fromIndex = 0 */) {
+    return NEGATIVE_ZERO
+    // convert -0 to +0
+    ? $native.apply(this, arguments) || 0 : $indexOf(this, searchElement, arguments[1]);
   }
 });
 
@@ -28565,102 +28451,13 @@ $export($export.P + $export.F * !__webpack_require__(25)([].filter, true), 'Arra
 
 
 var $export = __webpack_require__(0);
-var $some = __webpack_require__(29)(3);
-
-$export($export.P + $export.F * !__webpack_require__(25)([].some, true), 'Array', {
-  // 22.1.3.23 / 15.4.4.17 Array.prototype.some(callbackfn [, thisArg])
-  some: function some(callbackfn /* , thisArg */) {
-    return $some(this, callbackfn, arguments[1]);
-  }
-});
-
-/***/ }),
-/* 259 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var $export = __webpack_require__(0);
-var $every = __webpack_require__(29)(4);
-
-$export($export.P + $export.F * !__webpack_require__(25)([].every, true), 'Array', {
-  // 22.1.3.5 / 15.4.4.16 Array.prototype.every(callbackfn [, thisArg])
-  every: function every(callbackfn /* , thisArg */) {
-    return $every(this, callbackfn, arguments[1]);
-  }
-});
-
-/***/ }),
-/* 260 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var $export = __webpack_require__(0);
-var $reduce = __webpack_require__(124);
-
-$export($export.P + $export.F * !__webpack_require__(25)([].reduce, true), 'Array', {
-  // 22.1.3.18 / 15.4.4.21 Array.prototype.reduce(callbackfn [, initialValue])
-  reduce: function reduce(callbackfn /* , initialValue */) {
-    return $reduce(this, callbackfn, arguments.length, arguments[1], false);
-  }
-});
-
-/***/ }),
-/* 261 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var $export = __webpack_require__(0);
-var $reduce = __webpack_require__(124);
-
-$export($export.P + $export.F * !__webpack_require__(25)([].reduceRight, true), 'Array', {
-  // 22.1.3.19 / 15.4.4.22 Array.prototype.reduceRight(callbackfn [, initialValue])
-  reduceRight: function reduceRight(callbackfn /* , initialValue */) {
-    return $reduce(this, callbackfn, arguments.length, arguments[1], true);
-  }
-});
-
-/***/ }),
-/* 262 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var $export = __webpack_require__(0);
-var $indexOf = __webpack_require__(59)(false);
-var $native = [].indexOf;
-var NEGATIVE_ZERO = !!$native && 1 / [1].indexOf(1, -0) < 0;
-
-$export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(25)($native)), 'Array', {
-  // 22.1.3.11 / 15.4.4.14 Array.prototype.indexOf(searchElement [, fromIndex])
-  indexOf: function indexOf(searchElement /* , fromIndex = 0 */) {
-    return NEGATIVE_ZERO
-    // convert -0 to +0
-    ? $native.apply(this, arguments) || 0 : $indexOf(this, searchElement, arguments[1]);
-  }
-});
-
-/***/ }),
-/* 263 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var $export = __webpack_require__(0);
 var toIObject = __webpack_require__(18);
-var toInteger = __webpack_require__(24);
-var toLength = __webpack_require__(7);
+var toInteger = __webpack_require__(27);
+var toLength = __webpack_require__(9);
 var $native = [].lastIndexOf;
 var NEGATIVE_ZERO = !!$native && 1 / [1].lastIndexOf(1, -0) < 0;
 
-$export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(25)($native)), 'Array', {
+$export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(24)($native)), 'Array', {
   // 22.1.3.14 / 15.4.4.15 Array.prototype.lastIndexOf(searchElement [, fromIndex])
   lastIndexOf: function lastIndexOf(searchElement /* , fromIndex = @[*-1] */) {
     // convert -0 to +0
@@ -28677,29 +28474,29 @@ $export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(25)($nati
 });
 
 /***/ }),
-/* 264 */
+/* 259 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.3.3 Array.prototype.copyWithin(target, start, end = this.length)
 var $export = __webpack_require__(0);
 
-$export($export.P, 'Array', { copyWithin: __webpack_require__(125) });
+$export($export.P, 'Array', { copyWithin: __webpack_require__(121) });
 
 __webpack_require__(34)('copyWithin');
 
 /***/ }),
-/* 265 */
+/* 260 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.3.6 Array.prototype.fill(value, start = 0, end = this.length)
 var $export = __webpack_require__(0);
 
-$export($export.P, 'Array', { fill: __webpack_require__(97) });
+$export($export.P, 'Array', { fill: __webpack_require__(96) });
 
 __webpack_require__(34)('fill');
 
 /***/ }),
-/* 266 */
+/* 261 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28722,7 +28519,7 @@ $export($export.P + $export.F * forced, 'Array', {
 __webpack_require__(34)(KEY);
 
 /***/ }),
-/* 267 */
+/* 262 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28745,21 +28542,21 @@ $export($export.P + $export.F * forced, 'Array', {
 __webpack_require__(34)(KEY);
 
 /***/ }),
-/* 268 */
+/* 263 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(41)('Array');
 
 /***/ }),
-/* 269 */
+/* 264 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var global = __webpack_require__(2);
-var inheritIfRequired = __webpack_require__(85);
-var dP = __webpack_require__(9).f;
+var global = __webpack_require__(3);
+var inheritIfRequired = __webpack_require__(83);
+var dP = __webpack_require__(8).f;
 var gOPN = __webpack_require__(40).f;
-var isRegExp = __webpack_require__(63);
-var $flags = __webpack_require__(54);
+var isRegExp = __webpack_require__(60);
+var $flags = __webpack_require__(62);
 var $RegExp = global.RegExp;
 var Base = $RegExp;
 var proto = $RegExp.prototype;
@@ -28768,7 +28565,7 @@ var re2 = /a/g;
 // "new" creates a new object, old webkit buggy here
 var CORRECT_NEW = new $RegExp(re1) !== re1;
 
-if (__webpack_require__(8) && (!CORRECT_NEW || __webpack_require__(4)(function () {
+if (__webpack_require__(7) && (!CORRECT_NEW || __webpack_require__(4)(function () {
   re2[__webpack_require__(6)('match')] = false;
   // RegExp constructor can alter flags and IsRegExp works correct with @@match
   return $RegExp(re1) != re1 || $RegExp(re2) == re2 || $RegExp(re1, 'i') != '/a/i';
@@ -28800,16 +28597,16 @@ if (__webpack_require__(8) && (!CORRECT_NEW || __webpack_require__(4)(function (
 __webpack_require__(41)('RegExp');
 
 /***/ }),
-/* 270 */
+/* 265 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-__webpack_require__(128);
+__webpack_require__(123);
 var anObject = __webpack_require__(1);
-var $flags = __webpack_require__(54);
-var DESCRIPTORS = __webpack_require__(8);
+var $flags = __webpack_require__(62);
+var DESCRIPTORS = __webpack_require__(7);
 var TO_STRING = 'toString';
 var $toString = /./[TO_STRING];
 
@@ -28833,261 +28630,96 @@ if (__webpack_require__(4)(function () {
 }
 
 /***/ }),
-/* 271 */
+/* 266 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-
-
-var anObject = __webpack_require__(1);
-var toLength = __webpack_require__(7);
-var advanceStringIndex = __webpack_require__(100);
-var regExpExec = __webpack_require__(65);
-
 // @@match logic
-__webpack_require__(66)('match', 1, function (defined, MATCH, $match, maybeCallNative) {
-  return [
-  // `String.prototype.match` method
-  // https://tc39.github.io/ecma262/#sec-string.prototype.match
-  function match(regexp) {
+__webpack_require__(63)('match', 1, function (defined, MATCH, $match) {
+  // 21.1.3.11 String.prototype.match(regexp)
+  return [function match(regexp) {
+    'use strict';
+
     var O = defined(this);
     var fn = regexp == undefined ? undefined : regexp[MATCH];
     return fn !== undefined ? fn.call(regexp, O) : new RegExp(regexp)[MATCH](String(O));
-  },
-  // `RegExp.prototype[@@match]` method
-  // https://tc39.github.io/ecma262/#sec-regexp.prototype-@@match
-  function (regexp) {
-    var res = maybeCallNative($match, regexp, this);
-    if (res.done) return res.value;
-    var rx = anObject(regexp);
-    var S = String(this);
-    if (!rx.global) return regExpExec(rx, S);
-    var fullUnicode = rx.unicode;
-    rx.lastIndex = 0;
-    var A = [];
-    var n = 0;
-    var result;
-    while ((result = regExpExec(rx, S)) !== null) {
-      var matchStr = String(result[0]);
-      A[n] = matchStr;
-      if (matchStr === '') rx.lastIndex = advanceStringIndex(S, toLength(rx.lastIndex), fullUnicode);
-      n++;
-    }
-    return n === 0 ? null : A;
-  }];
+  }, $match];
 });
 
 /***/ }),
-/* 272 */
+/* 267 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-
-
-var anObject = __webpack_require__(1);
-var toObject = __webpack_require__(10);
-var toLength = __webpack_require__(7);
-var toInteger = __webpack_require__(24);
-var advanceStringIndex = __webpack_require__(100);
-var regExpExec = __webpack_require__(65);
-var max = Math.max;
-var min = Math.min;
-var floor = Math.floor;
-var SUBSTITUTION_SYMBOLS = /\$([$&`']|\d\d?|<[^>]*>)/g;
-var SUBSTITUTION_SYMBOLS_NO_NAMED = /\$([$&`']|\d\d?)/g;
-
-var maybeToString = function maybeToString(it) {
-  return it === undefined ? it : String(it);
-};
-
 // @@replace logic
-__webpack_require__(66)('replace', 2, function (defined, REPLACE, $replace, maybeCallNative) {
-  return [
-  // `String.prototype.replace` method
-  // https://tc39.github.io/ecma262/#sec-string.prototype.replace
-  function replace(searchValue, replaceValue) {
+__webpack_require__(63)('replace', 2, function (defined, REPLACE, $replace) {
+  // 21.1.3.14 String.prototype.replace(searchValue, replaceValue)
+  return [function replace(searchValue, replaceValue) {
+    'use strict';
+
     var O = defined(this);
     var fn = searchValue == undefined ? undefined : searchValue[REPLACE];
     return fn !== undefined ? fn.call(searchValue, O, replaceValue) : $replace.call(String(O), searchValue, replaceValue);
-  },
-  // `RegExp.prototype[@@replace]` method
-  // https://tc39.github.io/ecma262/#sec-regexp.prototype-@@replace
-  function (regexp, replaceValue) {
-    var res = maybeCallNative($replace, regexp, this, replaceValue);
-    if (res.done) return res.value;
-
-    var rx = anObject(regexp);
-    var S = String(this);
-    var functionalReplace = typeof replaceValue === 'function';
-    if (!functionalReplace) replaceValue = String(replaceValue);
-    var global = rx.global;
-    if (global) {
-      var fullUnicode = rx.unicode;
-      rx.lastIndex = 0;
-    }
-    var results = [];
-    while (true) {
-      var result = regExpExec(rx, S);
-      if (result === null) break;
-      results.push(result);
-      if (!global) break;
-      var matchStr = String(result[0]);
-      if (matchStr === '') rx.lastIndex = advanceStringIndex(S, toLength(rx.lastIndex), fullUnicode);
-    }
-    var accumulatedResult = '';
-    var nextSourcePosition = 0;
-    for (var i = 0; i < results.length; i++) {
-      result = results[i];
-      var matched = String(result[0]);
-      var position = max(min(toInteger(result.index), S.length), 0);
-      var captures = [];
-      // NOTE: This is equivalent to
-      //   captures = result.slice(1).map(maybeToString)
-      // but for some reason `nativeSlice.call(result, 1, result.length)` (called in
-      // the slice polyfill when slicing native arrays) "doesn't work" in safari 9 and
-      // causes a crash (https://pastebin.com/N21QzeQA) when trying to debug it.
-      for (var j = 1; j < result.length; j++) {
-        captures.push(maybeToString(result[j]));
-      }var namedCaptures = result.groups;
-      if (functionalReplace) {
-        var replacerArgs = [matched].concat(captures, position, S);
-        if (namedCaptures !== undefined) replacerArgs.push(namedCaptures);
-        var replacement = String(replaceValue.apply(undefined, replacerArgs));
-      } else {
-        replacement = getSubstitution(matched, S, position, captures, namedCaptures, replaceValue);
-      }
-      if (position >= nextSourcePosition) {
-        accumulatedResult += S.slice(nextSourcePosition, position) + replacement;
-        nextSourcePosition = position + matched.length;
-      }
-    }
-    return accumulatedResult + S.slice(nextSourcePosition);
-  }];
-
-  // https://tc39.github.io/ecma262/#sec-getsubstitution
-  function getSubstitution(matched, str, position, captures, namedCaptures, replacement) {
-    var tailPos = position + matched.length;
-    var m = captures.length;
-    var symbols = SUBSTITUTION_SYMBOLS_NO_NAMED;
-    if (namedCaptures !== undefined) {
-      namedCaptures = toObject(namedCaptures);
-      symbols = SUBSTITUTION_SYMBOLS;
-    }
-    return $replace.call(replacement, symbols, function (match, ch) {
-      var capture;
-      switch (ch.charAt(0)) {
-        case '$':
-          return '$';
-        case '&':
-          return matched;
-        case '`':
-          return str.slice(0, position);
-        case "'":
-          return str.slice(tailPos);
-        case '<':
-          capture = namedCaptures[ch.slice(1, -1)];
-          break;
-        default:
-          // \d\d?
-          var n = +ch;
-          if (n === 0) return match;
-          if (n > m) {
-            var f = floor(n / 10);
-            if (f === 0) return match;
-            if (f <= m) return captures[f - 1] === undefined ? ch.charAt(1) : captures[f - 1] + ch.charAt(1);
-            return match;
-          }
-          capture = captures[n - 1];
-      }
-      return capture === undefined ? '' : capture;
-    });
-  }
+  }, $replace];
 });
 
 /***/ }),
-/* 273 */
+/* 268 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-
-
-var anObject = __webpack_require__(1);
-var sameValue = __webpack_require__(114);
-var regExpExec = __webpack_require__(65);
-
 // @@search logic
-__webpack_require__(66)('search', 1, function (defined, SEARCH, $search, maybeCallNative) {
-  return [
-  // `String.prototype.search` method
-  // https://tc39.github.io/ecma262/#sec-string.prototype.search
-  function search(regexp) {
+__webpack_require__(63)('search', 1, function (defined, SEARCH, $search) {
+  // 21.1.3.15 String.prototype.search(regexp)
+  return [function search(regexp) {
+    'use strict';
+
     var O = defined(this);
     var fn = regexp == undefined ? undefined : regexp[SEARCH];
     return fn !== undefined ? fn.call(regexp, O) : new RegExp(regexp)[SEARCH](String(O));
-  },
-  // `RegExp.prototype[@@search]` method
-  // https://tc39.github.io/ecma262/#sec-regexp.prototype-@@search
-  function (regexp) {
-    var res = maybeCallNative($search, regexp, this);
-    if (res.done) return res.value;
-    var rx = anObject(regexp);
-    var S = String(this);
-    var previousLastIndex = rx.lastIndex;
-    if (!sameValue(previousLastIndex, 0)) rx.lastIndex = 0;
-    var result = regExpExec(rx, S);
-    if (!sameValue(rx.lastIndex, previousLastIndex)) rx.lastIndex = previousLastIndex;
-    return result === null ? -1 : result.index;
-  }];
+  }, $search];
 });
 
 /***/ }),
-/* 274 */
+/* 269 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-
-
-var isRegExp = __webpack_require__(63);
-var anObject = __webpack_require__(1);
-var speciesConstructor = __webpack_require__(55);
-var advanceStringIndex = __webpack_require__(100);
-var toLength = __webpack_require__(7);
-var callRegExpExec = __webpack_require__(65);
-var regexpExec = __webpack_require__(99);
-var fails = __webpack_require__(4);
-var $min = Math.min;
-var $push = [].push;
-var $SPLIT = 'split';
-var LENGTH = 'length';
-var LAST_INDEX = 'lastIndex';
-var MAX_UINT32 = 0xffffffff;
-
-// babel-minify transpiles RegExp('x', 'y') -> /x/y and it causes SyntaxError
-var SUPPORTS_Y = !fails(function () {
-  RegExp(MAX_UINT32, 'y');
-});
-
 // @@split logic
-__webpack_require__(66)('split', 2, function (defined, SPLIT, $split, maybeCallNative) {
-  var internalSplit;
+__webpack_require__(63)('split', 2, function (defined, SPLIT, $split) {
+  'use strict';
+
+  var isRegExp = __webpack_require__(60);
+  var _split = $split;
+  var $push = [].push;
+  var $SPLIT = 'split';
+  var LENGTH = 'length';
+  var LAST_INDEX = 'lastIndex';
   if ('abbc'[$SPLIT](/(b)*/)[1] == 'c' || 'test'[$SPLIT](/(?:)/, -1)[LENGTH] != 4 || 'ab'[$SPLIT](/(?:ab)*/)[LENGTH] != 2 || '.'[$SPLIT](/(.?)(.?)/)[LENGTH] != 4 || '.'[$SPLIT](/()()/)[LENGTH] > 1 || ''[$SPLIT](/.?/)[LENGTH]) {
+    var NPCG = /()??/.exec('')[1] === undefined; // nonparticipating capturing group
     // based on es5-shim implementation, need to rework it
-    internalSplit = function internalSplit(separator, limit) {
+    $split = function $split(separator, limit) {
       var string = String(this);
       if (separator === undefined && limit === 0) return [];
       // If `separator` is not a regex, use native split
-      if (!isRegExp(separator)) return $split.call(string, separator, limit);
+      if (!isRegExp(separator)) return _split.call(string, separator, limit);
       var output = [];
       var flags = (separator.ignoreCase ? 'i' : '') + (separator.multiline ? 'm' : '') + (separator.unicode ? 'u' : '') + (separator.sticky ? 'y' : '');
       var lastLastIndex = 0;
-      var splitLimit = limit === undefined ? MAX_UINT32 : limit >>> 0;
+      var splitLimit = limit === undefined ? 4294967295 : limit >>> 0;
       // Make `global` and avoid `lastIndex` issues by working with a copy
       var separatorCopy = new RegExp(separator.source, flags + 'g');
-      var match, lastIndex, lastLength;
-      while (match = regexpExec.call(separatorCopy, string)) {
-        lastIndex = separatorCopy[LAST_INDEX];
+      var separator2, match, lastIndex, lastLength, i;
+      // Doesn't need flags gy, but they don't hurt
+      if (!NPCG) separator2 = new RegExp('^' + separatorCopy.source + '$(?!\\s)', flags);
+      while (match = separatorCopy.exec(string)) {
+        // `separatorCopy.lastIndex` is not reliable cross-browser
+        lastIndex = match.index + match[0][LENGTH];
         if (lastIndex > lastLastIndex) {
           output.push(string.slice(lastLastIndex, match.index));
+          // Fix browsers whose `exec` methods don't consistently return `undefined` for NPCG
+          // eslint-disable-next-line no-loop-func
+          if (!NPCG && match[LENGTH] > 1) match[0].replace(separator2, function () {
+            for (i = 1; i < arguments[LENGTH] - 2; i++) {
+              if (arguments[i] === undefined) match[i] = undefined;
+            }
+          });
           if (match[LENGTH] > 1 && match.index < string[LENGTH]) $push.apply(output, match.slice(1));
           lastLength = match[0][LENGTH];
           lastLastIndex = lastIndex;
@@ -29102,90 +28734,41 @@ __webpack_require__(66)('split', 2, function (defined, SPLIT, $split, maybeCallN
     };
     // Chakra, V8
   } else if ('0'[$SPLIT](undefined, 0)[LENGTH]) {
-    internalSplit = function internalSplit(separator, limit) {
-      return separator === undefined && limit === 0 ? [] : $split.call(this, separator, limit);
+    $split = function $split(separator, limit) {
+      return separator === undefined && limit === 0 ? [] : _split.call(this, separator, limit);
     };
-  } else {
-    internalSplit = $split;
   }
-
-  return [
-  // `String.prototype.split` method
-  // https://tc39.github.io/ecma262/#sec-string.prototype.split
-  function split(separator, limit) {
+  // 21.1.3.17 String.prototype.split(separator, limit)
+  return [function split(separator, limit) {
     var O = defined(this);
-    var splitter = separator == undefined ? undefined : separator[SPLIT];
-    return splitter !== undefined ? splitter.call(separator, O, limit) : internalSplit.call(String(O), separator, limit);
-  },
-  // `RegExp.prototype[@@split]` method
-  // https://tc39.github.io/ecma262/#sec-regexp.prototype-@@split
-  //
-  // NOTE: This cannot be properly polyfilled in engines that don't support
-  // the 'y' flag.
-  function (regexp, limit) {
-    var res = maybeCallNative(internalSplit, regexp, this, limit, internalSplit !== $split);
-    if (res.done) return res.value;
-
-    var rx = anObject(regexp);
-    var S = String(this);
-    var C = speciesConstructor(rx, RegExp);
-
-    var unicodeMatching = rx.unicode;
-    var flags = (rx.ignoreCase ? 'i' : '') + (rx.multiline ? 'm' : '') + (rx.unicode ? 'u' : '') + (SUPPORTS_Y ? 'y' : 'g');
-
-    // ^(? + rx + ) is needed, in combination with some S slicing, to
-    // simulate the 'y' flag.
-    var splitter = new C(SUPPORTS_Y ? rx : '^(?:' + rx.source + ')', flags);
-    var lim = limit === undefined ? MAX_UINT32 : limit >>> 0;
-    if (lim === 0) return [];
-    if (S.length === 0) return callRegExpExec(splitter, S) === null ? [S] : [];
-    var p = 0;
-    var q = 0;
-    var A = [];
-    while (q < S.length) {
-      splitter.lastIndex = SUPPORTS_Y ? q : 0;
-      var z = callRegExpExec(splitter, SUPPORTS_Y ? S : S.slice(q));
-      var e;
-      if (z === null || (e = $min(toLength(splitter.lastIndex + (SUPPORTS_Y ? 0 : q)), S.length)) === p) {
-        q = advanceStringIndex(S, q, unicodeMatching);
-      } else {
-        A.push(S.slice(p, q));
-        if (A.length === lim) return A;
-        for (var i = 1; i <= z.length - 1; i++) {
-          A.push(z[i]);
-          if (A.length === lim) return A;
-        }
-        q = p = e;
-      }
-    }
-    A.push(S.slice(p));
-    return A;
-  }];
+    var fn = separator == undefined ? undefined : separator[SPLIT];
+    return fn !== undefined ? fn.call(separator, O, limit) : $split.call(String(O), separator, limit);
+  }, $split];
 });
 
 /***/ }),
-/* 275 */
+/* 270 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var LIBRARY = __webpack_require__(32);
-var global = __webpack_require__(2);
+var LIBRARY = __webpack_require__(33);
+var global = __webpack_require__(3);
 var ctx = __webpack_require__(22);
-var classof = __webpack_require__(48);
+var classof = __webpack_require__(52);
 var $export = __webpack_require__(0);
 var isObject = __webpack_require__(5);
 var aFunction = __webpack_require__(13);
 var anInstance = __webpack_require__(42);
 var forOf = __webpack_require__(43);
-var speciesConstructor = __webpack_require__(55);
-var task = __webpack_require__(101).set;
-var microtask = __webpack_require__(102)();
-var newPromiseCapabilityModule = __webpack_require__(103);
-var perform = __webpack_require__(129);
-var userAgent = __webpack_require__(67);
-var promiseResolve = __webpack_require__(130);
+var speciesConstructor = __webpack_require__(64);
+var task = __webpack_require__(98).set;
+var microtask = __webpack_require__(99)();
+var newPromiseCapabilityModule = __webpack_require__(100);
+var perform = __webpack_require__(124);
+var userAgent = __webpack_require__(65);
+var promiseResolve = __webpack_require__(125);
 var PROMISE = 'Promise';
 var TypeError = global.TypeError;
 var process = global.process;
@@ -29388,7 +28971,7 @@ if (!USE_NATIVE) {
 }
 
 $export($export.G + $export.W + $export.F * !USE_NATIVE, { Promise: $Promise });
-__webpack_require__(47)($Promise, PROMISE);
+__webpack_require__(46)($Promise, PROMISE);
 __webpack_require__(41)(PROMISE);
 Wrapper = __webpack_require__(21)[PROMISE];
 
@@ -29408,7 +28991,7 @@ $export($export.S + $export.F * (LIBRARY || !USE_NATIVE), PROMISE, {
     return promiseResolve(LIBRARY && this === Wrapper ? $Promise : this, x);
   }
 });
-$export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(64)(function (iter) {
+$export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(61)(function (iter) {
   $Promise.all(iter)['catch'](empty);
 })), PROMISE, {
   // 25.4.4.1 Promise.all(iterable)
@@ -29454,18 +29037,18 @@ $export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(64)(function
 });
 
 /***/ }),
-/* 276 */
+/* 271 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var weak = __webpack_require__(135);
-var validate = __webpack_require__(45);
+var weak = __webpack_require__(130);
+var validate = __webpack_require__(49);
 var WEAK_SET = 'WeakSet';
 
 // 23.4 WeakSet Objects
-__webpack_require__(68)(WEAK_SET, function (get) {
+__webpack_require__(66)(WEAK_SET, function (get) {
   return function WeakSet() {
     return get(this, arguments.length > 0 ? arguments[0] : undefined);
   };
@@ -29477,21 +29060,21 @@ __webpack_require__(68)(WEAK_SET, function (get) {
 }, weak, false, true);
 
 /***/ }),
-/* 277 */
+/* 272 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var $typed = __webpack_require__(69);
-var buffer = __webpack_require__(104);
+var $typed = __webpack_require__(67);
+var buffer = __webpack_require__(101);
 var anObject = __webpack_require__(1);
 var toAbsoluteIndex = __webpack_require__(38);
-var toLength = __webpack_require__(7);
+var toLength = __webpack_require__(9);
 var isObject = __webpack_require__(5);
-var ArrayBuffer = __webpack_require__(2).ArrayBuffer;
-var speciesConstructor = __webpack_require__(55);
+var ArrayBuffer = __webpack_require__(3).ArrayBuffer;
+var speciesConstructor = __webpack_require__(64);
 var $ArrayBuffer = buffer.ArrayBuffer;
 var $DataView = buffer.DataView;
 var $isView = $typed.ABV && ArrayBuffer.isView;
@@ -29530,16 +29113,16 @@ $export($export.P + $export.U + $export.F * __webpack_require__(4)(function () {
 __webpack_require__(41)(ARRAY_BUFFER);
 
 /***/ }),
-/* 278 */
+/* 273 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-$export($export.G + $export.W + $export.F * !__webpack_require__(69).ABV, {
-  DataView: __webpack_require__(104).DataView
+$export($export.G + $export.W + $export.F * !__webpack_require__(67).ABV, {
+  DataView: __webpack_require__(101).DataView
 });
 
 /***/ }),
-/* 279 */
+/* 274 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Int8', 1, function (init) {
@@ -29549,7 +29132,7 @@ __webpack_require__(30)('Int8', 1, function (init) {
 });
 
 /***/ }),
-/* 280 */
+/* 275 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Uint8', 1, function (init) {
@@ -29559,7 +29142,7 @@ __webpack_require__(30)('Uint8', 1, function (init) {
 });
 
 /***/ }),
-/* 281 */
+/* 276 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Uint8', 1, function (init) {
@@ -29569,7 +29152,7 @@ __webpack_require__(30)('Uint8', 1, function (init) {
 }, true);
 
 /***/ }),
-/* 282 */
+/* 277 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Int16', 2, function (init) {
@@ -29579,7 +29162,7 @@ __webpack_require__(30)('Int16', 2, function (init) {
 });
 
 /***/ }),
-/* 283 */
+/* 278 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Uint16', 2, function (init) {
@@ -29589,7 +29172,7 @@ __webpack_require__(30)('Uint16', 2, function (init) {
 });
 
 /***/ }),
-/* 284 */
+/* 279 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Int32', 4, function (init) {
@@ -29599,7 +29182,7 @@ __webpack_require__(30)('Int32', 4, function (init) {
 });
 
 /***/ }),
-/* 285 */
+/* 280 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Uint32', 4, function (init) {
@@ -29609,7 +29192,7 @@ __webpack_require__(30)('Uint32', 4, function (init) {
 });
 
 /***/ }),
-/* 286 */
+/* 281 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Float32', 4, function (init) {
@@ -29619,7 +29202,7 @@ __webpack_require__(30)('Float32', 4, function (init) {
 });
 
 /***/ }),
-/* 287 */
+/* 282 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(30)('Float64', 8, function (init) {
@@ -29629,14 +29212,14 @@ __webpack_require__(30)('Float64', 8, function (init) {
 });
 
 /***/ }),
-/* 288 */
+/* 283 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.1 Reflect.apply(target, thisArgument, argumentsList)
 var $export = __webpack_require__(0);
 var aFunction = __webpack_require__(13);
 var anObject = __webpack_require__(1);
-var rApply = (__webpack_require__(2).Reflect || {}).apply;
+var rApply = (__webpack_require__(3).Reflect || {}).apply;
 var fApply = Function.apply;
 // MS Edge argumentsList argument is optional
 $export($export.S + $export.F * !__webpack_require__(4)(function () {
@@ -29650,7 +29233,7 @@ $export($export.S + $export.F * !__webpack_require__(4)(function () {
 });
 
 /***/ }),
-/* 289 */
+/* 284 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.2 Reflect.construct(target, argumentsList [, newTarget])
@@ -29660,8 +29243,8 @@ var aFunction = __webpack_require__(13);
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
 var fails = __webpack_require__(4);
-var bind = __webpack_require__(115);
-var rConstruct = (__webpack_require__(2).Reflect || {}).construct;
+var bind = __webpack_require__(111);
+var rConstruct = (__webpack_require__(3).Reflect || {}).construct;
 
 // MS Edge supports only 2 arguments and argumentsList argument is optional
 // FF Nightly sets third argument as `new.target`, but does not create `this` from it
@@ -29707,14 +29290,14 @@ $export($export.S + $export.F * (NEW_TARGET_BUG || ARGS_BUG), 'Reflect', {
 });
 
 /***/ }),
-/* 290 */
+/* 285 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.3 Reflect.defineProperty(target, propertyKey, attributes)
-var dP = __webpack_require__(9);
+var dP = __webpack_require__(8);
 var $export = __webpack_require__(0);
 var anObject = __webpack_require__(1);
-var toPrimitive = __webpack_require__(26);
+var toPrimitive = __webpack_require__(25);
 
 // MS Edge has broken Reflect.defineProperty - throwing instead of returning false
 $export($export.S + $export.F * __webpack_require__(4)(function () {
@@ -29735,7 +29318,7 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-/* 291 */
+/* 286 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.4 Reflect.deleteProperty(target, propertyKey)
@@ -29751,7 +29334,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-/* 292 */
+/* 287 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -29769,7 +29352,7 @@ var Enumerate = function Enumerate(iterated) {
     keys.push(key);
   }
 };
-__webpack_require__(90)(Enumerate, 'Object', function () {
+__webpack_require__(89)(Enumerate, 'Object', function () {
   var that = this;
   var keys = that._k;
   var key;
@@ -29786,7 +29369,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-/* 293 */
+/* 288 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.6 Reflect.get(target, propertyKey [, receiver])
@@ -29808,7 +29391,7 @@ function get(target, propertyKey /* , receiver */) {
 $export($export.S, 'Reflect', { get: get });
 
 /***/ }),
-/* 294 */
+/* 289 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.7 Reflect.getOwnPropertyDescriptor(target, propertyKey)
@@ -29823,7 +29406,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-/* 295 */
+/* 290 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.8 Reflect.getPrototypeOf(target)
@@ -29838,7 +29421,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-/* 296 */
+/* 291 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.9 Reflect.has(target, propertyKey)
@@ -29851,7 +29434,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-/* 297 */
+/* 292 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.10 Reflect.isExtensible(target)
@@ -29867,16 +29450,16 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-/* 298 */
+/* 293 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.11 Reflect.ownKeys(target)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Reflect', { ownKeys: __webpack_require__(137) });
+$export($export.S, 'Reflect', { ownKeys: __webpack_require__(132) });
 
 /***/ }),
-/* 299 */
+/* 294 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.12 Reflect.preventExtensions(target)
@@ -29897,11 +29480,11 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-/* 300 */
+/* 295 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.13 Reflect.set(target, propertyKey, V [, receiver])
-var dP = __webpack_require__(9);
+var dP = __webpack_require__(8);
 var gOPD = __webpack_require__(19);
 var getPrototypeOf = __webpack_require__(20);
 var has = __webpack_require__(17);
@@ -29935,12 +29518,12 @@ function set(target, propertyKey, V /* , receiver */) {
 $export($export.S, 'Reflect', { set: set });
 
 /***/ }),
-/* 301 */
+/* 296 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.14 Reflect.setPrototypeOf(target, proto)
 var $export = __webpack_require__(0);
-var setProto = __webpack_require__(83);
+var setProto = __webpack_require__(81);
 
 if (setProto) $export($export.S, 'Reflect', {
   setPrototypeOf: function setPrototypeOf(target, proto) {
@@ -29955,7 +29538,7 @@ if (setProto) $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-/* 302 */
+/* 297 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -29963,7 +29546,7 @@ if (setProto) $export($export.S, 'Reflect', {
 // https://github.com/tc39/Array.prototype.includes
 
 var $export = __webpack_require__(0);
-var $includes = __webpack_require__(59)(true);
+var $includes = __webpack_require__(57)(true);
 
 $export($export.P, 'Array', {
   includes: function includes(el /* , fromIndex = 0 */) {
@@ -29974,7 +29557,7 @@ $export($export.P, 'Array', {
 __webpack_require__(34)('includes');
 
 /***/ }),
-/* 303 */
+/* 298 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -29982,11 +29565,11 @@ __webpack_require__(34)('includes');
 // https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flatMap
 
 var $export = __webpack_require__(0);
-var flattenIntoArray = __webpack_require__(138);
-var toObject = __webpack_require__(10);
-var toLength = __webpack_require__(7);
+var flattenIntoArray = __webpack_require__(133);
+var toObject = __webpack_require__(11);
+var toLength = __webpack_require__(9);
 var aFunction = __webpack_require__(13);
-var arraySpeciesCreate = __webpack_require__(96);
+var arraySpeciesCreate = __webpack_require__(95);
 
 $export($export.P, 'Array', {
   flatMap: function flatMap(callbackfn /* , thisArg */) {
@@ -30003,7 +29586,7 @@ $export($export.P, 'Array', {
 __webpack_require__(34)('flatMap');
 
 /***/ }),
-/* 304 */
+/* 299 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30011,11 +29594,11 @@ __webpack_require__(34)('flatMap');
 // https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flatten
 
 var $export = __webpack_require__(0);
-var flattenIntoArray = __webpack_require__(138);
-var toObject = __webpack_require__(10);
-var toLength = __webpack_require__(7);
-var toInteger = __webpack_require__(24);
-var arraySpeciesCreate = __webpack_require__(96);
+var flattenIntoArray = __webpack_require__(133);
+var toObject = __webpack_require__(11);
+var toLength = __webpack_require__(9);
+var toInteger = __webpack_require__(27);
+var arraySpeciesCreate = __webpack_require__(95);
 
 $export($export.P, 'Array', {
   flatten: function flatten() /* depthArg = 1 */{
@@ -30031,7 +29614,7 @@ $export($export.P, 'Array', {
 __webpack_require__(34)('flatten');
 
 /***/ }),
-/* 305 */
+/* 300 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30039,7 +29622,7 @@ __webpack_require__(34)('flatten');
 // https://github.com/mathiasbynens/String.prototype.at
 
 var $export = __webpack_require__(0);
-var $at = __webpack_require__(62)(true);
+var $at = __webpack_require__(87)(true);
 
 $export($export.P, 'String', {
   at: function at(pos) {
@@ -30048,7 +29631,7 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
-/* 306 */
+/* 301 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30056,20 +29639,18 @@ $export($export.P, 'String', {
 // https://github.com/tc39/proposal-string-pad-start-end
 
 var $export = __webpack_require__(0);
-var $pad = __webpack_require__(139);
-var userAgent = __webpack_require__(67);
+var $pad = __webpack_require__(134);
+var userAgent = __webpack_require__(65);
 
 // https://github.com/zloirock/core-js/issues/280
-var WEBKIT_BUG = /Version\/10\.\d+(\.\d+)?( Mobile\/\w+)? Safari\//.test(userAgent);
-
-$export($export.P + $export.F * WEBKIT_BUG, 'String', {
+$export($export.P + $export.F * /Version\/10\.\d+(\.\d+)? Safari\//.test(userAgent), 'String', {
   padStart: function padStart(maxLength /* , fillString = ' ' */) {
     return $pad(this, maxLength, arguments.length > 1 ? arguments[1] : undefined, true);
   }
 });
 
 /***/ }),
-/* 307 */
+/* 302 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30077,48 +29658,46 @@ $export($export.P + $export.F * WEBKIT_BUG, 'String', {
 // https://github.com/tc39/proposal-string-pad-start-end
 
 var $export = __webpack_require__(0);
-var $pad = __webpack_require__(139);
-var userAgent = __webpack_require__(67);
+var $pad = __webpack_require__(134);
+var userAgent = __webpack_require__(65);
 
 // https://github.com/zloirock/core-js/issues/280
-var WEBKIT_BUG = /Version\/10\.\d+(\.\d+)?( Mobile\/\w+)? Safari\//.test(userAgent);
-
-$export($export.P + $export.F * WEBKIT_BUG, 'String', {
+$export($export.P + $export.F * /Version\/10\.\d+(\.\d+)? Safari\//.test(userAgent), 'String', {
   padEnd: function padEnd(maxLength /* , fillString = ' ' */) {
     return $pad(this, maxLength, arguments.length > 1 ? arguments[1] : undefined, false);
   }
 });
 
 /***/ }),
-/* 308 */
+/* 303 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 // https://github.com/sebmarkbage/ecmascript-string-left-right-trim
 
-__webpack_require__(49)('trimLeft', function ($trim) {
+__webpack_require__(47)('trimLeft', function ($trim) {
   return function trimLeft() {
     return $trim(this, 1);
   };
 }, 'trimStart');
 
 /***/ }),
-/* 309 */
+/* 304 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 // https://github.com/sebmarkbage/ecmascript-string-left-right-trim
 
-__webpack_require__(49)('trimRight', function ($trim) {
+__webpack_require__(47)('trimRight', function ($trim) {
   return function trimRight() {
     return $trim(this, 2);
   };
 }, 'trimEnd');
 
 /***/ }),
-/* 310 */
+/* 305 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30126,10 +29705,10 @@ __webpack_require__(49)('trimRight', function ($trim) {
 // https://tc39.github.io/String.prototype.matchAll/
 
 var $export = __webpack_require__(0);
-var defined = __webpack_require__(27);
-var toLength = __webpack_require__(7);
-var isRegExp = __webpack_require__(63);
-var getFlags = __webpack_require__(54);
+var defined = __webpack_require__(26);
+var toLength = __webpack_require__(9);
+var isRegExp = __webpack_require__(60);
+var getFlags = __webpack_require__(62);
 var RegExpProto = RegExp.prototype;
 
 var $RegExpStringIterator = function $RegExpStringIterator(regexp, string) {
@@ -30137,7 +29716,7 @@ var $RegExpStringIterator = function $RegExpStringIterator(regexp, string) {
   this._s = string;
 };
 
-__webpack_require__(90)($RegExpStringIterator, 'RegExp String', function next() {
+__webpack_require__(89)($RegExpStringIterator, 'RegExp String', function next() {
   var match = this._r.exec(this._s);
   return { value: match, done: match === null };
 });
@@ -30155,27 +29734,27 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
-/* 311 */
+/* 306 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(79)('asyncIterator');
+__webpack_require__(77)('asyncIterator');
 
 /***/ }),
-/* 312 */
+/* 307 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(79)('observable');
+__webpack_require__(77)('observable');
 
 /***/ }),
-/* 313 */
+/* 308 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-getownpropertydescriptors
 var $export = __webpack_require__(0);
-var ownKeys = __webpack_require__(137);
+var ownKeys = __webpack_require__(132);
 var toIObject = __webpack_require__(18);
 var gOPD = __webpack_require__(19);
-var createProperty = __webpack_require__(94);
+var createProperty = __webpack_require__(93);
 
 $export($export.S, 'Object', {
   getOwnPropertyDescriptors: function getOwnPropertyDescriptors(object) {
@@ -30194,12 +29773,12 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
-/* 314 */
+/* 309 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-values-entries
 var $export = __webpack_require__(0);
-var $values = __webpack_require__(140)(false);
+var $values = __webpack_require__(135)(false);
 
 $export($export.S, 'Object', {
   values: function values(it) {
@@ -30208,12 +29787,12 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
-/* 315 */
+/* 310 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-values-entries
 var $export = __webpack_require__(0);
-var $entries = __webpack_require__(140)(true);
+var $entries = __webpack_require__(135)(true);
 
 $export($export.S, 'Object', {
   entries: function entries(it) {
@@ -30222,58 +29801,58 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
-/* 316 */
+/* 311 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var toObject = __webpack_require__(10);
+var toObject = __webpack_require__(11);
 var aFunction = __webpack_require__(13);
-var $defineProperty = __webpack_require__(9);
+var $defineProperty = __webpack_require__(8);
 
 // B.2.2.2 Object.prototype.__defineGetter__(P, getter)
-__webpack_require__(8) && $export($export.P + __webpack_require__(70), 'Object', {
+__webpack_require__(7) && $export($export.P + __webpack_require__(68), 'Object', {
   __defineGetter__: function __defineGetter__(P, getter) {
     $defineProperty.f(toObject(this), P, { get: aFunction(getter), enumerable: true, configurable: true });
   }
 });
 
 /***/ }),
-/* 317 */
+/* 312 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var toObject = __webpack_require__(10);
+var toObject = __webpack_require__(11);
 var aFunction = __webpack_require__(13);
-var $defineProperty = __webpack_require__(9);
+var $defineProperty = __webpack_require__(8);
 
 // B.2.2.3 Object.prototype.__defineSetter__(P, setter)
-__webpack_require__(8) && $export($export.P + __webpack_require__(70), 'Object', {
+__webpack_require__(7) && $export($export.P + __webpack_require__(68), 'Object', {
   __defineSetter__: function __defineSetter__(P, setter) {
     $defineProperty.f(toObject(this), P, { set: aFunction(setter), enumerable: true, configurable: true });
   }
 });
 
 /***/ }),
-/* 318 */
+/* 313 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var toObject = __webpack_require__(10);
-var toPrimitive = __webpack_require__(26);
+var toObject = __webpack_require__(11);
+var toPrimitive = __webpack_require__(25);
 var getPrototypeOf = __webpack_require__(20);
 var getOwnPropertyDescriptor = __webpack_require__(19).f;
 
 // B.2.2.4 Object.prototype.__lookupGetter__(P)
-__webpack_require__(8) && $export($export.P + __webpack_require__(70), 'Object', {
+__webpack_require__(7) && $export($export.P + __webpack_require__(68), 'Object', {
   __lookupGetter__: function __lookupGetter__(P) {
     var O = toObject(this);
     var K = toPrimitive(P, true);
@@ -30285,20 +29864,20 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(70), 'Object',
 });
 
 /***/ }),
-/* 319 */
+/* 314 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var $export = __webpack_require__(0);
-var toObject = __webpack_require__(10);
-var toPrimitive = __webpack_require__(26);
+var toObject = __webpack_require__(11);
+var toPrimitive = __webpack_require__(25);
 var getPrototypeOf = __webpack_require__(20);
 var getOwnPropertyDescriptor = __webpack_require__(19).f;
 
 // B.2.2.5 Object.prototype.__lookupSetter__(P)
-__webpack_require__(8) && $export($export.P + __webpack_require__(70), 'Object', {
+__webpack_require__(7) && $export($export.P + __webpack_require__(68), 'Object', {
   __lookupSetter__: function __lookupSetter__(P) {
     var O = toObject(this);
     var K = toPrimitive(P, true);
@@ -30310,99 +29889,99 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(70), 'Object',
 });
 
 /***/ }),
-/* 320 */
+/* 315 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
 var $export = __webpack_require__(0);
 
-$export($export.P + $export.R, 'Map', { toJSON: __webpack_require__(141)('Map') });
+$export($export.P + $export.R, 'Map', { toJSON: __webpack_require__(136)('Map') });
+
+/***/ }),
+/* 316 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// https://github.com/DavidBruant/Map-Set.prototype.toJSON
+var $export = __webpack_require__(0);
+
+$export($export.P + $export.R, 'Set', { toJSON: __webpack_require__(136)('Set') });
+
+/***/ }),
+/* 317 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// https://tc39.github.io/proposal-setmap-offrom/#sec-map.of
+__webpack_require__(69)('Map');
+
+/***/ }),
+/* 318 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// https://tc39.github.io/proposal-setmap-offrom/#sec-set.of
+__webpack_require__(69)('Set');
+
+/***/ }),
+/* 319 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.of
+__webpack_require__(69)('WeakMap');
+
+/***/ }),
+/* 320 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.of
+__webpack_require__(69)('WeakSet');
 
 /***/ }),
 /* 321 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// https://github.com/DavidBruant/Map-Set.prototype.toJSON
-var $export = __webpack_require__(0);
-
-$export($export.P + $export.R, 'Set', { toJSON: __webpack_require__(141)('Set') });
+// https://tc39.github.io/proposal-setmap-offrom/#sec-map.from
+__webpack_require__(70)('Map');
 
 /***/ }),
 /* 322 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// https://tc39.github.io/proposal-setmap-offrom/#sec-map.of
-__webpack_require__(71)('Map');
+// https://tc39.github.io/proposal-setmap-offrom/#sec-set.from
+__webpack_require__(70)('Set');
 
 /***/ }),
 /* 323 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// https://tc39.github.io/proposal-setmap-offrom/#sec-set.of
-__webpack_require__(71)('Set');
+// https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.from
+__webpack_require__(70)('WeakMap');
 
 /***/ }),
 /* 324 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.of
-__webpack_require__(71)('WeakMap');
+// https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.from
+__webpack_require__(70)('WeakSet');
 
 /***/ }),
 /* 325 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.of
-__webpack_require__(71)('WeakSet');
+// https://github.com/tc39/proposal-global
+var $export = __webpack_require__(0);
+
+$export($export.G, { global: __webpack_require__(3) });
 
 /***/ }),
 /* 326 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// https://tc39.github.io/proposal-setmap-offrom/#sec-map.from
-__webpack_require__(72)('Map');
+// https://github.com/tc39/proposal-global
+var $export = __webpack_require__(0);
+
+$export($export.S, 'System', { global: __webpack_require__(3) });
 
 /***/ }),
 /* 327 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// https://tc39.github.io/proposal-setmap-offrom/#sec-set.from
-__webpack_require__(72)('Set');
-
-/***/ }),
-/* 328 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.from
-__webpack_require__(72)('WeakMap');
-
-/***/ }),
-/* 329 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.from
-__webpack_require__(72)('WeakSet');
-
-/***/ }),
-/* 330 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// https://github.com/tc39/proposal-global
-var $export = __webpack_require__(0);
-
-$export($export.G, { global: __webpack_require__(2) });
-
-/***/ }),
-/* 331 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// https://github.com/tc39/proposal-global
-var $export = __webpack_require__(0);
-
-$export($export.S, 'System', { global: __webpack_require__(2) });
-
-/***/ }),
-/* 332 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/ljharb/proposal-is-error
@@ -30416,7 +29995,7 @@ $export($export.S, 'Error', {
 });
 
 /***/ }),
-/* 333 */
+/* 328 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -30429,7 +30008,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 334 */
+/* 329 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -30438,7 +30017,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { DEG_PER_RAD: Math.PI / 180 });
 
 /***/ }),
-/* 335 */
+/* 330 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -30452,13 +30031,13 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 336 */
+/* 331 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
 var $export = __webpack_require__(0);
-var scale = __webpack_require__(143);
-var fround = __webpack_require__(122);
+var scale = __webpack_require__(138);
+var fround = __webpack_require__(118);
 
 $export($export.S, 'Math', {
   fscale: function fscale(x, inLow, inHigh, outLow, outHigh) {
@@ -30467,7 +30046,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 337 */
+/* 332 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -30483,7 +30062,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 338 */
+/* 333 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -30499,7 +30078,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 339 */
+/* 334 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -30520,7 +30099,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 340 */
+/* 335 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -30529,7 +30108,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { RAD_PER_DEG: 180 / Math.PI });
 
 /***/ }),
-/* 341 */
+/* 336 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -30543,16 +30122,16 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 342 */
+/* 337 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Math', { scale: __webpack_require__(143) });
+$export($export.S, 'Math', { scale: __webpack_require__(138) });
 
 /***/ }),
-/* 343 */
+/* 338 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -30573,7 +30152,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-/* 344 */
+/* 339 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // http://jfbastien.github.io/papers/Math.signbit.html
@@ -30585,7 +30164,7 @@ $export($export.S, 'Math', { signbit: function signbit(x) {
   } });
 
 /***/ }),
-/* 345 */
+/* 340 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30594,9 +30173,9 @@ $export($export.S, 'Math', { signbit: function signbit(x) {
 
 var $export = __webpack_require__(0);
 var core = __webpack_require__(21);
-var global = __webpack_require__(2);
-var speciesConstructor = __webpack_require__(55);
-var promiseResolve = __webpack_require__(130);
+var global = __webpack_require__(3);
+var speciesConstructor = __webpack_require__(64);
+var promiseResolve = __webpack_require__(125);
 
 $export($export.P + $export.R, 'Promise', { 'finally': function _finally(onFinally) {
     var C = speciesConstructor(this, core.Promise || global.Promise);
@@ -30613,7 +30192,7 @@ $export($export.P + $export.R, 'Promise', { 'finally': function _finally(onFinal
   } });
 
 /***/ }),
-/* 346 */
+/* 341 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30621,8 +30200,8 @@ $export($export.P + $export.R, 'Promise', { 'finally': function _finally(onFinal
 // https://github.com/tc39/proposal-promise-try
 
 var $export = __webpack_require__(0);
-var newPromiseCapability = __webpack_require__(103);
-var perform = __webpack_require__(129);
+var newPromiseCapability = __webpack_require__(100);
+var perform = __webpack_require__(124);
 
 $export($export.S, 'Promise', { 'try': function _try(callbackfn) {
     var promiseCapability = newPromiseCapability.f(this);
@@ -30632,7 +30211,7 @@ $export($export.S, 'Promise', { 'try': function _try(callbackfn) {
   } });
 
 /***/ }),
-/* 347 */
+/* 342 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(31);
@@ -30645,7 +30224,7 @@ metadata.exp({ defineMetadata: function defineMetadata(metadataKey, metadataValu
   } });
 
 /***/ }),
-/* 348 */
+/* 343 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(31);
@@ -30665,7 +30244,7 @@ metadata.exp({ deleteMetadata: function deleteMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
-/* 349 */
+/* 344 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(31);
@@ -30687,11 +30266,11 @@ metadata.exp({ getMetadata: function getMetadata(metadataKey, target /* , target
   } });
 
 /***/ }),
-/* 350 */
+/* 345 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Set = __webpack_require__(133);
-var from = __webpack_require__(142);
+var Set = __webpack_require__(128);
+var from = __webpack_require__(137);
 var metadata = __webpack_require__(31);
 var anObject = __webpack_require__(1);
 var getPrototypeOf = __webpack_require__(20);
@@ -30711,7 +30290,7 @@ metadata.exp({ getMetadataKeys: function getMetadataKeys(target /* , targetKey *
   } });
 
 /***/ }),
-/* 351 */
+/* 346 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(31);
@@ -30724,7 +30303,7 @@ metadata.exp({ getOwnMetadata: function getOwnMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
-/* 352 */
+/* 347 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(31);
@@ -30737,7 +30316,7 @@ metadata.exp({ getOwnMetadataKeys: function getOwnMetadataKeys(target /* , targe
   } });
 
 /***/ }),
-/* 353 */
+/* 348 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(31);
@@ -30758,7 +30337,7 @@ metadata.exp({ hasMetadata: function hasMetadata(metadataKey, target /* , target
   } });
 
 /***/ }),
-/* 354 */
+/* 349 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(31);
@@ -30771,7 +30350,7 @@ metadata.exp({ hasOwnMetadata: function hasOwnMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
-/* 355 */
+/* 350 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $metadata = __webpack_require__(31);
@@ -30787,13 +30366,13 @@ $metadata.exp({ metadata: function metadata(metadataKey, metadataValue) {
   } });
 
 /***/ }),
-/* 356 */
+/* 351 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-09/sept-25.md#510-globalasap-for-enqueuing-a-microtask
 var $export = __webpack_require__(0);
-var microtask = __webpack_require__(102)();
-var process = __webpack_require__(2).process;
+var microtask = __webpack_require__(99)();
+var process = __webpack_require__(3).process;
 var isNode = __webpack_require__(23)(process) == 'process';
 
 $export($export.G, {
@@ -30804,7 +30383,7 @@ $export($export.G, {
 });
 
 /***/ }),
-/* 357 */
+/* 352 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30812,9 +30391,9 @@ $export($export.G, {
 // https://github.com/zenparsing/es-observable
 
 var $export = __webpack_require__(0);
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var core = __webpack_require__(21);
-var microtask = __webpack_require__(102)();
+var microtask = __webpack_require__(99)();
 var OBSERVABLE = __webpack_require__(6)('observable');
 var aFunction = __webpack_require__(13);
 var anObject = __webpack_require__(1);
@@ -31020,13 +30599,13 @@ $export($export.G, { Observable: $Observable });
 __webpack_require__(41)('Observable');
 
 /***/ }),
-/* 358 */
+/* 353 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // ie9- setTimeout & setInterval additional parameters fix
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var $export = __webpack_require__(0);
-var userAgent = __webpack_require__(67);
+var userAgent = __webpack_require__(65);
 var slice = [].slice;
 var MSIE = /MSIE .\./.test(userAgent); // <- dirty ie9- check
 var wrap = function wrap(set) {
@@ -31045,26 +30624,26 @@ $export($export.G + $export.B + $export.F * MSIE, {
 });
 
 /***/ }),
-/* 359 */
+/* 354 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $task = __webpack_require__(101);
+var $task = __webpack_require__(98);
 $export($export.G + $export.B, {
   setImmediate: $task.set,
   clearImmediate: $task.clear
 });
 
 /***/ }),
-/* 360 */
+/* 355 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var $iterators = __webpack_require__(98);
+var $iterators = __webpack_require__(97);
 var getKeys = __webpack_require__(37);
 var redefine = __webpack_require__(15);
-var global = __webpack_require__(2);
+var global = __webpack_require__(3);
 var hide = __webpack_require__(14);
-var Iterators = __webpack_require__(50);
+var Iterators = __webpack_require__(48);
 var wks = __webpack_require__(6);
 var ITERATOR = wks('iterator');
 var TO_STRING_TAG = wks('toStringTag');
@@ -31121,7 +30700,7 @@ for (var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++
 }
 
 /***/ }),
-/* 361 */
+/* 356 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global, module) {var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -31828,29 +31407,29 @@ for (var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++
 // object, this seems to be the most reliable technique that does not
 // use indirect eval (which violates Content Security Policy).
 (typeof global === "undefined" ? "undefined" : _typeof(global)) === "object" ? global : (typeof window === "undefined" ? "undefined" : _typeof(window)) === "object" ? window : (typeof self === "undefined" ? "undefined" : _typeof(self)) === "object" ? self : this);
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(77), __webpack_require__(12)(module)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(75), __webpack_require__(12)(module)))
 
 /***/ }),
-/* 362 */
+/* 357 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(363);
+__webpack_require__(358);
 module.exports = __webpack_require__(21).RegExp.escape;
 
 /***/ }),
-/* 363 */
+/* 358 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/benjamingr/RexExp.escape
 var $export = __webpack_require__(0);
-var $re = __webpack_require__(364)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+var $re = __webpack_require__(359)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
 
 $export($export.S, 'RegExp', { escape: function escape(it) {
     return $re(it);
   } });
 
 /***/ }),
-/* 364 */
+/* 359 */
 /***/ (function(module, exports) {
 
 module.exports = function (regExp, replace) {
@@ -31863,16 +31442,16 @@ module.exports = function (regExp, replace) {
 };
 
 /***/ }),
-/* 365 */
+/* 360 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initButtons;
 /* unused harmony export VButton */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(366);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(361);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_ripple__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -31915,7 +31494,7 @@ var VButton = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 366 */
+/* 361 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -33867,15 +33446,15 @@ var VButton = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 367 */
+/* 362 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDialogs;
 /* unused harmony export VDialog */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(46);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_dialog__ = __webpack_require__(368);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(45);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_dialog__ = __webpack_require__(363);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_dialog___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_dialog__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -33940,7 +33519,7 @@ var VDialog = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 368 */
+/* 363 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -37558,19 +37137,19 @@ var VDialog = function (_VBaseContainer) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 369 */
+/* 364 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDateTime;
 /* unused harmony export VDateTime */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(370);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(365);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield__ = __webpack_require__(145);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield__ = __webpack_require__(140);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__material_textfield__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__text_fields__ = __webpack_require__(146);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__config__ = __webpack_require__(58);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__text_fields__ = __webpack_require__(141);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__config__ = __webpack_require__(55);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -37676,2116 +37255,2196 @@ var VDateTime = function (_VTextField) {
 }(__WEBPACK_IMPORTED_MODULE_2__text_fields__["a" /* VTextField */]);
 
 /***/ }),
-/* 370 */
+/* 365 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-/* flatpickr v4.5.7, @license MIT */
+/* flatpickr v4.5.2, @license MIT */
 (function (global, factory) {
-    ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = factory() :  true ? !(__WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = factory() :  true ? !(__WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) :
 				__WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : (global = global || self, global.flatpickr = factory());
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : global.flatpickr = factory();
 })(this, function () {
-    'use strict';
+  'use strict';
 
-    /*! *****************************************************************************
-    Copyright (c) Microsoft Corporation. All rights reserved.
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-    this file except in compliance with the License. You may obtain a copy of the
-    License at http://www.apache.org/licenses/LICENSE-2.0
-      THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-    WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-    MERCHANTABLITY OR NON-INFRINGEMENT.
-      See the Apache Version 2.0 License for specific language governing permissions
-    and limitations under the License.
-    ***************************************************************************** */
+  var pad = function pad(number) {
+    return ("0" + number).slice(-2);
+  };
+  var int = function int(bool) {
+    return bool === true ? 1 : 0;
+  };
+  function debounce(func, wait, immediate) {
+    if (immediate === void 0) {
+      immediate = false;
+    }
 
-    var _assign = function __assign() {
-        _assign = Object.assign || function __assign(t) {
-            for (var s, i = 1, n = arguments.length; i < n; i++) {
-                s = arguments[i];
-                for (var p in s) {
-                    if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
-                }
-            }
-            return t;
-        };
-        return _assign.apply(this, arguments);
+    var timeout;
+    return function () {
+      var context = this,
+          args = arguments;
+      timeout !== null && clearTimeout(timeout);
+      timeout = window.setTimeout(function () {
+        timeout = null;
+        if (!immediate) func.apply(context, args);
+      }, wait);
+      if (immediate && !timeout) func.apply(context, args);
     };
+  }
+  var arrayify = function arrayify(obj) {
+    return obj instanceof Array ? obj : [obj];
+  };
 
-    var HOOKS = ["onChange", "onClose", "onDayCreate", "onDestroy", "onKeyDown", "onMonthChange", "onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange", "onPreCalendarPosition"];
-    var defaults = {
-        _disable: [],
-        _enable: [],
-        allowInput: false,
-        altFormat: "F j, Y",
-        altInput: false,
-        altInputClass: "form-control input",
-        animate: (typeof window === 'undefined' ? 'undefined' : _typeof(window)) === "object" && window.navigator.userAgent.indexOf("MSIE") === -1,
-        ariaDateFormat: "F j, Y",
-        clickOpens: true,
-        closeOnSelect: true,
-        conjunction: ", ",
-        dateFormat: "Y-m-d",
-        defaultHour: 12,
-        defaultMinute: 0,
-        defaultSeconds: 0,
-        disable: [],
-        disableMobile: false,
-        enable: [],
-        enableSeconds: false,
-        enableTime: false,
-        errorHandler: function errorHandler(err) {
-            return typeof console !== "undefined" && console.warn(err);
-        },
-        getWeek: function getWeek(givenDate) {
-            var date = new Date(givenDate.getTime());
-            date.setHours(0, 0, 0, 0);
-            // Thursday in current week decides the year.
-            date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
-            // January 4 is always in week 1.
-            var week1 = new Date(date.getFullYear(), 0, 4);
-            // Adjust to Thursday in week 1 and count number of weeks from date to week1.
-            return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getDay() + 6) % 7) / 7);
-        },
-        hourIncrement: 1,
-        ignoredFocusElements: [],
-        inline: false,
-        locale: "default",
-        minuteIncrement: 5,
-        mode: "single",
-        nextArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
-        noCalendar: false,
-        now: new Date(),
-        onChange: [],
-        onClose: [],
-        onDayCreate: [],
-        onDestroy: [],
-        onKeyDown: [],
-        onMonthChange: [],
-        onOpen: [],
-        onParseConfig: [],
-        onReady: [],
-        onValueUpdate: [],
-        onYearChange: [],
-        onPreCalendarPosition: [],
-        plugins: [],
-        position: "auto",
-        positionElement: undefined,
-        prevArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
-        shorthandCurrentMonth: false,
-        showMonths: 1,
-        static: false,
-        time_24hr: false,
-        weekNumbers: false,
-        wrap: false
-    };
+  var do_nothing = function do_nothing() {
+    return undefined;
+  };
 
-    var english = {
-        weekdays: {
-            shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-            longhand: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-        },
-        months: {
-            shorthand: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-            longhand: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-        },
-        daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-        firstDayOfWeek: 0,
-        ordinal: function ordinal(nth) {
-            var s = nth % 100;
-            if (s > 3 && s < 21) return "th";
-            switch (s % 10) {
-                case 1:
-                    return "st";
-                case 2:
-                    return "nd";
-                case 3:
-                    return "rd";
-                default:
-                    return "th";
-            }
-        },
-        rangeSeparator: " to ",
-        weekAbbreviation: "Wk",
-        scrollTitle: "Scroll to increment",
-        toggleTitle: "Click to toggle",
-        amPM: ["AM", "PM"],
-        yearAriaLabel: "Year"
-    };
+  var monthToStr = function monthToStr(monthNumber, shorthand, locale) {
+    return locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
+  };
+  var revFormat = {
+    D: do_nothing,
+    F: function F(dateObj, monthName, locale) {
+      dateObj.setMonth(locale.months.longhand.indexOf(monthName));
+    },
+    G: function G(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    H: function H(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    J: function J(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    K: function K(dateObj, amPM, locale) {
+      dateObj.setHours(dateObj.getHours() % 12 + 12 * int(new RegExp(locale.amPM[1], "i").test(amPM)));
+    },
+    M: function M(dateObj, shortMonth, locale) {
+      dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
+    },
+    S: function S(dateObj, seconds) {
+      dateObj.setSeconds(parseFloat(seconds));
+    },
+    U: function U(_, unixSeconds) {
+      return new Date(parseFloat(unixSeconds) * 1000);
+    },
+    W: function W(dateObj, weekNum) {
+      var weekNumber = parseInt(weekNum);
+      return new Date(dateObj.getFullYear(), 0, 2 + (weekNumber - 1) * 7, 0, 0, 0, 0);
+    },
+    Y: function Y(dateObj, year) {
+      dateObj.setFullYear(parseFloat(year));
+    },
+    Z: function Z(_, ISODate) {
+      return new Date(ISODate);
+    },
+    d: function d(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    h: function h(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    i: function i(dateObj, minutes) {
+      dateObj.setMinutes(parseFloat(minutes));
+    },
+    j: function j(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    l: do_nothing,
+    m: function m(dateObj, month) {
+      dateObj.setMonth(parseFloat(month) - 1);
+    },
+    n: function n(dateObj, month) {
+      dateObj.setMonth(parseFloat(month) - 1);
+    },
+    s: function s(dateObj, seconds) {
+      dateObj.setSeconds(parseFloat(seconds));
+    },
+    w: do_nothing,
+    y: function y(dateObj, year) {
+      dateObj.setFullYear(2000 + parseFloat(year));
+    }
+  };
+  var tokenRegex = {
+    D: "(\\w+)",
+    F: "(\\w+)",
+    G: "(\\d\\d|\\d)",
+    H: "(\\d\\d|\\d)",
+    J: "(\\d\\d|\\d)\\w+",
+    K: "",
+    M: "(\\w+)",
+    S: "(\\d\\d|\\d)",
+    U: "(.+)",
+    W: "(\\d\\d|\\d)",
+    Y: "(\\d{4})",
+    Z: "(.+)",
+    d: "(\\d\\d|\\d)",
+    h: "(\\d\\d|\\d)",
+    i: "(\\d\\d|\\d)",
+    j: "(\\d\\d|\\d)",
+    l: "(\\w+)",
+    m: "(\\d\\d|\\d)",
+    n: "(\\d\\d|\\d)",
+    s: "(\\d\\d|\\d)",
+    w: "(\\d\\d|\\d)",
+    y: "(\\d{2})"
+  };
+  var formats = {
+    Z: function Z(date) {
+      return date.toISOString();
+    },
+    D: function D(date, locale, options) {
+      return locale.weekdays.shorthand[formats.w(date, locale, options)];
+    },
+    F: function F(date, locale, options) {
+      return monthToStr(formats.n(date, locale, options) - 1, false, locale);
+    },
+    G: function G(date, locale, options) {
+      return pad(formats.h(date, locale, options));
+    },
+    H: function H(date) {
+      return pad(date.getHours());
+    },
+    J: function J(date, locale) {
+      return locale.ordinal !== undefined ? date.getDate() + locale.ordinal(date.getDate()) : date.getDate();
+    },
+    K: function K(date, locale) {
+      return locale.amPM[int(date.getHours() > 11)];
+    },
+    M: function M(date, locale) {
+      return monthToStr(date.getMonth(), true, locale);
+    },
+    S: function S(date) {
+      return pad(date.getSeconds());
+    },
+    U: function U(date) {
+      return date.getTime() / 1000;
+    },
+    W: function W(date, _, options) {
+      return options.getWeek(date);
+    },
+    Y: function Y(date) {
+      return date.getFullYear();
+    },
+    d: function d(date) {
+      return pad(date.getDate());
+    },
+    h: function h(date) {
+      return date.getHours() % 12 ? date.getHours() % 12 : 12;
+    },
+    i: function i(date) {
+      return pad(date.getMinutes());
+    },
+    j: function j(date) {
+      return date.getDate();
+    },
+    l: function l(date, locale) {
+      return locale.weekdays.longhand[date.getDay()];
+    },
+    m: function m(date) {
+      return pad(date.getMonth() + 1);
+    },
+    n: function n(date) {
+      return date.getMonth() + 1;
+    },
+    s: function s(date) {
+      return date.getSeconds();
+    },
+    w: function w(date) {
+      return date.getDay();
+    },
+    y: function y(date) {
+      return String(date.getFullYear()).substring(2);
+    }
+  };
 
-    var pad = function pad(number) {
-        return ("0" + number).slice(-2);
+  var english = {
+    weekdays: {
+      shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+      longhand: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    },
+    months: {
+      shorthand: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+      longhand: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+    },
+    daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+    firstDayOfWeek: 0,
+    ordinal: function ordinal(nth) {
+      var s = nth % 100;
+      if (s > 3 && s < 21) return "th";
+
+      switch (s % 10) {
+        case 1:
+          return "st";
+
+        case 2:
+          return "nd";
+
+        case 3:
+          return "rd";
+
+        default:
+          return "th";
+      }
+    },
+    rangeSeparator: " to ",
+    weekAbbreviation: "Wk",
+    scrollTitle: "Scroll to increment",
+    toggleTitle: "Click to toggle",
+    amPM: ["AM", "PM"],
+    yearAriaLabel: "Year"
+  };
+
+  var createDateFormatter = function createDateFormatter(_ref) {
+    var _ref$config = _ref.config,
+        config = _ref$config === void 0 ? defaults : _ref$config,
+        _ref$l10n = _ref.l10n,
+        l10n = _ref$l10n === void 0 ? english : _ref$l10n;
+    return function (dateObj, frmt, overrideLocale) {
+      var locale = overrideLocale || l10n;
+
+      if (config.formatDate !== undefined) {
+        return config.formatDate(dateObj, frmt, locale);
+      }
+
+      return frmt.split("").map(function (c, i, arr) {
+        return formats[c] && arr[i - 1] !== "\\" ? formats[c](dateObj, locale, config) : c !== "\\" ? c : "";
+      }).join("");
     };
-    var int = function int(bool) {
-        return bool === true ? 1 : 0;
-    };
-    /* istanbul ignore next */
-    function debounce(func, wait, immediate) {
-        if (immediate === void 0) {
-            immediate = false;
+  };
+  var createDateParser = function createDateParser(_ref2) {
+    var _ref2$config = _ref2.config,
+        config = _ref2$config === void 0 ? defaults : _ref2$config,
+        _ref2$l10n = _ref2.l10n,
+        l10n = _ref2$l10n === void 0 ? english : _ref2$l10n;
+    return function (date, givenFormat, timeless, customLocale) {
+      if (date !== 0 && !date) return undefined;
+      var locale = customLocale || l10n;
+      var parsedDate;
+      var date_orig = date;
+      if (date instanceof Date) parsedDate = new Date(date.getTime());else if (typeof date !== "string" && date.toFixed !== undefined) parsedDate = new Date(date);else if (typeof date === "string") {
+        var format = givenFormat || (config || defaults).dateFormat;
+        var datestr = String(date).trim();
+
+        if (datestr === "today") {
+          parsedDate = new Date();
+          timeless = true;
+        } else if (/Z$/.test(datestr) || /GMT$/.test(datestr)) parsedDate = new Date(date);else if (config && config.parseDate) parsedDate = config.parseDate(date, format);else {
+          parsedDate = !config || !config.noCalendar ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0) : new Date(new Date().setHours(0, 0, 0, 0));
+          var matched,
+              ops = [];
+
+          for (var i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
+            var token = format[i];
+            var isBackSlash = token === "\\";
+            var escaped = format[i - 1] === "\\" || isBackSlash;
+
+            if (tokenRegex[token] && !escaped) {
+              regexStr += tokenRegex[token];
+              var match = new RegExp(regexStr).exec(date);
+
+              if (match && (matched = true)) {
+                ops[token !== "Y" ? "push" : "unshift"]({
+                  fn: revFormat[token],
+                  val: match[++matchIndex]
+                });
+              }
+            } else if (!isBackSlash) regexStr += ".";
+
+            ops.forEach(function (_ref3) {
+              var fn = _ref3.fn,
+                  val = _ref3.val;
+              return parsedDate = fn(parsedDate, val, locale) || parsedDate;
+            });
+          }
+
+          parsedDate = matched ? parsedDate : undefined;
         }
-        var timeout;
-        return function () {
-            var context = this,
-                args = arguments;
-            timeout !== null && clearTimeout(timeout);
-            timeout = window.setTimeout(function () {
-                timeout = null;
-                if (!immediate) func.apply(context, args);
-            }, wait);
-            if (immediate && !timeout) func.apply(context, args);
-        };
-    }
-    var arrayify = function arrayify(obj) {
-        return obj instanceof Array ? obj : [obj];
-    };
+      }
 
-    function toggleClass(elem, className, bool) {
-        if (bool === true) return elem.classList.add(className);
-        elem.classList.remove(className);
-    }
-    function createElement(tag, className, content) {
-        var e = window.document.createElement(tag);
-        className = className || "";
-        content = content || "";
-        e.className = className;
-        if (content !== undefined) e.textContent = content;
-        return e;
-    }
-    function clearNode(node) {
-        while (node.firstChild) {
-            node.removeChild(node.firstChild);
-        }
-    }
-    function findParent(node, condition) {
-        if (condition(node)) return node;else if (node.parentNode) return findParent(node.parentNode, condition);
-        return undefined; // nothing found
-    }
-    function createNumberInput(inputClassName, opts) {
-        var wrapper = createElement("div", "numInputWrapper"),
-            numInput = createElement("input", "numInput " + inputClassName),
-            arrowUp = createElement("span", "arrowUp"),
-            arrowDown = createElement("span", "arrowDown");
-        if (navigator.userAgent.indexOf("MSIE 9.0") === -1) {
-            numInput.type = "number";
-        } else {
-            numInput.type = "text";
-            numInput.pattern = "\\d*";
-        }
-        if (opts !== undefined) for (var key in opts) {
-            numInput.setAttribute(key, opts[key]);
-        }wrapper.appendChild(numInput);
-        wrapper.appendChild(arrowUp);
-        wrapper.appendChild(arrowDown);
-        return wrapper;
-    }
-    function getEventTarget(event) {
-        if (typeof event.composedPath === "function") {
-            var path = event.composedPath();
-            return path[0];
-        }
-        return event.target;
-    }
-
-    var do_nothing = function do_nothing() {
+      if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
+        config.errorHandler(new Error("Invalid date provided: " + date_orig));
         return undefined;
-    };
-    var monthToStr = function monthToStr(monthNumber, shorthand, locale) {
-        return locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
-    };
-    var revFormat = {
-        D: do_nothing,
-        F: function F(dateObj, monthName, locale) {
-            dateObj.setMonth(locale.months.longhand.indexOf(monthName));
-        },
-        G: function G(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        H: function H(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        J: function J(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        K: function K(dateObj, amPM, locale) {
-            dateObj.setHours(dateObj.getHours() % 12 + 12 * int(new RegExp(locale.amPM[1], "i").test(amPM)));
-        },
-        M: function M(dateObj, shortMonth, locale) {
-            dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
-        },
-        S: function S(dateObj, seconds) {
-            dateObj.setSeconds(parseFloat(seconds));
-        },
-        U: function U(_, unixSeconds) {
-            return new Date(parseFloat(unixSeconds) * 1000);
-        },
-        W: function W(dateObj, weekNum) {
-            var weekNumber = parseInt(weekNum);
-            return new Date(dateObj.getFullYear(), 0, 2 + (weekNumber - 1) * 7, 0, 0, 0, 0);
-        },
-        Y: function Y(dateObj, year) {
-            dateObj.setFullYear(parseFloat(year));
-        },
-        Z: function Z(_, ISODate) {
-            return new Date(ISODate);
-        },
-        d: function d(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        h: function h(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        i: function i(dateObj, minutes) {
-            dateObj.setMinutes(parseFloat(minutes));
-        },
-        j: function j(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        l: do_nothing,
-        m: function m(dateObj, month) {
-            dateObj.setMonth(parseFloat(month) - 1);
-        },
-        n: function n(dateObj, month) {
-            dateObj.setMonth(parseFloat(month) - 1);
-        },
-        s: function s(dateObj, seconds) {
-            dateObj.setSeconds(parseFloat(seconds));
-        },
-        u: function u(_, unixMillSeconds) {
-            return new Date(parseFloat(unixMillSeconds));
-        },
-        w: do_nothing,
-        y: function y(dateObj, year) {
-            dateObj.setFullYear(2000 + parseFloat(year));
-        }
-    };
-    var tokenRegex = {
-        D: "(\\w+)",
-        F: "(\\w+)",
-        G: "(\\d\\d|\\d)",
-        H: "(\\d\\d|\\d)",
-        J: "(\\d\\d|\\d)\\w+",
-        K: "",
-        M: "(\\w+)",
-        S: "(\\d\\d|\\d)",
-        U: "(.+)",
-        W: "(\\d\\d|\\d)",
-        Y: "(\\d{4})",
-        Z: "(.+)",
-        d: "(\\d\\d|\\d)",
-        h: "(\\d\\d|\\d)",
-        i: "(\\d\\d|\\d)",
-        j: "(\\d\\d|\\d)",
-        l: "(\\w+)",
-        m: "(\\d\\d|\\d)",
-        n: "(\\d\\d|\\d)",
-        s: "(\\d\\d|\\d)",
-        u: "(.+)",
-        w: "(\\d\\d|\\d)",
-        y: "(\\d{2})"
-    };
-    var formats = {
-        // get the date in UTC
-        Z: function Z(date) {
-            return date.toISOString();
-        },
-        // weekday name, short, e.g. Thu
-        D: function D(date, locale, options) {
-            return locale.weekdays.shorthand[formats.w(date, locale, options)];
-        },
-        // full month name e.g. January
-        F: function F(date, locale, options) {
-            return monthToStr(formats.n(date, locale, options) - 1, false, locale);
-        },
-        // padded hour 1-12
-        G: function G(date, locale, options) {
-            return pad(formats.h(date, locale, options));
-        },
-        // hours with leading zero e.g. 03
-        H: function H(date) {
-            return pad(date.getHours());
-        },
-        // day (1-30) with ordinal suffix e.g. 1st, 2nd
-        J: function J(date, locale) {
-            return locale.ordinal !== undefined ? date.getDate() + locale.ordinal(date.getDate()) : date.getDate();
-        },
-        // AM/PM
-        K: function K(date, locale) {
-            return locale.amPM[int(date.getHours() > 11)];
-        },
-        // shorthand month e.g. Jan, Sep, Oct, etc
-        M: function M(date, locale) {
-            return monthToStr(date.getMonth(), true, locale);
-        },
-        // seconds 00-59
-        S: function S(date) {
-            return pad(date.getSeconds());
-        },
-        // unix timestamp
-        U: function U(date) {
-            return date.getTime() / 1000;
-        },
-        W: function W(date, _, options) {
-            return options.getWeek(date);
-        },
-        // full year e.g. 2016
-        Y: function Y(date) {
-            return date.getFullYear();
-        },
-        // day in month, padded (01-30)
-        d: function d(date) {
-            return pad(date.getDate());
-        },
-        // hour from 1-12 (am/pm)
-        h: function h(date) {
-            return date.getHours() % 12 ? date.getHours() % 12 : 12;
-        },
-        // minutes, padded with leading zero e.g. 09
-        i: function i(date) {
-            return pad(date.getMinutes());
-        },
-        // day in month (1-30)
-        j: function j(date) {
-            return date.getDate();
-        },
-        // weekday name, full, e.g. Thursday
-        l: function l(date, locale) {
-            return locale.weekdays.longhand[date.getDay()];
-        },
-        // padded month number (01-12)
-        m: function m(date) {
-            return pad(date.getMonth() + 1);
-        },
-        // the month number (1-12)
-        n: function n(date) {
-            return date.getMonth() + 1;
-        },
-        // seconds 0-59
-        s: function s(date) {
-            return date.getSeconds();
-        },
-        // Unix Milliseconds
-        u: function u(date) {
-            return date.getTime();
-        },
-        // number of the day of the week
-        w: function w(date) {
-            return date.getDay();
-        },
-        // last two digits of year e.g. 16 for 2016
-        y: function y(date) {
-            return String(date.getFullYear()).substring(2);
-        }
-    };
+      }
 
-    var createDateFormatter = function createDateFormatter(_a) {
-        var _b = _a.config,
-            config = _b === void 0 ? defaults : _b,
-            _c = _a.l10n,
-            l10n = _c === void 0 ? english : _c;
-        return function (dateObj, frmt, overrideLocale) {
-            var locale = overrideLocale || l10n;
-            if (config.formatDate !== undefined) {
-                return config.formatDate(dateObj, frmt, locale);
-            }
-            return frmt.split("").map(function (c, i, arr) {
-                return formats[c] && arr[i - 1] !== "\\" ? formats[c](dateObj, locale, config) : c !== "\\" ? c : "";
-            }).join("");
-        };
+      if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
+      return parsedDate;
     };
-    var createDateParser = function createDateParser(_a) {
-        var _b = _a.config,
-            config = _b === void 0 ? defaults : _b,
-            _c = _a.l10n,
-            l10n = _c === void 0 ? english : _c;
-        return function (date, givenFormat, timeless, customLocale) {
-            if (date !== 0 && !date) return undefined;
-            var locale = customLocale || l10n;
-            var parsedDate;
-            var date_orig = date;
-            if (date instanceof Date) parsedDate = new Date(date.getTime());else if (typeof date !== "string" && date.toFixed !== undefined // timestamp
-            )
-                // create a copy
-                parsedDate = new Date(date);else if (typeof date === "string") {
-                // date string
-                var format = givenFormat || (config || defaults).dateFormat;
-                var datestr = String(date).trim();
-                if (datestr === "today") {
-                    parsedDate = new Date();
-                    timeless = true;
-                } else if (/Z$/.test(datestr) || /GMT$/.test(datestr) // datestrings w/ timezone
-                ) parsedDate = new Date(date);else if (config && config.parseDate) parsedDate = config.parseDate(date, format);else {
-                    parsedDate = !config || !config.noCalendar ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0) : new Date(new Date().setHours(0, 0, 0, 0));
-                    var matched = void 0,
-                        ops = [];
-                    for (var i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
-                        var token_1 = format[i];
-                        var isBackSlash = token_1 === "\\";
-                        var escaped = format[i - 1] === "\\" || isBackSlash;
-                        if (tokenRegex[token_1] && !escaped) {
-                            regexStr += tokenRegex[token_1];
-                            var match = new RegExp(regexStr).exec(date);
-                            if (match && (matched = true)) {
-                                ops[token_1 !== "Y" ? "push" : "unshift"]({
-                                    fn: revFormat[token_1],
-                                    val: match[++matchIndex]
-                                });
-                            }
-                        } else if (!isBackSlash) regexStr += "."; // don't really care
-                        ops.forEach(function (_a) {
-                            var fn = _a.fn,
-                                val = _a.val;
-                            return parsedDate = fn(parsedDate, val, locale) || parsedDate;
-                        });
-                    }
-                    parsedDate = matched ? parsedDate : undefined;
-                }
-            }
-            /* istanbul ignore next */
-            if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
-                config.errorHandler(new Error("Invalid date provided: " + date_orig));
-                return undefined;
-            }
-            if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
-            return parsedDate;
-        };
-    };
-    /**
-     * Compute the difference in dates, measured in ms
-     */
-    function compareDates(date1, date2, timeless) {
-        if (timeless === void 0) {
-            timeless = true;
-        }
-        if (timeless !== false) {
-            return new Date(date1.getTime()).setHours(0, 0, 0, 0) - new Date(date2.getTime()).setHours(0, 0, 0, 0);
-        }
-        return date1.getTime() - date2.getTime();
-    }
-    var isBetween = function isBetween(ts, ts1, ts2) {
-        return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
-    };
-    var duration = {
-        DAY: 86400000
-    };
-
-    if (typeof Object.assign !== "function") {
-        Object.assign = function (target) {
-            var args = [];
-            for (var _i = 1; _i < arguments.length; _i++) {
-                args[_i - 1] = arguments[_i];
-            }
-            if (!target) {
-                throw TypeError("Cannot convert undefined or null to object");
-            }
-            var _loop_1 = function _loop_1(source) {
-                if (source) {
-                    Object.keys(source).forEach(function (key) {
-                        return target[key] = source[key];
-                    });
-                }
-            };
-            for (var _a = 0, args_1 = args; _a < args_1.length; _a++) {
-                var source = args_1[_a];
-                _loop_1(source);
-            }
-            return target;
-        };
+  };
+  function compareDates(date1, date2, timeless) {
+    if (timeless === void 0) {
+      timeless = true;
     }
 
-    var DEBOUNCED_CHANGE_MS = 300;
-    function FlatpickrInstance(element, instanceConfig) {
-        var self = {
-            config: _assign({}, flatpickr.defaultConfig),
-            l10n: english
-        };
-        self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
-        self._handlers = [];
-        self._bind = bind;
-        self._setHoursFromDate = setHoursFromDate;
-        self._positionCalendar = positionCalendar;
-        self.changeMonth = changeMonth;
-        self.changeYear = changeYear;
-        self.clear = clear;
-        self.close = close;
-        self._createElement = createElement;
-        self.destroy = destroy;
-        self.isEnabled = isEnabled;
-        self.jumpToDate = jumpToDate;
-        self.open = open;
-        self.redraw = redraw;
-        self.set = set;
-        self.setDate = setDate;
-        self.toggle = toggle;
-        function setupHelperFunctions() {
-            self.utils = {
-                getDaysInMonth: function getDaysInMonth(month, yr) {
-                    if (month === void 0) {
-                        month = self.currentMonth;
-                    }
-                    if (yr === void 0) {
-                        yr = self.currentYear;
-                    }
-                    if (month === 1 && (yr % 4 === 0 && yr % 100 !== 0 || yr % 400 === 0)) return 29;
-                    return self.l10n.daysInMonth[month];
-                }
-            };
-        }
-        function init() {
-            self.element = self.input = element;
-            self.isOpen = false;
-            parseConfig();
-            setupLocale();
-            setupInputs();
-            setupDates();
-            setupHelperFunctions();
-            if (!self.isMobile) build();
-            bindEvents();
-            if (self.selectedDates.length || self.config.noCalendar) {
-                if (self.config.enableTime) {
-                    setHoursFromDate(self.config.noCalendar ? self.latestSelectedDateObj || self.config.minDate : undefined);
-                }
-                updateValue(false);
-            }
-            setCalendarWidth();
-            self.showTimeInput = self.selectedDates.length > 0 || self.config.noCalendar;
-            var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            /* TODO: investigate this further
-                       Currently, there is weird positioning behavior in safari causing pages
-              to scroll up. https://github.com/chmln/flatpickr/issues/563
-                       However, most browsers are not Safari and positioning is expensive when used
-              in scale. https://github.com/chmln/flatpickr/issues/1096
-            */
-            if (!self.isMobile && isSafari) {
-                positionCalendar();
-            }
-            triggerEvent("onReady");
-        }
-        function bindToInstance(fn) {
-            return fn.bind(self);
-        }
-        function setCalendarWidth() {
-            var config = self.config;
-            if (config.weekNumbers === false && config.showMonths === 1) return;else if (config.noCalendar !== true) {
-                window.requestAnimationFrame(function () {
-                    if (self.calendarContainer !== undefined) {
-                        self.calendarContainer.style.visibility = "hidden";
-                        self.calendarContainer.style.display = "block";
-                    }
-                    if (self.daysContainer !== undefined) {
-                        var daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
-                        self.daysContainer.style.width = daysWidth + "px";
-                        self.calendarContainer.style.width = daysWidth + (self.weekWrapper !== undefined ? self.weekWrapper.offsetWidth : 0) + "px";
-                        self.calendarContainer.style.removeProperty("visibility");
-                        self.calendarContainer.style.removeProperty("display");
-                    }
-                });
-            }
-        }
-        /**
-         * The handler for all events targeting the time inputs
-         */
-        function updateTime(e) {
-            if (self.selectedDates.length === 0) {
-                setDefaultTime();
-            }
-            if (e !== undefined && e.type !== "blur") {
-                timeWrapper(e);
-            }
-            var prevValue = self._input.value;
-            setHoursFromInputs();
-            updateValue();
-            if (self._input.value !== prevValue) {
-                self._debouncedChange();
-            }
-        }
-        function ampm2military(hour, amPM) {
-            return hour % 12 + 12 * int(amPM === self.l10n.amPM[1]);
-        }
-        function military2ampm(hour) {
-            switch (hour % 24) {
-                case 0:
-                case 12:
-                    return 12;
-                default:
-                    return hour % 12;
-            }
-        }
-        /**
-         * Syncs the selected date object time with user's time input
-         */
-        function setHoursFromInputs() {
-            if (self.hourElement === undefined || self.minuteElement === undefined) return;
-            var hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
-                minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
-                seconds = self.secondElement !== undefined ? (parseInt(self.secondElement.value, 10) || 0) % 60 : 0;
-            if (self.amPM !== undefined) {
-                hours = ampm2military(hours, self.amPM.textContent);
-            }
-            var limitMinHours = self.config.minTime !== undefined || self.config.minDate && self.minDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.minDate, true) === 0;
-            var limitMaxHours = self.config.maxTime !== undefined || self.config.maxDate && self.maxDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.maxDate, true) === 0;
-            if (limitMaxHours) {
-                var maxTime = self.config.maxTime !== undefined ? self.config.maxTime : self.config.maxDate;
-                hours = Math.min(hours, maxTime.getHours());
-                if (hours === maxTime.getHours()) minutes = Math.min(minutes, maxTime.getMinutes());
-                if (minutes === maxTime.getMinutes()) seconds = Math.min(seconds, maxTime.getSeconds());
-            }
-            if (limitMinHours) {
-                var minTime = self.config.minTime !== undefined ? self.config.minTime : self.config.minDate;
-                hours = Math.max(hours, minTime.getHours());
-                if (hours === minTime.getHours()) minutes = Math.max(minutes, minTime.getMinutes());
-                if (minutes === minTime.getMinutes()) seconds = Math.max(seconds, minTime.getSeconds());
-            }
-            setHours(hours, minutes, seconds);
-        }
-        /**
-         * Syncs time input values with a date
-         */
-        function setHoursFromDate(dateObj) {
-            var date = dateObj || self.latestSelectedDateObj;
-            if (date) setHours(date.getHours(), date.getMinutes(), date.getSeconds());
-        }
-        function setDefaultHours() {
-            var hours = self.config.defaultHour;
-            var minutes = self.config.defaultMinute;
-            var seconds = self.config.defaultSeconds;
-            if (self.config.minDate !== undefined) {
-                var min_hr = self.config.minDate.getHours();
-                var min_minutes = self.config.minDate.getMinutes();
-                hours = Math.max(hours, min_hr);
-                if (hours === min_hr) minutes = Math.max(min_minutes, minutes);
-                if (hours === min_hr && minutes === min_minutes) seconds = self.config.minDate.getSeconds();
-            }
-            if (self.config.maxDate !== undefined) {
-                var max_hr = self.config.maxDate.getHours();
-                var max_minutes = self.config.maxDate.getMinutes();
-                hours = Math.min(hours, max_hr);
-                if (hours === max_hr) minutes = Math.min(max_minutes, minutes);
-                if (hours === max_hr && minutes === max_minutes) seconds = self.config.maxDate.getSeconds();
-            }
-            setHours(hours, minutes, seconds);
-        }
-        /**
-         * Sets the hours, minutes, and optionally seconds
-         * of the latest selected date object and the
-         * corresponding time inputs
-         * @param {Number} hours the hour. whether its military
-         *                 or am-pm gets inferred from config
-         * @param {Number} minutes the minutes
-         * @param {Number} seconds the seconds (optional)
-         */
-        function setHours(hours, minutes, seconds) {
-            if (self.latestSelectedDateObj !== undefined) {
-                self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
-            }
-            if (!self.hourElement || !self.minuteElement || self.isMobile) return;
-            self.hourElement.value = pad(!self.config.time_24hr ? (12 + hours) % 12 + 12 * int(hours % 12 === 0) : hours);
-            self.minuteElement.value = pad(minutes);
-            if (self.amPM !== undefined) self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
-            if (self.secondElement !== undefined) self.secondElement.value = pad(seconds);
-        }
-        /**
-         * Handles the year input and incrementing events
-         * @param {Event} event the keyup or increment event
-         */
-        function onYearInput(event) {
-            var year = parseInt(event.target.value) + (event.delta || 0);
-            if (year / 1000 > 1 || event.key === "Enter" && !/[^\d]/.test(year.toString())) {
-                changeYear(year);
-            }
-        }
-        /**
-         * Essentially addEventListener + tracking
-         * @param {Element} element the element to addEventListener to
-         * @param {String} event the event name
-         * @param {Function} handler the event handler
-         */
-        function bind(element, event, handler, options) {
-            if (event instanceof Array) return event.forEach(function (ev) {
-                return bind(element, ev, handler, options);
-            });
-            if (element instanceof Array) return element.forEach(function (el) {
-                return bind(el, event, handler, options);
-            });
-            element.addEventListener(event, handler, options);
-            self._handlers.push({
-                element: element,
-                event: event,
-                handler: handler,
-                options: options
-            });
-        }
-        /**
-         * A mousedown handler which mimics click.
-         * Minimizes latency, since we don't need to wait for mouseup in most cases.
-         * Also, avoids handling right clicks.
-         *
-         * @param {Function} handler the event handler
-         */
-        function onClick(handler) {
-            return function (evt) {
-                evt.which === 1 && handler(evt);
-            };
-        }
-        function triggerChange() {
-            triggerEvent("onChange");
-        }
-        /**
-         * Adds all the necessary event listeners
-         */
-        function bindEvents() {
-            if (self.config.wrap) {
-                ["open", "close", "toggle", "clear"].forEach(function (evt) {
-                    Array.prototype.forEach.call(self.element.querySelectorAll("[data-" + evt + "]"), function (el) {
-                        return bind(el, "click", self[evt]);
-                    });
-                });
-            }
-            if (self.isMobile) {
-                setupMobile();
-                return;
-            }
-            var debouncedResize = debounce(onResize, 50);
-            self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
-            if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent)) bind(self.daysContainer, "mouseover", function (e) {
-                if (self.config.mode === "range") onMouseOver(e.target);
-            });
-            bind(window.document.body, "keydown", onKeyDown);
-            if (!self.config.static) bind(self._input, "keydown", onKeyDown);
-            if (!self.config.inline && !self.config.static) bind(window, "resize", debouncedResize);
-            if (window.ontouchstart !== undefined) bind(window.document, "click", documentClick);else bind(window.document, "mousedown", onClick(documentClick));
-            bind(window.document, "focus", documentClick, { capture: true });
-            if (self.config.clickOpens === true) {
-                bind(self._input, "focus", self.open);
-                bind(self._input, "mousedown", onClick(self.open));
-            }
-            if (self.daysContainer !== undefined) {
-                bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
-                bind(self.monthNav, ["keyup", "increment"], onYearInput);
-                bind(self.daysContainer, "mousedown", onClick(selectDate));
-            }
-            if (self.timeContainer !== undefined && self.minuteElement !== undefined && self.hourElement !== undefined) {
-                var selText = function selText(e) {
-                    return e.target.select();
-                };
-                bind(self.timeContainer, ["increment"], updateTime);
-                bind(self.timeContainer, "blur", updateTime, { capture: true });
-                bind(self.timeContainer, "mousedown", onClick(timeIncrement));
-                bind([self.hourElement, self.minuteElement], ["focus", "click"], selText);
-                if (self.secondElement !== undefined) bind(self.secondElement, "focus", function () {
-                    return self.secondElement && self.secondElement.select();
-                });
-                if (self.amPM !== undefined) {
-                    bind(self.amPM, "mousedown", onClick(function (e) {
-                        updateTime(e);
-                        triggerChange();
-                    }));
-                }
-            }
-        }
-        /**
-         * Set the calendar view to a particular date.
-         * @param {Date} jumpDate the date to set the view to
-         */
-        function jumpToDate(jumpDate) {
-            var jumpTo = jumpDate !== undefined ? self.parseDate(jumpDate) : self.latestSelectedDateObj || (self.config.minDate && self.config.minDate > self.now ? self.config.minDate : self.config.maxDate && self.config.maxDate < self.now ? self.config.maxDate : self.now);
-            try {
-                if (jumpTo !== undefined) {
-                    self.currentYear = jumpTo.getFullYear();
-                    self.currentMonth = jumpTo.getMonth();
-                }
-            } catch (e) {
-                /* istanbul ignore next */
-                e.message = "Invalid date supplied: " + jumpTo;
-                self.config.errorHandler(e);
-            }
-            self.redraw();
-        }
-        /**
-         * The up/down arrow handler for time inputs
-         * @param {Event} e the click event
-         */
-        function timeIncrement(e) {
-            if (~e.target.className.indexOf("arrow")) incrementNumInput(e, e.target.classList.contains("arrowUp") ? 1 : -1);
-        }
-        /**
-         * Increments/decrements the value of input associ-
-         * ated with the up/down arrow by dispatching an
-         * "increment" event on the input.
-         *
-         * @param {Event} e the click event
-         * @param {Number} delta the diff (usually 1 or -1)
-         * @param {Element} inputElem the input element
-         */
-        function incrementNumInput(e, delta, inputElem) {
-            var target = e && e.target;
-            var input = inputElem || target && target.parentNode && target.parentNode.firstChild;
-            var event = createEvent("increment");
-            event.delta = delta;
-            input && input.dispatchEvent(event);
-        }
-        function build() {
-            var fragment = window.document.createDocumentFragment();
-            self.calendarContainer = createElement("div", "flatpickr-calendar");
-            self.calendarContainer.tabIndex = -1;
-            if (!self.config.noCalendar) {
-                fragment.appendChild(buildMonthNav());
-                self.innerContainer = createElement("div", "flatpickr-innerContainer");
-                if (self.config.weekNumbers) {
-                    var _a = buildWeeks(),
-                        weekWrapper = _a.weekWrapper,
-                        weekNumbers = _a.weekNumbers;
-                    self.innerContainer.appendChild(weekWrapper);
-                    self.weekNumbers = weekNumbers;
-                    self.weekWrapper = weekWrapper;
-                }
-                self.rContainer = createElement("div", "flatpickr-rContainer");
-                self.rContainer.appendChild(buildWeekdays());
-                if (!self.daysContainer) {
-                    self.daysContainer = createElement("div", "flatpickr-days");
-                    self.daysContainer.tabIndex = -1;
-                }
-                buildDays();
-                self.rContainer.appendChild(self.daysContainer);
-                self.innerContainer.appendChild(self.rContainer);
-                fragment.appendChild(self.innerContainer);
-            }
-            if (self.config.enableTime) {
-                fragment.appendChild(buildTime());
-            }
-            toggleClass(self.calendarContainer, "rangeMode", self.config.mode === "range");
-            toggleClass(self.calendarContainer, "animate", self.config.animate === true);
-            toggleClass(self.calendarContainer, "multiMonth", self.config.showMonths > 1);
-            self.calendarContainer.appendChild(fragment);
-            var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType !== undefined;
-            if (self.config.inline || self.config.static) {
-                self.calendarContainer.classList.add(self.config.inline ? "inline" : "static");
-                if (self.config.inline) {
-                    if (!customAppend && self.element.parentNode) self.element.parentNode.insertBefore(self.calendarContainer, self._input.nextSibling);else if (self.config.appendTo !== undefined) self.config.appendTo.appendChild(self.calendarContainer);
-                }
-                if (self.config.static) {
-                    var wrapper = createElement("div", "flatpickr-wrapper");
-                    if (self.element.parentNode) self.element.parentNode.insertBefore(wrapper, self.element);
-                    wrapper.appendChild(self.element);
-                    if (self.altInput) wrapper.appendChild(self.altInput);
-                    wrapper.appendChild(self.calendarContainer);
-                }
-            }
-            if (!self.config.static && !self.config.inline) (self.config.appendTo !== undefined ? self.config.appendTo : window.document.body).appendChild(self.calendarContainer);
-        }
-        function createDay(className, date, dayNumber, i) {
-            var dateIsEnabled = isEnabled(date, true),
-                dayElement = createElement("span", "flatpickr-day " + className, date.getDate().toString());
-            dayElement.dateObj = date;
-            dayElement.$i = i;
-            dayElement.setAttribute("aria-label", self.formatDate(date, self.config.ariaDateFormat));
-            if (className.indexOf("hidden") === -1 && compareDates(date, self.now) === 0) {
-                self.todayDateElem = dayElement;
-                dayElement.classList.add("today");
-                dayElement.setAttribute("aria-current", "date");
-            }
-            if (dateIsEnabled) {
-                dayElement.tabIndex = -1;
-                if (isDateSelected(date)) {
-                    dayElement.classList.add("selected");
-                    self.selectedDateElem = dayElement;
-                    if (self.config.mode === "range") {
-                        toggleClass(dayElement, "startRange", self.selectedDates[0] && compareDates(date, self.selectedDates[0], true) === 0);
-                        toggleClass(dayElement, "endRange", self.selectedDates[1] && compareDates(date, self.selectedDates[1], true) === 0);
-                        if (className === "nextMonthDay") dayElement.classList.add("inRange");
-                    }
-                }
-            } else {
-                dayElement.classList.add("disabled");
-            }
-            if (self.config.mode === "range") {
-                if (isDateInRange(date) && !isDateSelected(date)) dayElement.classList.add("inRange");
-            }
-            if (self.weekNumbers && self.config.showMonths === 1 && className !== "prevMonthDay" && dayNumber % 7 === 1) {
-                self.weekNumbers.insertAdjacentHTML("beforeend", "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>");
-            }
-            triggerEvent("onDayCreate", dayElement);
-            return dayElement;
-        }
-        function focusOnDayElem(targetNode) {
-            targetNode.focus();
-            if (self.config.mode === "range") onMouseOver(targetNode);
-        }
-        function getFirstAvailableDay(delta) {
-            var startMonth = delta > 0 ? 0 : self.config.showMonths - 1;
-            var endMonth = delta > 0 ? self.config.showMonths : -1;
-            for (var m = startMonth; m != endMonth; m += delta) {
-                var month = self.daysContainer.children[m];
-                var startIndex = delta > 0 ? 0 : month.children.length - 1;
-                var endIndex = delta > 0 ? month.children.length : -1;
-                for (var i = startIndex; i != endIndex; i += delta) {
-                    var c = month.children[i];
-                    if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj)) return c;
-                }
-            }
-            return undefined;
-        }
-        function getNextAvailableDay(current, delta) {
-            var givenMonth = current.className.indexOf("Month") === -1 ? current.dateObj.getMonth() : self.currentMonth;
-            var endMonth = delta > 0 ? self.config.showMonths : -1;
-            var loopDelta = delta > 0 ? 1 : -1;
-            for (var m = givenMonth - self.currentMonth; m != endMonth; m += loopDelta) {
-                var month = self.daysContainer.children[m];
-                var startIndex = givenMonth - self.currentMonth === m ? current.$i + delta : delta < 0 ? month.children.length - 1 : 0;
-                var numMonthDays = month.children.length;
-                for (var i = startIndex; i >= 0 && i < numMonthDays && i != (delta > 0 ? numMonthDays : -1); i += loopDelta) {
-                    var c = month.children[i];
-                    if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj) && Math.abs(current.$i - i) >= Math.abs(delta)) return focusOnDayElem(c);
-                }
-            }
-            self.changeMonth(loopDelta);
-            focusOnDay(getFirstAvailableDay(loopDelta), 0);
-            return undefined;
-        }
-        function focusOnDay(current, offset) {
-            var dayFocused = isInView(document.activeElement || document.body);
-            var startElem = current !== undefined ? current : dayFocused ? document.activeElement : self.selectedDateElem !== undefined && isInView(self.selectedDateElem) ? self.selectedDateElem : self.todayDateElem !== undefined && isInView(self.todayDateElem) ? self.todayDateElem : getFirstAvailableDay(offset > 0 ? 1 : -1);
-            if (startElem === undefined) return self._input.focus();
-            if (!dayFocused) return focusOnDayElem(startElem);
-            getNextAvailableDay(startElem, offset);
-        }
-        function buildMonthDays(year, month) {
-            var firstOfMonth = (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
-            var prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12);
-            var daysInMonth = self.utils.getDaysInMonth(month),
-                days = window.document.createDocumentFragment(),
-                isMultiMonth = self.config.showMonths > 1,
-                prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
-                nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
-            var dayNumber = prevMonthDays + 1 - firstOfMonth,
-                dayIndex = 0;
-            // prepend days from the ending of previous month
-            for (; dayNumber <= prevMonthDays; dayNumber++, dayIndex++) {
-                days.appendChild(createDay(prevMonthDayClass, new Date(year, month - 1, dayNumber), dayNumber, dayIndex));
-            }
-            // Start at 1 since there is no 0th day
-            for (dayNumber = 1; dayNumber <= daysInMonth; dayNumber++, dayIndex++) {
-                days.appendChild(createDay("", new Date(year, month, dayNumber), dayNumber, dayIndex));
-            }
-            // append days from the next month
-            for (var dayNum = daysInMonth + 1; dayNum <= 42 - firstOfMonth && (self.config.showMonths === 1 || dayIndex % 7 !== 0); dayNum++, dayIndex++) {
-                days.appendChild(createDay(nextMonthDayClass, new Date(year, month + 1, dayNum % daysInMonth), dayNum, dayIndex));
-            }
-            //updateNavigationCurrentMonth();
-            var dayContainer = createElement("div", "dayContainer");
-            dayContainer.appendChild(days);
-            return dayContainer;
-        }
-        function buildDays() {
-            if (self.daysContainer === undefined) {
-                return;
-            }
-            clearNode(self.daysContainer);
-            // TODO: week numbers for each month
-            if (self.weekNumbers) clearNode(self.weekNumbers);
-            var frag = document.createDocumentFragment();
-            for (var i = 0; i < self.config.showMonths; i++) {
-                var d = new Date(self.currentYear, self.currentMonth, 1);
-                d.setMonth(self.currentMonth + i);
-                frag.appendChild(buildMonthDays(d.getFullYear(), d.getMonth()));
-            }
-            self.daysContainer.appendChild(frag);
-            self.days = self.daysContainer.firstChild;
-            if (self.config.mode === "range" && self.selectedDates.length === 1) {
-                onMouseOver();
-            }
-        }
-        function buildMonth() {
-            var container = createElement("div", "flatpickr-month");
-            var monthNavFragment = window.document.createDocumentFragment();
-            var monthElement = createElement("span", "cur-month");
-            var yearInput = createNumberInput("cur-year", { tabindex: "-1" });
-            var yearElement = yearInput.getElementsByTagName("input")[0];
-            yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
-            if (self.config.minDate) {
-                yearElement.setAttribute("min", self.config.minDate.getFullYear().toString());
-            }
-            if (self.config.maxDate) {
-                yearElement.setAttribute("max", self.config.maxDate.getFullYear().toString());
-                yearElement.disabled = !!self.config.minDate && self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
-            }
-            var currentMonth = createElement("div", "flatpickr-current-month");
-            currentMonth.appendChild(monthElement);
-            currentMonth.appendChild(yearInput);
-            monthNavFragment.appendChild(currentMonth);
-            container.appendChild(monthNavFragment);
-            return {
-                container: container,
-                yearElement: yearElement,
-                monthElement: monthElement
-            };
-        }
-        function buildMonths() {
-            clearNode(self.monthNav);
-            self.monthNav.appendChild(self.prevMonthNav);
-            if (self.config.showMonths) {
-                self.yearElements = [];
-                self.monthElements = [];
-            }
-            for (var m = self.config.showMonths; m--;) {
-                var month = buildMonth();
-                self.yearElements.push(month.yearElement);
-                self.monthElements.push(month.monthElement);
-                self.monthNav.appendChild(month.container);
-            }
-            self.monthNav.appendChild(self.nextMonthNav);
-        }
-        function buildMonthNav() {
-            self.monthNav = createElement("div", "flatpickr-months");
-            self.yearElements = [];
-            self.monthElements = [];
-            self.prevMonthNav = createElement("span", "flatpickr-prev-month");
-            self.prevMonthNav.innerHTML = self.config.prevArrow;
-            self.nextMonthNav = createElement("span", "flatpickr-next-month");
-            self.nextMonthNav.innerHTML = self.config.nextArrow;
-            buildMonths();
-            Object.defineProperty(self, "_hidePrevMonthArrow", {
-                get: function get() {
-                    return self.__hidePrevMonthArrow;
-                },
-                set: function set(bool) {
-                    if (self.__hidePrevMonthArrow !== bool) {
-                        toggleClass(self.prevMonthNav, "disabled", bool);
-                        self.__hidePrevMonthArrow = bool;
-                    }
-                }
-            });
-            Object.defineProperty(self, "_hideNextMonthArrow", {
-                get: function get() {
-                    return self.__hideNextMonthArrow;
-                },
-                set: function set(bool) {
-                    if (self.__hideNextMonthArrow !== bool) {
-                        toggleClass(self.nextMonthNav, "disabled", bool);
-                        self.__hideNextMonthArrow = bool;
-                    }
-                }
-            });
-            self.currentYearElement = self.yearElements[0];
-            updateNavigationCurrentMonth();
-            return self.monthNav;
-        }
-        function buildTime() {
-            self.calendarContainer.classList.add("hasTime");
-            if (self.config.noCalendar) self.calendarContainer.classList.add("noCalendar");
-            self.timeContainer = createElement("div", "flatpickr-time");
-            self.timeContainer.tabIndex = -1;
-            var separator = createElement("span", "flatpickr-time-separator", ":");
-            var hourInput = createNumberInput("flatpickr-hour");
-            self.hourElement = hourInput.getElementsByTagName("input")[0];
-            var minuteInput = createNumberInput("flatpickr-minute");
-            self.minuteElement = minuteInput.getElementsByTagName("input")[0];
-            self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
-            self.hourElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getHours() : self.config.time_24hr ? self.config.defaultHour : military2ampm(self.config.defaultHour));
-            self.minuteElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getMinutes() : self.config.defaultMinute);
-            self.hourElement.setAttribute("step", self.config.hourIncrement.toString());
-            self.minuteElement.setAttribute("step", self.config.minuteIncrement.toString());
-            self.hourElement.setAttribute("min", self.config.time_24hr ? "0" : "1");
-            self.hourElement.setAttribute("max", self.config.time_24hr ? "23" : "12");
-            self.minuteElement.setAttribute("min", "0");
-            self.minuteElement.setAttribute("max", "59");
-            self.timeContainer.appendChild(hourInput);
-            self.timeContainer.appendChild(separator);
-            self.timeContainer.appendChild(minuteInput);
-            if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
-            if (self.config.enableSeconds) {
-                self.timeContainer.classList.add("hasSeconds");
-                var secondInput = createNumberInput("flatpickr-second");
-                self.secondElement = secondInput.getElementsByTagName("input")[0];
-                self.secondElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getSeconds() : self.config.defaultSeconds);
-                self.secondElement.setAttribute("step", self.minuteElement.getAttribute("step"));
-                self.secondElement.setAttribute("min", "0");
-                self.secondElement.setAttribute("max", "59");
-                self.timeContainer.appendChild(createElement("span", "flatpickr-time-separator", ":"));
-                self.timeContainer.appendChild(secondInput);
-            }
-            if (!self.config.time_24hr) {
-                // add self.amPM if appropriate
-                self.amPM = createElement("span", "flatpickr-am-pm", self.l10n.amPM[int((self.latestSelectedDateObj ? self.hourElement.value : self.config.defaultHour) > 11)]);
-                self.amPM.title = self.l10n.toggleTitle;
-                self.amPM.tabIndex = -1;
-                self.timeContainer.appendChild(self.amPM);
-            }
-            return self.timeContainer;
-        }
-        function buildWeekdays() {
-            if (!self.weekdayContainer) self.weekdayContainer = createElement("div", "flatpickr-weekdays");else clearNode(self.weekdayContainer);
-            for (var i = self.config.showMonths; i--;) {
-                var container = createElement("div", "flatpickr-weekdaycontainer");
-                self.weekdayContainer.appendChild(container);
-            }
-            updateWeekdays();
-            return self.weekdayContainer;
-        }
-        function updateWeekdays() {
-            var firstDayOfWeek = self.l10n.firstDayOfWeek;
-            var weekdays = self.l10n.weekdays.shorthand.slice();
-            if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {
-                weekdays = weekdays.splice(firstDayOfWeek, weekdays.length).concat(weekdays.splice(0, firstDayOfWeek));
-            }
-            for (var i = self.config.showMonths; i--;) {
-                self.weekdayContainer.children[i].innerHTML = "\n      <span class='flatpickr-weekday'>\n        " + weekdays.join("</span><span class='flatpickr-weekday'>") + "\n      </span>\n      ";
-            }
-        }
-        /* istanbul ignore next */
-        function buildWeeks() {
-            self.calendarContainer.classList.add("hasWeeks");
-            var weekWrapper = createElement("div", "flatpickr-weekwrapper");
-            weekWrapper.appendChild(createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation));
-            var weekNumbers = createElement("div", "flatpickr-weeks");
-            weekWrapper.appendChild(weekNumbers);
-            return {
-                weekWrapper: weekWrapper,
-                weekNumbers: weekNumbers
-            };
-        }
-        function changeMonth(value, is_offset) {
-            if (is_offset === void 0) {
-                is_offset = true;
-            }
-            var delta = is_offset ? value : value - self.currentMonth;
-            if (delta < 0 && self._hidePrevMonthArrow === true || delta > 0 && self._hideNextMonthArrow === true) return;
-            self.currentMonth += delta;
-            if (self.currentMonth < 0 || self.currentMonth > 11) {
-                self.currentYear += self.currentMonth > 11 ? 1 : -1;
-                self.currentMonth = (self.currentMonth + 12) % 12;
-                triggerEvent("onYearChange");
-            }
-            buildDays();
-            triggerEvent("onMonthChange");
-            updateNavigationCurrentMonth();
-        }
-        function clear(triggerChangeEvent, toInitial) {
-            if (triggerChangeEvent === void 0) {
-                triggerChangeEvent = true;
-            }
-            if (toInitial === void 0) {
-                toInitial = true;
-            }
-            self.input.value = "";
-            if (self.altInput !== undefined) self.altInput.value = "";
-            if (self.mobileInput !== undefined) self.mobileInput.value = "";
-            self.selectedDates = [];
-            self.latestSelectedDateObj = undefined;
-            if (toInitial === true) {
-                self.currentYear = self._initialDate.getFullYear();
-                self.currentMonth = self._initialDate.getMonth();
-            }
-            self.showTimeInput = false;
-            if (self.config.enableTime === true) {
-                setDefaultHours();
-            }
-            self.redraw();
-            if (triggerChangeEvent)
-                // triggerChangeEvent is true (default) or an Event
-                triggerEvent("onChange");
-        }
-        function close() {
-            self.isOpen = false;
-            if (!self.isMobile) {
-                if (self.calendarContainer !== undefined) {
-                    self.calendarContainer.classList.remove("open");
-                }
-                if (self._input !== undefined) {
-                    self._input.classList.remove("active");
-                }
-            }
-            triggerEvent("onClose");
-        }
-        function destroy() {
-            if (self.config !== undefined) triggerEvent("onDestroy");
-            for (var i = self._handlers.length; i--;) {
-                var h = self._handlers[i];
-                h.element.removeEventListener(h.event, h.handler, h.options);
-            }
-            self._handlers = [];
-            if (self.mobileInput) {
-                if (self.mobileInput.parentNode) self.mobileInput.parentNode.removeChild(self.mobileInput);
-                self.mobileInput = undefined;
-            } else if (self.calendarContainer && self.calendarContainer.parentNode) {
-                if (self.config.static && self.calendarContainer.parentNode) {
-                    var wrapper = self.calendarContainer.parentNode;
-                    wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
-                    if (wrapper.parentNode) {
-                        while (wrapper.firstChild) {
-                            wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
-                        }wrapper.parentNode.removeChild(wrapper);
-                    }
-                } else self.calendarContainer.parentNode.removeChild(self.calendarContainer);
-            }
-            if (self.altInput) {
-                self.input.type = "text";
-                if (self.altInput.parentNode) self.altInput.parentNode.removeChild(self.altInput);
-                delete self.altInput;
-            }
-            if (self.input) {
-                self.input.type = self.input._type;
-                self.input.classList.remove("flatpickr-input");
-                self.input.removeAttribute("readonly");
-                self.input.value = "";
-            }
-            ["_showTimeInput", "latestSelectedDateObj", "_hideNextMonthArrow", "_hidePrevMonthArrow", "__hideNextMonthArrow", "__hidePrevMonthArrow", "isMobile", "isOpen", "selectedDateElem", "minDateHasTime", "maxDateHasTime", "days", "daysContainer", "_input", "_positionElement", "innerContainer", "rContainer", "monthNav", "todayDateElem", "calendarContainer", "weekdayContainer", "prevMonthNav", "nextMonthNav", "currentMonthElement", "currentYearElement", "navigationCurrentMonth", "selectedDateElem", "config"].forEach(function (k) {
-                try {
-                    delete self[k];
-                } catch (_) {}
-            });
-        }
-        function isCalendarElem(elem) {
-            if (self.config.appendTo && self.config.appendTo.contains(elem)) return true;
-            return self.calendarContainer.contains(elem);
-        }
-        function documentClick(e) {
-            if (self.isOpen && !self.config.inline) {
-                var eventTarget_1 = getEventTarget(e);
-                var isCalendarElement = isCalendarElem(eventTarget_1);
-                var isInput = eventTarget_1 === self.input || eventTarget_1 === self.altInput || self.element.contains(eventTarget_1) ||
-                // web components
-                // e.path is not present in all browsers. circumventing typechecks
-                e.path && e.path.indexOf && (~e.path.indexOf(self.input) || ~e.path.indexOf(self.altInput));
-                var lostFocus = e.type === "blur" ? isInput && e.relatedTarget && !isCalendarElem(e.relatedTarget) : !isInput && !isCalendarElement && !isCalendarElem(e.relatedTarget);
-                var isIgnored = !self.config.ignoredFocusElements.some(function (elem) {
-                    return elem.contains(eventTarget_1);
-                });
-                if (lostFocus && isIgnored) {
-                    self.close();
-                    if (self.config.mode === "range" && self.selectedDates.length === 1) {
-                        self.clear(false);
-                        self.redraw();
-                    }
-                }
-            }
-        }
-        function changeYear(newYear) {
-            if (!newYear || self.config.minDate && newYear < self.config.minDate.getFullYear() || self.config.maxDate && newYear > self.config.maxDate.getFullYear()) return;
-            var newYearNum = newYear,
-                isNewYear = self.currentYear !== newYearNum;
-            self.currentYear = newYearNum || self.currentYear;
-            if (self.config.maxDate && self.currentYear === self.config.maxDate.getFullYear()) {
-                self.currentMonth = Math.min(self.config.maxDate.getMonth(), self.currentMonth);
-            } else if (self.config.minDate && self.currentYear === self.config.minDate.getFullYear()) {
-                self.currentMonth = Math.max(self.config.minDate.getMonth(), self.currentMonth);
-            }
-            if (isNewYear) {
-                self.redraw();
-                triggerEvent("onYearChange");
-            }
-        }
-        function isEnabled(date, timeless) {
-            if (timeless === void 0) {
-                timeless = true;
-            }
-            var dateToCheck = self.parseDate(date, undefined, timeless); // timeless
-            if (self.config.minDate && dateToCheck && compareDates(dateToCheck, self.config.minDate, timeless !== undefined ? timeless : !self.minDateHasTime) < 0 || self.config.maxDate && dateToCheck && compareDates(dateToCheck, self.config.maxDate, timeless !== undefined ? timeless : !self.maxDateHasTime) > 0) return false;
-            if (self.config.enable.length === 0 && self.config.disable.length === 0) return true;
-            if (dateToCheck === undefined) return false;
-            var bool = self.config.enable.length > 0,
-                array = bool ? self.config.enable : self.config.disable;
-            for (var i = 0, d = void 0; i < array.length; i++) {
-                d = array[i];
-                if (typeof d === "function" && d(dateToCheck) // disabled by function
-                ) return bool;else if (d instanceof Date && dateToCheck !== undefined && d.getTime() === dateToCheck.getTime())
-                    // disabled by date
-                    return bool;else if (typeof d === "string" && dateToCheck !== undefined) {
-                    // disabled by date string
-                    var parsed = self.parseDate(d, undefined, true);
-                    return parsed && parsed.getTime() === dateToCheck.getTime() ? bool : !bool;
-                } else if (
-                // disabled by range
-                (typeof d === 'undefined' ? 'undefined' : _typeof(d)) === "object" && dateToCheck !== undefined && d.from && d.to && dateToCheck.getTime() >= d.from.getTime() && dateToCheck.getTime() <= d.to.getTime()) return bool;
-            }
-            return !bool;
-        }
-        function isInView(elem) {
-            if (self.daysContainer !== undefined) return elem.className.indexOf("hidden") === -1 && self.daysContainer.contains(elem);
-            return false;
-        }
-        function onKeyDown(e) {
-            // e.key                      e.keyCode
-            // "Backspace"                        8
-            // "Tab"                              9
-            // "Enter"                           13
-            // "Escape"     (IE "Esc")           27
-            // "ArrowLeft"  (IE "Left")          37
-            // "ArrowUp"    (IE "Up")            38
-            // "ArrowRight" (IE "Right")         39
-            // "ArrowDown"  (IE "Down")          40
-            // "Delete"     (IE "Del")           46
-            var isInput = e.target === self._input;
-            var allowInput = self.config.allowInput;
-            var allowKeydown = self.isOpen && (!allowInput || !isInput);
-            var allowInlineKeydown = self.config.inline && isInput && !allowInput;
-            if (e.keyCode === 13 && isInput) {
-                if (allowInput) {
-                    self.setDate(self._input.value, true, e.target === self.altInput ? self.config.altFormat : self.config.dateFormat);
-                    return e.target.blur();
-                } else self.open();
-            } else if (isCalendarElem(e.target) || allowKeydown || allowInlineKeydown) {
-                var isTimeObj = !!self.timeContainer && self.timeContainer.contains(e.target);
-                switch (e.keyCode) {
-                    case 13:
-                        if (isTimeObj) {
-                            updateTime();
-                            focusAndClose();
-                        } else selectDate(e);
-                        break;
-                    case 27:
-                        // escape
-                        e.preventDefault();
-                        focusAndClose();
-                        break;
-                    case 8:
-                    case 46:
-                        if (isInput && !self.config.allowInput) {
-                            e.preventDefault();
-                            self.clear();
-                        }
-                        break;
-                    case 37:
-                    case 39:
-                        if (!isTimeObj) {
-                            e.preventDefault();
-                            if (self.daysContainer !== undefined && (allowInput === false || document.activeElement && isInView(document.activeElement))) {
-                                var delta_1 = e.keyCode === 39 ? 1 : -1;
-                                if (!e.ctrlKey) focusOnDay(undefined, delta_1);else {
-                                    e.stopPropagation();
-                                    changeMonth(delta_1);
-                                    focusOnDay(getFirstAvailableDay(1), 0);
-                                }
-                            }
-                        } else if (self.hourElement) self.hourElement.focus();
-                        break;
-                    case 38:
-                    case 40:
-                        e.preventDefault();
-                        var delta = e.keyCode === 40 ? 1 : -1;
-                        if (self.daysContainer && e.target.$i !== undefined || e.target === self.input) {
-                            if (e.ctrlKey) {
-                                e.stopPropagation();
-                                changeYear(self.currentYear - delta);
-                                focusOnDay(getFirstAvailableDay(1), 0);
-                            } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
-                        } else if (self.config.enableTime) {
-                            if (!isTimeObj && self.hourElement) self.hourElement.focus();
-                            updateTime(e);
-                            self._debouncedChange();
-                        }
-                        break;
-                    case 9:
-                        if (isTimeObj) {
-                            var elems = [self.hourElement, self.minuteElement, self.secondElement, self.amPM].filter(function (x) {
-                                return x;
-                            });
-                            var i = elems.indexOf(e.target);
-                            if (i !== -1) {
-                                var target = elems[i + (e.shiftKey ? -1 : 1)];
-                                if (target !== undefined) {
-                                    e.preventDefault();
-                                    target.focus();
-                                } else if (e.shiftKey) {
-                                    e.preventDefault();
-                                    self._input.focus();
-                                }
-                            }
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            if (self.amPM !== undefined && e.target === self.amPM) {
-                switch (e.key) {
-                    case self.l10n.amPM[0].charAt(0):
-                    case self.l10n.amPM[0].charAt(0).toLowerCase():
-                        self.amPM.textContent = self.l10n.amPM[0];
-                        setHoursFromInputs();
-                        updateValue();
-                        break;
-                    case self.l10n.amPM[1].charAt(0):
-                    case self.l10n.amPM[1].charAt(0).toLowerCase():
-                        self.amPM.textContent = self.l10n.amPM[1];
-                        setHoursFromInputs();
-                        updateValue();
-                        break;
-                }
-            }
-            triggerEvent("onKeyDown", e);
-        }
-        function onMouseOver(elem) {
-            if (self.selectedDates.length !== 1 || elem && (!elem.classList.contains("flatpickr-day") || elem.classList.contains("disabled"))) return;
-            var hoverDate = elem ? elem.dateObj.getTime() : self.days.firstElementChild.dateObj.getTime(),
-                initialDate = self.parseDate(self.selectedDates[0], undefined, true).getTime(),
-                rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
-                rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime()),
-                lastDate = self.daysContainer.lastChild.lastChild.dateObj.getTime();
-            var containsDisabled = false;
-            var minRange = 0,
-                maxRange = 0;
-            for (var t = rangeStartDate; t < lastDate; t += duration.DAY) {
-                if (!isEnabled(new Date(t), true)) {
-                    containsDisabled = containsDisabled || t > rangeStartDate && t < rangeEndDate;
-                    if (t < initialDate && (!minRange || t > minRange)) minRange = t;else if (t > initialDate && (!maxRange || t < maxRange)) maxRange = t;
-                }
-            }
-            for (var m = 0; m < self.config.showMonths; m++) {
-                var month = self.daysContainer.children[m];
-                var prevMonth = self.daysContainer.children[m - 1];
-                var _loop_1 = function _loop_1(i, l) {
-                    var dayElem = month.children[i],
-                        date = dayElem.dateObj;
-                    var timestamp = date.getTime();
-                    var outOfRange = minRange > 0 && timestamp < minRange || maxRange > 0 && timestamp > maxRange;
-                    if (outOfRange) {
-                        dayElem.classList.add("notAllowed");
-                        ["inRange", "startRange", "endRange"].forEach(function (c) {
-                            dayElem.classList.remove(c);
-                        });
-                        return "continue";
-                    } else if (containsDisabled && !outOfRange) return "continue";
-                    ["startRange", "inRange", "endRange", "notAllowed"].forEach(function (c) {
-                        dayElem.classList.remove(c);
-                    });
-                    if (elem !== undefined) {
-                        elem.classList.add(hoverDate < self.selectedDates[0].getTime() ? "startRange" : "endRange");
-                        if (month.contains(elem) || !(m > 0 && prevMonth && prevMonth.lastChild.dateObj.getTime() >= timestamp)) {
-                            if (initialDate < hoverDate && timestamp === initialDate) dayElem.classList.add("startRange");else if (initialDate > hoverDate && timestamp === initialDate) dayElem.classList.add("endRange");
-                            if (timestamp >= minRange && (maxRange === 0 || timestamp <= maxRange) && isBetween(timestamp, initialDate, hoverDate)) dayElem.classList.add("inRange");
-                        }
-                    }
-                };
-                for (var i = 0, l = month.children.length; i < l; i++) {
-                    _loop_1(i, l);
-                }
-            }
-        }
-        function onResize() {
-            if (self.isOpen && !self.config.static && !self.config.inline) positionCalendar();
-        }
-        function setDefaultTime() {
-            self.setDate(self.config.minDate !== undefined ? new Date(self.config.minDate.getTime()) : new Date(), false);
-            setDefaultHours();
-            updateValue();
-        }
-        function open(e, positionElement) {
-            if (positionElement === void 0) {
-                positionElement = self._positionElement;
-            }
-            if (self.isMobile === true) {
-                if (e) {
-                    e.preventDefault();
-                    e.target && e.target.blur();
-                }
-                if (self.mobileInput !== undefined) {
-                    self.mobileInput.focus();
-                    self.mobileInput.click();
-                }
-                triggerEvent("onOpen");
-                return;
-            }
-            if (self._input.disabled || self.config.inline) return;
-            var wasOpen = self.isOpen;
-            self.isOpen = true;
-            if (!wasOpen) {
-                self.calendarContainer.classList.add("open");
-                self._input.classList.add("active");
-                triggerEvent("onOpen");
-                positionCalendar(positionElement);
-            }
-            if (self.config.enableTime === true && self.config.noCalendar === true) {
-                if (self.selectedDates.length === 0) {
-                    setDefaultTime();
-                }
-                if (self.config.allowInput === false && (e === undefined || !self.timeContainer.contains(e.relatedTarget))) {
-                    setTimeout(function () {
-                        return self.hourElement.select();
-                    }, 50);
-                }
-            }
-        }
-        function minMaxDateSetter(type) {
-            return function (date) {
-                var dateObj = self.config["_" + type + "Date"] = self.parseDate(date, self.config.dateFormat);
-                var inverseDateObj = self.config["_" + (type === "min" ? "max" : "min") + "Date"];
-                if (dateObj !== undefined) {
-                    self[type === "min" ? "minDateHasTime" : "maxDateHasTime"] = dateObj.getHours() > 0 || dateObj.getMinutes() > 0 || dateObj.getSeconds() > 0;
-                }
-                if (self.selectedDates) {
-                    self.selectedDates = self.selectedDates.filter(function (d) {
-                        return isEnabled(d);
-                    });
-                    if (!self.selectedDates.length && type === "min") setHoursFromDate(dateObj);
-                    updateValue();
-                }
-                if (self.daysContainer) {
-                    redraw();
-                    if (dateObj !== undefined) self.currentYearElement[type] = dateObj.getFullYear().toString();else self.currentYearElement.removeAttribute(type);
-                    self.currentYearElement.disabled = !!inverseDateObj && dateObj !== undefined && inverseDateObj.getFullYear() === dateObj.getFullYear();
-                }
-            };
-        }
-        function parseConfig() {
-            var boolOpts = ["wrap", "weekNumbers", "allowInput", "clickOpens", "time_24hr", "enableTime", "noCalendar", "altInput", "shorthandCurrentMonth", "inline", "static", "enableSeconds", "disableMobile"];
-            var userConfig = _assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
-            var formats = {};
-            self.config.parseDate = userConfig.parseDate;
-            self.config.formatDate = userConfig.formatDate;
-            Object.defineProperty(self.config, "enable", {
-                get: function get() {
-                    return self.config._enable;
-                },
-                set: function set(dates) {
-                    self.config._enable = parseDateRules(dates);
-                }
-            });
-            Object.defineProperty(self.config, "disable", {
-                get: function get() {
-                    return self.config._disable;
-                },
-                set: function set(dates) {
-                    self.config._disable = parseDateRules(dates);
-                }
-            });
-            var timeMode = userConfig.mode === "time";
-            if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
-                formats.dateFormat = userConfig.noCalendar || timeMode ? "H:i" + (userConfig.enableSeconds ? ":S" : "") : flatpickr.defaultConfig.dateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
-            }
-            if (userConfig.altInput && (userConfig.enableTime || timeMode) && !userConfig.altFormat) {
-                formats.altFormat = userConfig.noCalendar || timeMode ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K") : flatpickr.defaultConfig.altFormat + (" h:i" + (userConfig.enableSeconds ? ":S" : "") + " K");
-            }
-            Object.defineProperty(self.config, "minDate", {
-                get: function get() {
-                    return self.config._minDate;
-                },
-                set: minMaxDateSetter("min")
-            });
-            Object.defineProperty(self.config, "maxDate", {
-                get: function get() {
-                    return self.config._maxDate;
-                },
-                set: minMaxDateSetter("max")
-            });
-            var minMaxTimeSetter = function minMaxTimeSetter(type) {
-                return function (val) {
-                    self.config[type === "min" ? "_minTime" : "_maxTime"] = self.parseDate(val, "H:i");
-                };
-            };
-            Object.defineProperty(self.config, "minTime", {
-                get: function get() {
-                    return self.config._minTime;
-                },
-                set: minMaxTimeSetter("min")
-            });
-            Object.defineProperty(self.config, "maxTime", {
-                get: function get() {
-                    return self.config._maxTime;
-                },
-                set: minMaxTimeSetter("max")
-            });
-            if (userConfig.mode === "time") {
-                self.config.noCalendar = true;
-                self.config.enableTime = true;
-            }
-            Object.assign(self.config, formats, userConfig);
-            for (var i = 0; i < boolOpts.length; i++) {
-                self.config[boolOpts[i]] = self.config[boolOpts[i]] === true || self.config[boolOpts[i]] === "true";
-            }HOOKS.filter(function (hook) {
-                return self.config[hook] !== undefined;
-            }).forEach(function (hook) {
-                self.config[hook] = arrayify(self.config[hook] || []).map(bindToInstance);
-            });
-            self.isMobile = !self.config.disableMobile && !self.config.inline && self.config.mode === "single" && !self.config.disable.length && !self.config.enable.length && !self.config.weekNumbers && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-            for (var i = 0; i < self.config.plugins.length; i++) {
-                var pluginConf = self.config.plugins[i](self) || {};
-                for (var key in pluginConf) {
-                    if (HOOKS.indexOf(key) > -1) {
-                        self.config[key] = arrayify(pluginConf[key]).map(bindToInstance).concat(self.config[key]);
-                    } else if (typeof userConfig[key] === "undefined") self.config[key] = pluginConf[key];
-                }
-            }
-            triggerEvent("onParseConfig");
-        }
-        function setupLocale() {
-            if (_typeof(self.config.locale) !== "object" && typeof flatpickr.l10ns[self.config.locale] === "undefined") self.config.errorHandler(new Error("flatpickr: invalid locale " + self.config.locale));
-            self.l10n = _assign({}, flatpickr.l10ns["default"], _typeof(self.config.locale) === "object" ? self.config.locale : self.config.locale !== "default" ? flatpickr.l10ns[self.config.locale] : undefined);
-            tokenRegex.K = "(" + self.l10n.amPM[0] + "|" + self.l10n.amPM[1] + "|" + self.l10n.amPM[0].toLowerCase() + "|" + self.l10n.amPM[1].toLowerCase() + ")";
-            self.formatDate = createDateFormatter(self);
-            self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
-        }
-        function positionCalendar(customPositionElement) {
-            if (self.calendarContainer === undefined) return;
-            triggerEvent("onPreCalendarPosition");
-            var positionElement = customPositionElement || self._positionElement;
-            var calendarHeight = Array.prototype.reduce.call(self.calendarContainer.children, function (acc, child) {
-                return acc + child.offsetHeight;
-            }, 0),
-                calendarWidth = self.calendarContainer.offsetWidth,
-                configPos = self.config.position.split(" "),
-                configPosVertical = configPos[0],
-                configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
-                inputBounds = positionElement.getBoundingClientRect(),
-                distanceFromBottom = window.innerHeight - inputBounds.bottom,
-                showOnTop = configPosVertical === "above" || configPosVertical !== "below" && distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
-            var top = window.pageYOffset + inputBounds.top + (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
-            toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
-            toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
-            if (self.config.inline) return;
-            var left = window.pageXOffset + inputBounds.left - (configPosHorizontal != null && configPosHorizontal === "center" ? (calendarWidth - inputBounds.width) / 2 : 0);
-            var right = window.document.body.offsetWidth - inputBounds.right;
-            var rightMost = left + calendarWidth > window.document.body.offsetWidth;
-            var centerMost = right + calendarWidth > window.document.body.offsetWidth;
-            toggleClass(self.calendarContainer, "rightMost", rightMost);
-            if (self.config.static) return;
-            self.calendarContainer.style.top = top + "px";
-            if (!rightMost) {
-                self.calendarContainer.style.left = left + "px";
-                self.calendarContainer.style.right = "auto";
-            } else if (!centerMost) {
-                self.calendarContainer.style.left = "auto";
-                self.calendarContainer.style.right = right + "px";
-            } else {
-                var doc = document.styleSheets[0];
-                // some testing environments don't have css support
-                if (doc === undefined) return;
-                var bodyWidth = window.document.body.offsetWidth;
-                var centerLeft = Math.max(0, bodyWidth / 2 - calendarWidth / 2);
-                var centerBefore = ".flatpickr-calendar.centerMost:before";
-                var centerAfter = ".flatpickr-calendar.centerMost:after";
-                var centerIndex = doc.cssRules.length;
-                var centerStyle = "{left:" + inputBounds.left + "px;right:auto;}";
-                toggleClass(self.calendarContainer, "rightMost", false);
-                toggleClass(self.calendarContainer, "centerMost", true);
-                doc.insertRule(centerBefore + "," + centerAfter + centerStyle, centerIndex);
-                self.calendarContainer.style.left = centerLeft + "px";
-                self.calendarContainer.style.right = "auto";
-            }
-        }
-        function redraw() {
-            if (self.config.noCalendar || self.isMobile) return;
-            updateNavigationCurrentMonth();
-            buildDays();
-        }
-        function focusAndClose() {
-            self._input.focus();
-            if (window.navigator.userAgent.indexOf("MSIE") !== -1 || navigator.msMaxTouchPoints !== undefined) {
-                // hack - bugs in the way IE handles focus keeps the calendar open
-                setTimeout(self.close, 0);
-            } else {
-                self.close();
-            }
-        }
-        function selectDate(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            var isSelectable = function isSelectable(day) {
-                return day.classList && day.classList.contains("flatpickr-day") && !day.classList.contains("disabled") && !day.classList.contains("notAllowed");
-            };
-            var t = findParent(e.target, isSelectable);
-            if (t === undefined) return;
-            var target = t;
-            var selectedDate = self.latestSelectedDateObj = new Date(target.dateObj.getTime());
-            var shouldChangeMonth = (selectedDate.getMonth() < self.currentMonth || selectedDate.getMonth() > self.currentMonth + self.config.showMonths - 1) && self.config.mode !== "range";
-            self.selectedDateElem = target;
-            if (self.config.mode === "single") self.selectedDates = [selectedDate];else if (self.config.mode === "multiple") {
-                var selectedIndex = isDateSelected(selectedDate);
-                if (selectedIndex) self.selectedDates.splice(parseInt(selectedIndex), 1);else self.selectedDates.push(selectedDate);
-            } else if (self.config.mode === "range") {
-                if (self.selectedDates.length === 2) {
-                    self.clear(false, false);
-                }
-                self.latestSelectedDateObj = selectedDate;
-                self.selectedDates.push(selectedDate);
-                // unless selecting same date twice, sort ascendingly
-                if (compareDates(selectedDate, self.selectedDates[0], true) !== 0) self.selectedDates.sort(function (a, b) {
-                    return a.getTime() - b.getTime();
-                });
-            }
-            setHoursFromInputs();
-            if (shouldChangeMonth) {
-                var isNewYear = self.currentYear !== selectedDate.getFullYear();
-                self.currentYear = selectedDate.getFullYear();
-                self.currentMonth = selectedDate.getMonth();
-                if (isNewYear) triggerEvent("onYearChange");
-                triggerEvent("onMonthChange");
-            }
-            updateNavigationCurrentMonth();
-            buildDays();
-            updateValue();
-            if (self.config.enableTime) setTimeout(function () {
-                return self.showTimeInput = true;
-            }, 50);
-            // maintain focus
-            if (!shouldChangeMonth && self.config.mode !== "range" && self.config.showMonths === 1) focusOnDayElem(target);else if (self.selectedDateElem !== undefined && self.hourElement === undefined) {
-                self.selectedDateElem && self.selectedDateElem.focus();
-            }
-            if (self.hourElement !== undefined) self.hourElement !== undefined && self.hourElement.focus();
-            if (self.config.closeOnSelect) {
-                var single = self.config.mode === "single" && !self.config.enableTime;
-                var range = self.config.mode === "range" && self.selectedDates.length === 2 && !self.config.enableTime;
-                if (single || range) {
-                    focusAndClose();
-                }
-            }
-            triggerChange();
-        }
-        var CALLBACKS = {
-            locale: [setupLocale, updateWeekdays],
-            showMonths: [buildMonths, setCalendarWidth, buildWeekdays]
-        };
-        function set(option, value) {
-            if (option !== null && (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === "object") Object.assign(self.config, option);else {
-                self.config[option] = value;
-                if (CALLBACKS[option] !== undefined) CALLBACKS[option].forEach(function (x) {
-                    return x();
-                });else if (HOOKS.indexOf(option) > -1) self.config[option] = arrayify(value);
-            }
-            self.redraw();
-            updateValue(false);
-        }
-        function setSelectedDate(inputDate, format) {
-            var dates = [];
-            if (inputDate instanceof Array) dates = inputDate.map(function (d) {
-                return self.parseDate(d, format);
-            });else if (inputDate instanceof Date || typeof inputDate === "number") dates = [self.parseDate(inputDate, format)];else if (typeof inputDate === "string") {
-                switch (self.config.mode) {
-                    case "single":
-                    case "time":
-                        dates = [self.parseDate(inputDate, format)];
-                        break;
-                    case "multiple":
-                        dates = inputDate.split(self.config.conjunction).map(function (date) {
-                            return self.parseDate(date, format);
-                        });
-                        break;
-                    case "range":
-                        dates = inputDate.split(self.l10n.rangeSeparator).map(function (date) {
-                            return self.parseDate(date, format);
-                        });
-                        break;
-                    default:
-                        break;
-                }
-            } else self.config.errorHandler(new Error("Invalid date supplied: " + JSON.stringify(inputDate)));
-            self.selectedDates = dates.filter(function (d) {
-                return d instanceof Date && isEnabled(d, false);
-            });
-            if (self.config.mode === "range") self.selectedDates.sort(function (a, b) {
-                return a.getTime() - b.getTime();
-            });
-        }
-        function setDate(date, triggerChange, format) {
-            if (triggerChange === void 0) {
-                triggerChange = false;
-            }
-            if (format === void 0) {
-                format = self.config.dateFormat;
-            }
-            if (date !== 0 && !date || date instanceof Array && date.length === 0) return self.clear(triggerChange);
-            setSelectedDate(date, format);
-            self.showTimeInput = self.selectedDates.length > 0;
-            self.latestSelectedDateObj = self.selectedDates[0];
-            self.redraw();
-            jumpToDate();
-            setHoursFromDate();
-            updateValue(triggerChange);
-            if (triggerChange) triggerEvent("onChange");
-        }
-        function parseDateRules(arr) {
-            return arr.slice().map(function (rule) {
-                if (typeof rule === "string" || typeof rule === "number" || rule instanceof Date) {
-                    return self.parseDate(rule, undefined, true);
-                } else if (rule && (typeof rule === 'undefined' ? 'undefined' : _typeof(rule)) === "object" && rule.from && rule.to) return {
-                    from: self.parseDate(rule.from, undefined),
-                    to: self.parseDate(rule.to, undefined)
-                };
-                return rule;
-            }).filter(function (x) {
-                return x;
-            }); // remove falsy values
-        }
-        function setupDates() {
-            self.selectedDates = [];
-            self.now = self.parseDate(self.config.now) || new Date();
-            // Workaround IE11 setting placeholder as the input's value
-            var preloadedDate = self.config.defaultDate || ((self.input.nodeName === "INPUT" || self.input.nodeName === "TEXTAREA") && self.input.placeholder && self.input.value === self.input.placeholder ? null : self.input.value);
-            if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
-            self._initialDate = self.selectedDates.length > 0 ? self.selectedDates[0] : self.config.minDate && self.config.minDate.getTime() > self.now.getTime() ? self.config.minDate : self.config.maxDate && self.config.maxDate.getTime() < self.now.getTime() ? self.config.maxDate : self.now;
-            self.currentYear = self._initialDate.getFullYear();
-            self.currentMonth = self._initialDate.getMonth();
-            if (self.selectedDates.length > 0) self.latestSelectedDateObj = self.selectedDates[0];
-            if (self.config.minTime !== undefined) self.config.minTime = self.parseDate(self.config.minTime, "H:i");
-            if (self.config.maxTime !== undefined) self.config.maxTime = self.parseDate(self.config.maxTime, "H:i");
-            self.minDateHasTime = !!self.config.minDate && (self.config.minDate.getHours() > 0 || self.config.minDate.getMinutes() > 0 || self.config.minDate.getSeconds() > 0);
-            self.maxDateHasTime = !!self.config.maxDate && (self.config.maxDate.getHours() > 0 || self.config.maxDate.getMinutes() > 0 || self.config.maxDate.getSeconds() > 0);
-            Object.defineProperty(self, "showTimeInput", {
-                get: function get() {
-                    return self._showTimeInput;
-                },
-                set: function set(bool) {
-                    self._showTimeInput = bool;
-                    if (self.calendarContainer) toggleClass(self.calendarContainer, "showTimeInput", bool);
-                    self.isOpen && positionCalendar();
-                }
-            });
-        }
-        function setupInputs() {
-            self.input = self.config.wrap ? element.querySelector("[data-input]") : element;
-            /* istanbul ignore next */
-            if (!self.input) {
-                self.config.errorHandler(new Error("Invalid input element specified"));
-                return;
-            }
-            // hack: store previous type to restore it after destroy()
-            self.input._type = self.input.type;
-            self.input.type = "text";
-            self.input.classList.add("flatpickr-input");
-            self._input = self.input;
-            if (self.config.altInput) {
-                // replicate self.element
-                self.altInput = createElement(self.input.nodeName, self.input.className + " " + self.config.altInputClass);
-                self._input = self.altInput;
-                self.altInput.placeholder = self.input.placeholder;
-                self.altInput.disabled = self.input.disabled;
-                self.altInput.required = self.input.required;
-                self.altInput.tabIndex = self.input.tabIndex;
-                self.altInput.type = "text";
-                self.input.setAttribute("type", "hidden");
-                if (!self.config.static && self.input.parentNode) self.input.parentNode.insertBefore(self.altInput, self.input.nextSibling);
-            }
-            if (!self.config.allowInput) self._input.setAttribute("readonly", "readonly");
-            self._positionElement = self.config.positionElement || self._input;
-        }
-        function setupMobile() {
-            var inputType = self.config.enableTime ? self.config.noCalendar ? "time" : "datetime-local" : "date";
-            self.mobileInput = createElement("input", self.input.className + " flatpickr-mobile");
-            self.mobileInput.step = self.input.getAttribute("step") || "any";
-            self.mobileInput.tabIndex = 1;
-            self.mobileInput.type = inputType;
-            self.mobileInput.disabled = self.input.disabled;
-            self.mobileInput.required = self.input.required;
-            self.mobileInput.placeholder = self.input.placeholder;
-            self.mobileFormatStr = inputType === "datetime-local" ? "Y-m-d\\TH:i:S" : inputType === "date" ? "Y-m-d" : "H:i:S";
-            if (self.selectedDates.length > 0) {
-                self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(self.selectedDates[0], self.mobileFormatStr);
-            }
-            if (self.config.minDate) self.mobileInput.min = self.formatDate(self.config.minDate, "Y-m-d");
-            if (self.config.maxDate) self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
-            self.input.type = "hidden";
-            if (self.altInput !== undefined) self.altInput.type = "hidden";
-            try {
-                if (self.input.parentNode) self.input.parentNode.insertBefore(self.mobileInput, self.input.nextSibling);
-            } catch (_a) {}
-            bind(self.mobileInput, "change", function (e) {
-                self.setDate(e.target.value, false, self.mobileFormatStr);
-                triggerEvent("onChange");
-                triggerEvent("onClose");
-            });
-        }
-        function toggle(e) {
-            if (self.isOpen === true) return self.close();
-            self.open(e);
-        }
-        function triggerEvent(event, data) {
-            // If the instance has been destroyed already, all hooks have been removed
-            if (self.config === undefined) return;
-            var hooks = self.config[event];
-            if (hooks !== undefined && hooks.length > 0) {
-                for (var i = 0; hooks[i] && i < hooks.length; i++) {
-                    hooks[i](self.selectedDates, self.input.value, self, data);
-                }
-            }
-            if (event === "onChange") {
-                self.input.dispatchEvent(createEvent("change"));
-                // many front-end frameworks bind to the input event
-                self.input.dispatchEvent(createEvent("input"));
-            }
-        }
-        function createEvent(name) {
-            var e = document.createEvent("Event");
-            e.initEvent(name, true, true);
-            return e;
-        }
-        function isDateSelected(date) {
-            for (var i = 0; i < self.selectedDates.length; i++) {
-                if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
-            }
-            return false;
-        }
-        function isDateInRange(date) {
-            if (self.config.mode !== "range" || self.selectedDates.length < 2) return false;
-            return compareDates(date, self.selectedDates[0]) >= 0 && compareDates(date, self.selectedDates[1]) <= 0;
-        }
-        function updateNavigationCurrentMonth() {
-            if (self.config.noCalendar || self.isMobile || !self.monthNav) return;
-            self.yearElements.forEach(function (yearElement, i) {
-                var d = new Date(self.currentYear, self.currentMonth, 1);
-                d.setMonth(self.currentMonth + i);
-                self.monthElements[i].textContent = monthToStr(d.getMonth(), self.config.shorthandCurrentMonth, self.l10n) + " ";
-                yearElement.value = d.getFullYear().toString();
-            });
-            self._hidePrevMonthArrow = self.config.minDate !== undefined && (self.currentYear === self.config.minDate.getFullYear() ? self.currentMonth <= self.config.minDate.getMonth() : self.currentYear < self.config.minDate.getFullYear());
-            self._hideNextMonthArrow = self.config.maxDate !== undefined && (self.currentYear === self.config.maxDate.getFullYear() ? self.currentMonth + 1 > self.config.maxDate.getMonth() : self.currentYear > self.config.maxDate.getFullYear());
-        }
-        function getDateStr(format) {
-            return self.selectedDates.map(function (dObj) {
-                return self.formatDate(dObj, format);
-            }).filter(function (d, i, arr) {
-                return self.config.mode !== "range" || self.config.enableTime || arr.indexOf(d) === i;
-            }).join(self.config.mode !== "range" ? self.config.conjunction : self.l10n.rangeSeparator);
-        }
-        /**
-         * Updates the values of inputs associated with the calendar
-         */
-        function updateValue(triggerChange) {
-            if (triggerChange === void 0) {
-                triggerChange = true;
-            }
-            if (self.selectedDates.length === 0) return self.clear(triggerChange);
-            if (self.mobileInput !== undefined && self.mobileFormatStr) {
-                self.mobileInput.value = self.latestSelectedDateObj !== undefined ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr) : "";
-            }
-            self.input.value = getDateStr(self.config.dateFormat);
-            if (self.altInput !== undefined) {
-                self.altInput.value = getDateStr(self.config.altFormat);
-            }
-            if (triggerChange !== false) triggerEvent("onValueUpdate");
-        }
-        function onMonthNavClick(e) {
-            e.preventDefault();
-            var isPrevMonth = self.prevMonthNav.contains(e.target);
-            var isNextMonth = self.nextMonthNav.contains(e.target);
-            if (isPrevMonth || isNextMonth) {
-                changeMonth(isPrevMonth ? -1 : 1);
-            } else if (self.yearElements.indexOf(e.target) >= 0) {
-                e.target.select();
-            } else if (e.target.classList.contains("arrowUp")) {
-                self.changeYear(self.currentYear + 1);
-            } else if (e.target.classList.contains("arrowDown")) {
-                self.changeYear(self.currentYear - 1);
-            }
-        }
-        function timeWrapper(e) {
-            e.preventDefault();
-            var isKeyDown = e.type === "keydown",
-                input = e.target;
-            if (self.amPM !== undefined && e.target === self.amPM) {
-                self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
-            }
-            var min = parseFloat(input.getAttribute("min")),
-                max = parseFloat(input.getAttribute("max")),
-                step = parseFloat(input.getAttribute("step")),
-                curValue = parseInt(input.value, 10),
-                delta = e.delta || (isKeyDown ? e.which === 38 ? 1 : -1 : 0);
-            var newValue = curValue + step * delta;
-            if (typeof input.value !== "undefined" && input.value.length === 2) {
-                var isHourElem = input === self.hourElement,
-                    isMinuteElem = input === self.minuteElement;
-                if (newValue < min) {
-                    newValue = max + newValue + int(!isHourElem) + (int(isHourElem) && int(!self.amPM));
-                    if (isMinuteElem) incrementNumInput(undefined, -1, self.hourElement);
-                } else if (newValue > max) {
-                    newValue = input === self.hourElement ? newValue - max - int(!self.amPM) : min;
-                    if (isMinuteElem) incrementNumInput(undefined, 1, self.hourElement);
-                }
-                if (self.amPM && isHourElem && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) {
-                    self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
-                }
-                input.value = pad(newValue);
-            }
-        }
-        init();
-        return self;
+    if (timeless !== false) {
+      return new Date(date1.getTime()).setHours(0, 0, 0, 0) - new Date(date2.getTime()).setHours(0, 0, 0, 0);
     }
-    /* istanbul ignore next */
-    function _flatpickr(nodeList, config) {
-        // static list
-        var nodes = Array.prototype.slice.call(nodeList).filter(function (x) {
-            return x instanceof HTMLElement;
+
+    return date1.getTime() - date2.getTime();
+  }
+  var getWeek = function getWeek(givenDate) {
+    var date = new Date(givenDate.getTime());
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
+    var week1 = new Date(date.getFullYear(), 0, 4);
+    return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getDay() + 6) % 7) / 7);
+  };
+  var isBetween = function isBetween(ts, ts1, ts2) {
+    return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
+  };
+  var duration = {
+    DAY: 86400000
+  };
+
+  var HOOKS = ["onChange", "onClose", "onDayCreate", "onDestroy", "onKeyDown", "onMonthChange", "onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange", "onPreCalendarPosition"];
+  var defaults = {
+    _disable: [],
+    _enable: [],
+    allowInput: false,
+    altFormat: "F j, Y",
+    altInput: false,
+    altInputClass: "form-control input",
+    animate: (typeof window === 'undefined' ? 'undefined' : _typeof(window)) === "object" && window.navigator.userAgent.indexOf("MSIE") === -1,
+    ariaDateFormat: "F j, Y",
+    clickOpens: true,
+    closeOnSelect: true,
+    conjunction: ", ",
+    dateFormat: "Y-m-d",
+    defaultHour: 12,
+    defaultMinute: 0,
+    defaultSeconds: 0,
+    disable: [],
+    disableMobile: false,
+    enable: [],
+    enableSeconds: false,
+    enableTime: false,
+    errorHandler: function errorHandler(err) {
+      return typeof console !== "undefined" && console.warn(err);
+    },
+    getWeek: getWeek,
+    hourIncrement: 1,
+    ignoredFocusElements: [],
+    inline: false,
+    locale: "default",
+    minuteIncrement: 5,
+    mode: "single",
+    nextArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
+    noCalendar: false,
+    now: new Date(),
+    onChange: [],
+    onClose: [],
+    onDayCreate: [],
+    onDestroy: [],
+    onKeyDown: [],
+    onMonthChange: [],
+    onOpen: [],
+    onParseConfig: [],
+    onReady: [],
+    onValueUpdate: [],
+    onYearChange: [],
+    onPreCalendarPosition: [],
+    plugins: [],
+    position: "auto",
+    positionElement: undefined,
+    prevArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
+    shorthandCurrentMonth: false,
+    showMonths: 1,
+    static: false,
+    time_24hr: false,
+    weekNumbers: false,
+    wrap: false
+  };
+
+  function toggleClass(elem, className, bool) {
+    if (bool === true) return elem.classList.add(className);
+    elem.classList.remove(className);
+  }
+  function createElement(tag, className, content) {
+    var e = window.document.createElement(tag);
+    className = className || "";
+    content = content || "";
+    e.className = className;
+    if (content !== undefined) e.textContent = content;
+    return e;
+  }
+  function clearNode(node) {
+    while (node.firstChild) {
+      node.removeChild(node.firstChild);
+    }
+  }
+  function findParent(node, condition) {
+    if (condition(node)) return node;else if (node.parentNode) return findParent(node.parentNode, condition);
+    return undefined;
+  }
+  function createNumberInput(inputClassName, opts) {
+    var wrapper = createElement("div", "numInputWrapper"),
+        numInput = createElement("input", "numInput " + inputClassName),
+        arrowUp = createElement("span", "arrowUp"),
+        arrowDown = createElement("span", "arrowDown");
+    numInput.type = "text";
+    numInput.pattern = "\\d*";
+    if (opts !== undefined) for (var key in opts) {
+      numInput.setAttribute(key, opts[key]);
+    }
+    wrapper.appendChild(numInput);
+    wrapper.appendChild(arrowUp);
+    wrapper.appendChild(arrowDown);
+    return wrapper;
+  }
+
+  if (typeof Object.assign !== "function") {
+    Object.assign = function (target) {
+      if (!target) {
+        throw TypeError("Cannot convert undefined or null to object");
+      }
+
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      var _loop = function _loop() {
+        var source = args[_i];
+
+        if (source) {
+          Object.keys(source).forEach(function (key) {
+            return target[key] = source[key];
+          });
+        }
+      };
+
+      for (var _i = 0; _i < args.length; _i++) {
+        _loop();
+      }
+
+      return target;
+    };
+  }
+
+  var DEBOUNCED_CHANGE_MS = 300;
+
+  function FlatpickrInstance(element, instanceConfig) {
+    var self = {
+      config: Object.assign({}, flatpickr.defaultConfig),
+      l10n: english
+    };
+    self.parseDate = createDateParser({
+      config: self.config,
+      l10n: self.l10n
+    });
+    self._handlers = [];
+    self._bind = bind;
+    self._setHoursFromDate = setHoursFromDate;
+    self._positionCalendar = positionCalendar;
+    self.changeMonth = changeMonth;
+    self.changeYear = changeYear;
+    self.clear = clear;
+    self.close = close;
+    self._createElement = createElement;
+    self.destroy = destroy;
+    self.isEnabled = isEnabled;
+    self.jumpToDate = jumpToDate;
+    self.open = open;
+    self.redraw = redraw;
+    self.set = set;
+    self.setDate = setDate;
+    self.toggle = toggle;
+
+    function setupHelperFunctions() {
+      self.utils = {
+        getDaysInMonth: function getDaysInMonth(month, yr) {
+          if (month === void 0) {
+            month = self.currentMonth;
+          }
+
+          if (yr === void 0) {
+            yr = self.currentYear;
+          }
+
+          if (month === 1 && (yr % 4 === 0 && yr % 100 !== 0 || yr % 400 === 0)) return 29;
+          return self.l10n.daysInMonth[month];
+        }
+      };
+    }
+
+    function init() {
+      self.element = self.input = element;
+      self.isOpen = false;
+      parseConfig();
+      setupLocale();
+      setupInputs();
+      setupDates();
+      setupHelperFunctions();
+      if (!self.isMobile) build();
+      bindEvents();
+
+      if (self.selectedDates.length || self.config.noCalendar) {
+        if (self.config.enableTime) {
+          setHoursFromDate(self.config.noCalendar ? self.latestSelectedDateObj || self.config.minDate : undefined);
+        }
+
+        updateValue(false);
+      }
+
+      setCalendarWidth();
+      self.showTimeInput = self.selectedDates.length > 0 || self.config.noCalendar;
+      var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+      if (!self.isMobile && isSafari) {
+        positionCalendar();
+      }
+
+      triggerEvent("onReady");
+    }
+
+    function bindToInstance(fn) {
+      return fn.bind(self);
+    }
+
+    function setCalendarWidth() {
+      var config = self.config;
+      if (config.weekNumbers === false && config.showMonths === 1) return;else if (config.noCalendar !== true) {
+        window.requestAnimationFrame(function () {
+          self.calendarContainer.style.visibility = "hidden";
+          self.calendarContainer.style.display = "block";
+
+          if (self.daysContainer !== undefined) {
+            var daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
+            self.daysContainer.style.width = daysWidth + "px";
+            self.calendarContainer.style.width = daysWidth + (self.weekWrapper !== undefined ? self.weekWrapper.offsetWidth : 0) + "px";
+            self.calendarContainer.style.removeProperty("visibility");
+            self.calendarContainer.style.removeProperty("display");
+          }
         });
-        var instances = [];
-        for (var i = 0; i < nodes.length; i++) {
-            var node = nodes[i];
-            try {
-                if (node.getAttribute("data-fp-omit") !== null) continue;
-                if (node._flatpickr !== undefined) {
-                    node._flatpickr.destroy();
-                    node._flatpickr = undefined;
-                }
-                node._flatpickr = FlatpickrInstance(node, config || {});
-                instances.push(node._flatpickr);
-            } catch (e) {
-                console.error(e);
-            }
-        }
-        return instances.length === 1 ? instances[0] : instances;
-    }
-    /* istanbul ignore next */
-    if (typeof HTMLElement !== "undefined") {
-        // browser env
-        HTMLCollection.prototype.flatpickr = NodeList.prototype.flatpickr = function (config) {
-            return _flatpickr(this, config);
-        };
-        HTMLElement.prototype.flatpickr = function (config) {
-            return _flatpickr([this], config);
-        };
-    }
-    /* istanbul ignore next */
-    var flatpickr = function flatpickr(selector, config) {
-        if (typeof selector === "string") {
-            return _flatpickr(window.document.querySelectorAll(selector), config);
-        } else if (selector instanceof Node) {
-            return _flatpickr([selector], config);
-        } else {
-            return _flatpickr(selector, config);
-        }
-    };
-    /* istanbul ignore next */
-    flatpickr.defaultConfig = defaults;
-    flatpickr.l10ns = {
-        en: _assign({}, english),
-        "default": _assign({}, english)
-    };
-    flatpickr.localize = function (l10n) {
-        flatpickr.l10ns["default"] = _assign({}, flatpickr.l10ns["default"], l10n);
-    };
-    flatpickr.setDefaults = function (config) {
-        flatpickr.defaultConfig = _assign({}, flatpickr.defaultConfig, config);
-    };
-    flatpickr.parseDate = createDateParser({});
-    flatpickr.formatDate = createDateFormatter({});
-    flatpickr.compareDates = compareDates;
-    /* istanbul ignore next */
-    if (typeof jQuery !== "undefined") {
-        jQuery.fn.flatpickr = function (config) {
-            return _flatpickr(this, config);
-        };
-    }
-    Date.prototype.fp_incr = function (days) {
-        return new Date(this.getFullYear(), this.getMonth(), this.getDate() + (typeof days === "string" ? parseInt(days, 10) : days));
-    };
-    if (typeof window !== "undefined") {
-        window.flatpickr = flatpickr;
+      }
     }
 
-    return flatpickr;
+    function updateTime(e) {
+      if (self.selectedDates.length === 0) return;
+
+      if (e !== undefined && e.type !== "blur") {
+        timeWrapper(e);
+      }
+
+      var prevValue = self._input.value;
+      setHoursFromInputs();
+      updateValue();
+
+      if (self._input.value !== prevValue) {
+        self._debouncedChange();
+      }
+    }
+
+    function ampm2military(hour, amPM) {
+      return hour % 12 + 12 * int(amPM === self.l10n.amPM[1]);
+    }
+
+    function military2ampm(hour) {
+      switch (hour % 24) {
+        case 0:
+        case 12:
+          return 12;
+
+        default:
+          return hour % 12;
+      }
+    }
+
+    function setHoursFromInputs() {
+      if (self.hourElement === undefined || self.minuteElement === undefined) return;
+      var hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
+          minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
+          seconds = self.secondElement !== undefined ? (parseInt(self.secondElement.value, 10) || 0) % 60 : 0;
+
+      if (self.amPM !== undefined) {
+        hours = ampm2military(hours, self.amPM.textContent);
+      }
+
+      var limitMinHours = self.config.minTime !== undefined || self.config.minDate && self.minDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.minDate, true) === 0;
+      var limitMaxHours = self.config.maxTime !== undefined || self.config.maxDate && self.maxDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.maxDate, true) === 0;
+
+      if (limitMaxHours) {
+        var maxTime = self.config.maxTime !== undefined ? self.config.maxTime : self.config.maxDate;
+        hours = Math.min(hours, maxTime.getHours());
+        if (hours === maxTime.getHours()) minutes = Math.min(minutes, maxTime.getMinutes());
+        if (minutes === maxTime.getMinutes()) seconds = Math.min(seconds, maxTime.getSeconds());
+      }
+
+      if (limitMinHours) {
+        var minTime = self.config.minTime !== undefined ? self.config.minTime : self.config.minDate;
+        hours = Math.max(hours, minTime.getHours());
+        if (hours === minTime.getHours()) minutes = Math.max(minutes, minTime.getMinutes());
+        if (minutes === minTime.getMinutes()) seconds = Math.max(seconds, minTime.getSeconds());
+      }
+
+      setHours(hours, minutes, seconds);
+    }
+
+    function setHoursFromDate(dateObj) {
+      var date = dateObj || self.latestSelectedDateObj;
+      if (date) setHours(date.getHours(), date.getMinutes(), date.getSeconds());
+    }
+
+    function setDefaultHours() {
+      var hours = self.config.defaultHour;
+      var minutes = self.config.defaultMinute;
+      var seconds = self.config.defaultSeconds;
+
+      if (self.config.minDate !== undefined) {
+        var min_hr = self.config.minDate.getHours();
+        var min_minutes = self.config.minDate.getMinutes();
+        hours = Math.max(hours, min_hr);
+        if (hours === min_hr) minutes = Math.max(min_minutes, minutes);
+        if (hours === min_hr && minutes === min_minutes) seconds = self.config.minDate.getSeconds();
+      }
+
+      if (self.config.maxDate !== undefined) {
+        var max_hr = self.config.maxDate.getHours();
+        var max_minutes = self.config.maxDate.getMinutes();
+        hours = Math.min(hours, max_hr);
+        if (hours === max_hr) minutes = Math.min(max_minutes, minutes);
+        if (hours === max_hr && minutes === max_minutes) seconds = self.config.maxDate.getSeconds();
+      }
+
+      setHours(hours, minutes, seconds);
+    }
+
+    function setHours(hours, minutes, seconds) {
+      if (self.latestSelectedDateObj !== undefined) {
+        self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
+      }
+
+      if (!self.hourElement || !self.minuteElement || self.isMobile) return;
+      self.hourElement.value = pad(!self.config.time_24hr ? (12 + hours) % 12 + 12 * int(hours % 12 === 0) : hours);
+      self.minuteElement.value = pad(minutes);
+      if (self.amPM !== undefined) self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
+      if (self.secondElement !== undefined) self.secondElement.value = pad(seconds);
+    }
+
+    function onYearInput(event) {
+      var year = parseInt(event.target.value) + (event.delta || 0);
+
+      if (year / 1000 > 1 || event.key === "Enter" && !/[^\d]/.test(year.toString())) {
+        changeYear(year);
+      }
+    }
+
+    function bind(element, event, handler, options) {
+      if (event instanceof Array) return event.forEach(function (ev) {
+        return bind(element, ev, handler, options);
+      });
+      if (element instanceof Array) return element.forEach(function (el) {
+        return bind(el, event, handler, options);
+      });
+      element.addEventListener(event, handler, options);
+
+      self._handlers.push({
+        element: element,
+        event: event,
+        handler: handler,
+        options: options
+      });
+    }
+
+    function onClick(handler) {
+      return function (evt) {
+        evt.which === 1 && handler(evt);
+      };
+    }
+
+    function triggerChange() {
+      triggerEvent("onChange");
+    }
+
+    function bindEvents() {
+      if (self.config.wrap) {
+        ["open", "close", "toggle", "clear"].forEach(function (evt) {
+          Array.prototype.forEach.call(self.element.querySelectorAll("[data-" + evt + "]"), function (el) {
+            return bind(el, "click", self[evt]);
+          });
+        });
+      }
+
+      if (self.isMobile) {
+        setupMobile();
+        return;
+      }
+
+      var debouncedResize = debounce(onResize, 50);
+      self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
+      if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent)) bind(self.daysContainer, "mouseover", function (e) {
+        if (self.config.mode === "range") onMouseOver(e.target);
+      });
+      bind(window.document.body, "keydown", onKeyDown);
+      if (!self.config.static) bind(self._input, "keydown", onKeyDown);
+      if (!self.config.inline && !self.config.static) bind(window, "resize", debouncedResize);
+      if (window.ontouchstart !== undefined) bind(window.document, "click", documentClick);else bind(window.document, "mousedown", onClick(documentClick));
+      bind(window.document, "focus", documentClick, {
+        capture: true
+      });
+
+      if (self.config.clickOpens === true) {
+        bind(self._input, "focus", self.open);
+        bind(self._input, "mousedown", onClick(self.open));
+      }
+
+      if (self.daysContainer !== undefined) {
+        bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
+        bind(self.monthNav, ["keyup", "increment"], onYearInput);
+        bind(self.daysContainer, "mousedown", onClick(selectDate));
+      }
+
+      if (self.timeContainer !== undefined && self.minuteElement !== undefined && self.hourElement !== undefined) {
+        var selText = function selText(e) {
+          return e.target.select();
+        };
+
+        bind(self.timeContainer, ["increment"], updateTime);
+        bind(self.timeContainer, "blur", updateTime, {
+          capture: true
+        });
+        bind(self.timeContainer, "mousedown", onClick(timeIncrement));
+        bind([self.hourElement, self.minuteElement], ["focus", "click"], selText);
+        if (self.secondElement !== undefined) bind(self.secondElement, "focus", function () {
+          return self.secondElement && self.secondElement.select();
+        });
+
+        if (self.amPM !== undefined) {
+          bind(self.amPM, "mousedown", onClick(function (e) {
+            updateTime(e);
+            triggerChange();
+          }));
+        }
+      }
+    }
+
+    function jumpToDate(jumpDate) {
+      var jumpTo = jumpDate !== undefined ? self.parseDate(jumpDate) : self.latestSelectedDateObj || (self.config.minDate && self.config.minDate > self.now ? self.config.minDate : self.config.maxDate && self.config.maxDate < self.now ? self.config.maxDate : self.now);
+
+      try {
+        if (jumpTo !== undefined) {
+          self.currentYear = jumpTo.getFullYear();
+          self.currentMonth = jumpTo.getMonth();
+        }
+      } catch (e) {
+        e.message = "Invalid date supplied: " + jumpTo;
+        self.config.errorHandler(e);
+      }
+
+      self.redraw();
+    }
+
+    function timeIncrement(e) {
+      if (~e.target.className.indexOf("arrow")) incrementNumInput(e, e.target.classList.contains("arrowUp") ? 1 : -1);
+    }
+
+    function incrementNumInput(e, delta, inputElem) {
+      var target = e && e.target;
+      var input = inputElem || target && target.parentNode && target.parentNode.firstChild;
+      var event = createEvent("increment");
+      event.delta = delta;
+      input && input.dispatchEvent(event);
+    }
+
+    function build() {
+      var fragment = window.document.createDocumentFragment();
+      self.calendarContainer = createElement("div", "flatpickr-calendar");
+      self.calendarContainer.tabIndex = -1;
+
+      if (!self.config.noCalendar) {
+        fragment.appendChild(buildMonthNav());
+        self.innerContainer = createElement("div", "flatpickr-innerContainer");
+
+        if (self.config.weekNumbers) {
+          var _buildWeeks = buildWeeks(),
+              weekWrapper = _buildWeeks.weekWrapper,
+              weekNumbers = _buildWeeks.weekNumbers;
+
+          self.innerContainer.appendChild(weekWrapper);
+          self.weekNumbers = weekNumbers;
+          self.weekWrapper = weekWrapper;
+        }
+
+        self.rContainer = createElement("div", "flatpickr-rContainer");
+        self.rContainer.appendChild(buildWeekdays());
+
+        if (!self.daysContainer) {
+          self.daysContainer = createElement("div", "flatpickr-days");
+          self.daysContainer.tabIndex = -1;
+        }
+
+        buildDays();
+        self.rContainer.appendChild(self.daysContainer);
+        self.innerContainer.appendChild(self.rContainer);
+        fragment.appendChild(self.innerContainer);
+      }
+
+      if (self.config.enableTime) {
+        fragment.appendChild(buildTime());
+      }
+
+      toggleClass(self.calendarContainer, "rangeMode", self.config.mode === "range");
+      toggleClass(self.calendarContainer, "animate", self.config.animate === true);
+      toggleClass(self.calendarContainer, "multiMonth", self.config.showMonths > 1);
+      self.calendarContainer.appendChild(fragment);
+      var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType !== undefined;
+
+      if (self.config.inline || self.config.static) {
+        self.calendarContainer.classList.add(self.config.inline ? "inline" : "static");
+
+        if (self.config.inline) {
+          if (!customAppend && self.element.parentNode) self.element.parentNode.insertBefore(self.calendarContainer, self._input.nextSibling);else if (self.config.appendTo !== undefined) self.config.appendTo.appendChild(self.calendarContainer);
+        }
+
+        if (self.config.static) {
+          var wrapper = createElement("div", "flatpickr-wrapper");
+          if (self.element.parentNode) self.element.parentNode.insertBefore(wrapper, self.element);
+          wrapper.appendChild(self.element);
+          if (self.altInput) wrapper.appendChild(self.altInput);
+          wrapper.appendChild(self.calendarContainer);
+        }
+      }
+
+      if (!self.config.static && !self.config.inline) (self.config.appendTo !== undefined ? self.config.appendTo : window.document.body).appendChild(self.calendarContainer);
+    }
+
+    function createDay(className, date, dayNumber, i) {
+      var dateIsEnabled = isEnabled(date, true),
+          dayElement = createElement("span", "flatpickr-day " + className, date.getDate().toString());
+      dayElement.dateObj = date;
+      dayElement.$i = i;
+      dayElement.setAttribute("aria-label", self.formatDate(date, self.config.ariaDateFormat));
+
+      if (className.indexOf("hidden") === -1 && compareDates(date, self.now) === 0) {
+        self.todayDateElem = dayElement;
+        dayElement.classList.add("today");
+        dayElement.setAttribute("aria-current", "date");
+      }
+
+      if (dateIsEnabled) {
+        dayElement.tabIndex = -1;
+
+        if (isDateSelected(date)) {
+          dayElement.classList.add("selected");
+          self.selectedDateElem = dayElement;
+
+          if (self.config.mode === "range") {
+            toggleClass(dayElement, "startRange", self.selectedDates[0] && compareDates(date, self.selectedDates[0], true) === 0);
+            toggleClass(dayElement, "endRange", self.selectedDates[1] && compareDates(date, self.selectedDates[1], true) === 0);
+            if (className === "nextMonthDay") dayElement.classList.add("inRange");
+          }
+        }
+      } else {
+        dayElement.classList.add("disabled");
+      }
+
+      if (self.config.mode === "range") {
+        if (isDateInRange(date) && !isDateSelected(date)) dayElement.classList.add("inRange");
+      }
+
+      if (self.weekNumbers && self.config.showMonths === 1 && className !== "prevMonthDay" && dayNumber % 7 === 1) {
+        self.weekNumbers.insertAdjacentHTML("beforeend", "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>");
+      }
+
+      triggerEvent("onDayCreate", dayElement);
+      return dayElement;
+    }
+
+    function focusOnDayElem(targetNode) {
+      targetNode.focus();
+      if (self.config.mode === "range") onMouseOver(targetNode);
+    }
+
+    function getFirstAvailableDay(delta) {
+      var startMonth = delta > 0 ? 0 : self.config.showMonths - 1;
+      var endMonth = delta > 0 ? self.config.showMonths : -1;
+
+      for (var m = startMonth; m != endMonth; m += delta) {
+        var month = self.daysContainer.children[m];
+        var startIndex = delta > 0 ? 0 : month.children.length - 1;
+        var endIndex = delta > 0 ? month.children.length : -1;
+
+        for (var i = startIndex; i != endIndex; i += delta) {
+          var c = month.children[i];
+          if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj)) return c;
+        }
+      }
+
+      return undefined;
+    }
+
+    function getNextAvailableDay(current, delta) {
+      var givenMonth = current.className.indexOf("Month") === -1 ? current.dateObj.getMonth() : self.currentMonth;
+      var endMonth = delta > 0 ? self.config.showMonths : -1;
+      var loopDelta = delta > 0 ? 1 : -1;
+
+      for (var m = givenMonth - self.currentMonth; m != endMonth; m += loopDelta) {
+        var month = self.daysContainer.children[m];
+        var startIndex = givenMonth - self.currentMonth === m ? current.$i + delta : delta < 0 ? month.children.length - 1 : 0;
+        var numMonthDays = month.children.length;
+
+        for (var i = startIndex; i >= 0 && i < numMonthDays && i != (delta > 0 ? numMonthDays : -1); i += loopDelta) {
+          var c = month.children[i];
+          if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj) && Math.abs(current.$i - i) >= Math.abs(delta)) return focusOnDayElem(c);
+        }
+      }
+
+      self.changeMonth(loopDelta);
+      focusOnDay(getFirstAvailableDay(loopDelta), 0);
+      return undefined;
+    }
+
+    function focusOnDay(current, offset) {
+      var dayFocused = isInView(document.activeElement || document.body);
+      var startElem = current !== undefined ? current : dayFocused ? document.activeElement : self.selectedDateElem !== undefined && isInView(self.selectedDateElem) ? self.selectedDateElem : self.todayDateElem !== undefined && isInView(self.todayDateElem) ? self.todayDateElem : getFirstAvailableDay(offset > 0 ? 1 : -1);
+      if (startElem === undefined) return self._input.focus();
+      if (!dayFocused) return focusOnDayElem(startElem);
+      getNextAvailableDay(startElem, offset);
+    }
+
+    function buildMonthDays(year, month) {
+      var firstOfMonth = (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
+      var prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12);
+      var daysInMonth = self.utils.getDaysInMonth(month),
+          days = window.document.createDocumentFragment(),
+          isMultiMonth = self.config.showMonths > 1,
+          prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
+          nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
+      var dayNumber = prevMonthDays + 1 - firstOfMonth,
+          dayIndex = 0;
+
+      for (; dayNumber <= prevMonthDays; dayNumber++, dayIndex++) {
+        days.appendChild(createDay(prevMonthDayClass, new Date(year, month - 1, dayNumber), dayNumber, dayIndex));
+      }
+
+      for (dayNumber = 1; dayNumber <= daysInMonth; dayNumber++, dayIndex++) {
+        days.appendChild(createDay("", new Date(year, month, dayNumber), dayNumber, dayIndex));
+      }
+
+      for (var dayNum = daysInMonth + 1; dayNum <= 42 - firstOfMonth && (self.config.showMonths === 1 || dayIndex % 7 !== 0); dayNum++, dayIndex++) {
+        days.appendChild(createDay(nextMonthDayClass, new Date(year, month + 1, dayNum % daysInMonth), dayNum, dayIndex));
+      }
+
+      var dayContainer = createElement("div", "dayContainer");
+      dayContainer.appendChild(days);
+      return dayContainer;
+    }
+
+    function buildDays() {
+      if (self.daysContainer === undefined) {
+        return;
+      }
+
+      clearNode(self.daysContainer);
+      if (self.weekNumbers) clearNode(self.weekNumbers);
+      var frag = document.createDocumentFragment();
+
+      for (var i = 0; i < self.config.showMonths; i++) {
+        var d = new Date(self.currentYear, self.currentMonth, 1);
+        d.setMonth(self.currentMonth + i);
+        frag.appendChild(buildMonthDays(d.getFullYear(), d.getMonth()));
+      }
+
+      self.daysContainer.appendChild(frag);
+      self.days = self.daysContainer.firstChild;
+
+      if (self.config.mode === "range" && self.selectedDates.length === 1) {
+        onMouseOver();
+      }
+    }
+
+    function buildMonth() {
+      var container = createElement("div", "flatpickr-month");
+      var monthNavFragment = window.document.createDocumentFragment();
+      var monthElement = createElement("span", "cur-month");
+      var yearInput = createNumberInput("cur-year", {
+        tabindex: "-1"
+      });
+      var yearElement = yearInput.getElementsByTagName("input")[0];
+      yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
+      if (self.config.minDate) yearElement.setAttribute("data-min", self.config.minDate.getFullYear().toString());
+
+      if (self.config.maxDate) {
+        yearElement.setAttribute("data-max", self.config.maxDate.getFullYear().toString());
+        yearElement.disabled = !!self.config.minDate && self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
+      }
+
+      var currentMonth = createElement("div", "flatpickr-current-month");
+      currentMonth.appendChild(monthElement);
+      currentMonth.appendChild(yearInput);
+      monthNavFragment.appendChild(currentMonth);
+      container.appendChild(monthNavFragment);
+      return {
+        container: container,
+        yearElement: yearElement,
+        monthElement: monthElement
+      };
+    }
+
+    function buildMonths() {
+      clearNode(self.monthNav);
+      self.monthNav.appendChild(self.prevMonthNav);
+
+      for (var m = self.config.showMonths; m--;) {
+        var month = buildMonth();
+        self.yearElements.push(month.yearElement);
+        self.monthElements.push(month.monthElement);
+        self.monthNav.appendChild(month.container);
+      }
+
+      self.monthNav.appendChild(self.nextMonthNav);
+    }
+
+    function buildMonthNav() {
+      self.monthNav = createElement("div", "flatpickr-months");
+      self.yearElements = [];
+      self.monthElements = [];
+      self.prevMonthNav = createElement("span", "flatpickr-prev-month");
+      self.prevMonthNav.innerHTML = self.config.prevArrow;
+      self.nextMonthNav = createElement("span", "flatpickr-next-month");
+      self.nextMonthNav.innerHTML = self.config.nextArrow;
+      buildMonths();
+      Object.defineProperty(self, "_hidePrevMonthArrow", {
+        get: function get() {
+          return self.__hidePrevMonthArrow;
+        },
+        set: function set(bool) {
+          if (self.__hidePrevMonthArrow !== bool) {
+            toggleClass(self.prevMonthNav, "disabled", bool);
+            self.__hidePrevMonthArrow = bool;
+          }
+        }
+      });
+      Object.defineProperty(self, "_hideNextMonthArrow", {
+        get: function get() {
+          return self.__hideNextMonthArrow;
+        },
+        set: function set(bool) {
+          if (self.__hideNextMonthArrow !== bool) {
+            toggleClass(self.nextMonthNav, "disabled", bool);
+            self.__hideNextMonthArrow = bool;
+          }
+        }
+      });
+      self.currentYearElement = self.yearElements[0];
+      updateNavigationCurrentMonth();
+      return self.monthNav;
+    }
+
+    function buildTime() {
+      self.calendarContainer.classList.add("hasTime");
+      if (self.config.noCalendar) self.calendarContainer.classList.add("noCalendar");
+      self.timeContainer = createElement("div", "flatpickr-time");
+      self.timeContainer.tabIndex = -1;
+      var separator = createElement("span", "flatpickr-time-separator", ":");
+      var hourInput = createNumberInput("flatpickr-hour");
+      self.hourElement = hourInput.getElementsByTagName("input")[0];
+      var minuteInput = createNumberInput("flatpickr-minute");
+      self.minuteElement = minuteInput.getElementsByTagName("input")[0];
+      self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
+      self.hourElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getHours() : self.config.time_24hr ? self.config.defaultHour : military2ampm(self.config.defaultHour));
+      self.minuteElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getMinutes() : self.config.defaultMinute);
+      self.hourElement.setAttribute("data-step", self.config.hourIncrement.toString());
+      self.minuteElement.setAttribute("data-step", self.config.minuteIncrement.toString());
+      self.hourElement.setAttribute("data-min", self.config.time_24hr ? "0" : "1");
+      self.hourElement.setAttribute("data-max", self.config.time_24hr ? "23" : "12");
+      self.minuteElement.setAttribute("data-min", "0");
+      self.minuteElement.setAttribute("data-max", "59");
+      self.timeContainer.appendChild(hourInput);
+      self.timeContainer.appendChild(separator);
+      self.timeContainer.appendChild(minuteInput);
+      if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
+
+      if (self.config.enableSeconds) {
+        self.timeContainer.classList.add("hasSeconds");
+        var secondInput = createNumberInput("flatpickr-second");
+        self.secondElement = secondInput.getElementsByTagName("input")[0];
+        self.secondElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getSeconds() : self.config.defaultSeconds);
+        self.secondElement.setAttribute("data-step", self.minuteElement.getAttribute("data-step"));
+        self.secondElement.setAttribute("data-min", self.minuteElement.getAttribute("data-min"));
+        self.secondElement.setAttribute("data-max", self.minuteElement.getAttribute("data-max"));
+        self.timeContainer.appendChild(createElement("span", "flatpickr-time-separator", ":"));
+        self.timeContainer.appendChild(secondInput);
+      }
+
+      if (!self.config.time_24hr) {
+        self.amPM = createElement("span", "flatpickr-am-pm", self.l10n.amPM[int((self.latestSelectedDateObj ? self.hourElement.value : self.config.defaultHour) > 11)]);
+        self.amPM.title = self.l10n.toggleTitle;
+        self.amPM.tabIndex = -1;
+        self.timeContainer.appendChild(self.amPM);
+      }
+
+      return self.timeContainer;
+    }
+
+    function buildWeekdays() {
+      if (!self.weekdayContainer) self.weekdayContainer = createElement("div", "flatpickr-weekdays");else clearNode(self.weekdayContainer);
+
+      for (var i = self.config.showMonths; i--;) {
+        var container = createElement("div", "flatpickr-weekdaycontainer");
+        self.weekdayContainer.appendChild(container);
+      }
+
+      updateWeekdays();
+      return self.weekdayContainer;
+    }
+
+    function updateWeekdays() {
+      var firstDayOfWeek = self.l10n.firstDayOfWeek;
+      var weekdays = self.l10n.weekdays.shorthand.concat();
+
+      if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {
+        weekdays = weekdays.splice(firstDayOfWeek, weekdays.length).concat(weekdays.splice(0, firstDayOfWeek));
+      }
+
+      for (var i = self.config.showMonths; i--;) {
+        self.weekdayContainer.children[i].innerHTML = "\n      <span class=flatpickr-weekday>\n        " + weekdays.join("</span><span class=flatpickr-weekday>") + "\n      </span>\n      ";
+      }
+    }
+
+    function buildWeeks() {
+      self.calendarContainer.classList.add("hasWeeks");
+      var weekWrapper = createElement("div", "flatpickr-weekwrapper");
+      weekWrapper.appendChild(createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation));
+      var weekNumbers = createElement("div", "flatpickr-weeks");
+      weekWrapper.appendChild(weekNumbers);
+      return {
+        weekWrapper: weekWrapper,
+        weekNumbers: weekNumbers
+      };
+    }
+
+    function changeMonth(value, is_offset) {
+      if (is_offset === void 0) {
+        is_offset = true;
+      }
+
+      var delta = is_offset ? value : value - self.currentMonth;
+      if (delta < 0 && self._hidePrevMonthArrow === true || delta > 0 && self._hideNextMonthArrow === true) return;
+      self.currentMonth += delta;
+
+      if (self.currentMonth < 0 || self.currentMonth > 11) {
+        self.currentYear += self.currentMonth > 11 ? 1 : -1;
+        self.currentMonth = (self.currentMonth + 12) % 12;
+        triggerEvent("onYearChange");
+      }
+
+      buildDays();
+      triggerEvent("onMonthChange");
+      updateNavigationCurrentMonth();
+    }
+
+    function clear(triggerChangeEvent) {
+      if (triggerChangeEvent === void 0) {
+        triggerChangeEvent = true;
+      }
+
+      self.input.value = "";
+      if (self.altInput !== undefined) self.altInput.value = "";
+      if (self.mobileInput !== undefined) self.mobileInput.value = "";
+      self.selectedDates = [];
+      self.latestSelectedDateObj = undefined;
+      self.showTimeInput = false;
+
+      if (self.config.enableTime === true) {
+        setDefaultHours();
+      }
+
+      self.redraw();
+      if (triggerChangeEvent) triggerEvent("onChange");
+    }
+
+    function close() {
+      self.isOpen = false;
+
+      if (!self.isMobile) {
+        self.calendarContainer.classList.remove("open");
+
+        self._input.classList.remove("active");
+      }
+
+      triggerEvent("onClose");
+    }
+
+    function destroy() {
+      if (self.config !== undefined) triggerEvent("onDestroy");
+
+      for (var i = self._handlers.length; i--;) {
+        var h = self._handlers[i];
+        h.element.removeEventListener(h.event, h.handler, h.options);
+      }
+
+      self._handlers = [];
+
+      if (self.mobileInput) {
+        if (self.mobileInput.parentNode) self.mobileInput.parentNode.removeChild(self.mobileInput);
+        self.mobileInput = undefined;
+      } else if (self.calendarContainer && self.calendarContainer.parentNode) {
+        if (self.config.static && self.calendarContainer.parentNode) {
+          var wrapper = self.calendarContainer.parentNode;
+          wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
+
+          if (wrapper.parentNode) {
+            while (wrapper.firstChild) {
+              wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
+            }
+
+            wrapper.parentNode.removeChild(wrapper);
+          }
+        } else self.calendarContainer.parentNode.removeChild(self.calendarContainer);
+      }
+
+      if (self.altInput) {
+        self.input.type = "text";
+        if (self.altInput.parentNode) self.altInput.parentNode.removeChild(self.altInput);
+        delete self.altInput;
+      }
+
+      if (self.input) {
+        self.input.type = self.input._type;
+        self.input.classList.remove("flatpickr-input");
+        self.input.removeAttribute("readonly");
+        self.input.value = "";
+      }
+
+      ["_showTimeInput", "latestSelectedDateObj", "_hideNextMonthArrow", "_hidePrevMonthArrow", "__hideNextMonthArrow", "__hidePrevMonthArrow", "isMobile", "isOpen", "selectedDateElem", "minDateHasTime", "maxDateHasTime", "days", "daysContainer", "_input", "_positionElement", "innerContainer", "rContainer", "monthNav", "todayDateElem", "calendarContainer", "weekdayContainer", "prevMonthNav", "nextMonthNav", "currentMonthElement", "currentYearElement", "navigationCurrentMonth", "selectedDateElem", "config"].forEach(function (k) {
+        try {
+          delete self[k];
+        } catch (_) {}
+      });
+    }
+
+    function isCalendarElem(elem) {
+      if (self.config.appendTo && self.config.appendTo.contains(elem)) return true;
+      return self.calendarContainer.contains(elem);
+    }
+
+    function documentClick(e) {
+      if (self.isOpen && !self.config.inline) {
+        var isCalendarElement = isCalendarElem(e.target);
+        var isInput = e.target === self.input || e.target === self.altInput || self.element.contains(e.target) || e.path && e.path.indexOf && (~e.path.indexOf(self.input) || ~e.path.indexOf(self.altInput));
+        var lostFocus = e.type === "blur" ? isInput && e.relatedTarget && !isCalendarElem(e.relatedTarget) : !isInput && !isCalendarElement;
+        var isIgnored = !self.config.ignoredFocusElements.some(function (elem) {
+          return elem.contains(e.target);
+        });
+
+        if (lostFocus && isIgnored) {
+          self.close();
+
+          if (self.config.mode === "range" && self.selectedDates.length === 1) {
+            self.clear(false);
+            self.redraw();
+          }
+        }
+      }
+    }
+
+    function changeYear(newYear) {
+      if (!newYear || self.config.minDate && newYear < self.config.minDate.getFullYear() || self.config.maxDate && newYear > self.config.maxDate.getFullYear()) return;
+      var newYearNum = newYear,
+          isNewYear = self.currentYear !== newYearNum;
+      self.currentYear = newYearNum || self.currentYear;
+
+      if (self.config.maxDate && self.currentYear === self.config.maxDate.getFullYear()) {
+        self.currentMonth = Math.min(self.config.maxDate.getMonth(), self.currentMonth);
+      } else if (self.config.minDate && self.currentYear === self.config.minDate.getFullYear()) {
+        self.currentMonth = Math.max(self.config.minDate.getMonth(), self.currentMonth);
+      }
+
+      if (isNewYear) {
+        self.redraw();
+        triggerEvent("onYearChange");
+      }
+    }
+
+    function isEnabled(date, timeless) {
+      if (timeless === void 0) {
+        timeless = true;
+      }
+
+      var dateToCheck = self.parseDate(date, undefined, timeless);
+      if (self.config.minDate && dateToCheck && compareDates(dateToCheck, self.config.minDate, timeless !== undefined ? timeless : !self.minDateHasTime) < 0 || self.config.maxDate && dateToCheck && compareDates(dateToCheck, self.config.maxDate, timeless !== undefined ? timeless : !self.maxDateHasTime) > 0) return false;
+      if (self.config.enable.length === 0 && self.config.disable.length === 0) return true;
+      if (dateToCheck === undefined) return false;
+      var bool = self.config.enable.length > 0,
+          array = bool ? self.config.enable : self.config.disable;
+
+      for (var i = 0, d; i < array.length; i++) {
+        d = array[i];
+        if (typeof d === "function" && d(dateToCheck)) return bool;else if (d instanceof Date && dateToCheck !== undefined && d.getTime() === dateToCheck.getTime()) return bool;else if (typeof d === "string" && dateToCheck !== undefined) {
+          var parsed = self.parseDate(d, undefined, true);
+          return parsed && parsed.getTime() === dateToCheck.getTime() ? bool : !bool;
+        } else if ((typeof d === 'undefined' ? 'undefined' : _typeof(d)) === "object" && dateToCheck !== undefined && d.from && d.to && dateToCheck.getTime() >= d.from.getTime() && dateToCheck.getTime() <= d.to.getTime()) return bool;
+      }
+
+      return !bool;
+    }
+
+    function isInView(elem) {
+      if (self.daysContainer !== undefined) return elem.className.indexOf("hidden") === -1 && self.daysContainer.contains(elem);
+      return false;
+    }
+
+    function onKeyDown(e) {
+      var isInput = e.target === self._input;
+      var allowInput = self.config.allowInput;
+      var allowKeydown = self.isOpen && (!allowInput || !isInput);
+      var allowInlineKeydown = self.config.inline && isInput && !allowInput;
+
+      if (e.keyCode === 13 && isInput) {
+        if (allowInput) {
+          self.setDate(self._input.value, true, e.target === self.altInput ? self.config.altFormat : self.config.dateFormat);
+          return e.target.blur();
+        } else self.open();
+      } else if (isCalendarElem(e.target) || allowKeydown || allowInlineKeydown) {
+        var isTimeObj = !!self.timeContainer && self.timeContainer.contains(e.target);
+
+        switch (e.keyCode) {
+          case 13:
+            if (isTimeObj) updateTime();else selectDate(e);
+            break;
+
+          case 27:
+            e.preventDefault();
+            focusAndClose();
+            break;
+
+          case 8:
+          case 46:
+            if (isInput && !self.config.allowInput) {
+              e.preventDefault();
+              self.clear();
+            }
+
+            break;
+
+          case 37:
+          case 39:
+            if (!isTimeObj) {
+              e.preventDefault();
+
+              if (self.daysContainer !== undefined && (allowInput === false || isInView(document.activeElement))) {
+                var _delta = e.keyCode === 39 ? 1 : -1;
+
+                if (!e.ctrlKey) focusOnDay(undefined, _delta);else {
+                  changeMonth(_delta);
+                  focusOnDay(getFirstAvailableDay(1), 0);
+                }
+              }
+            } else if (self.hourElement) self.hourElement.focus();
+
+            break;
+
+          case 38:
+          case 40:
+            e.preventDefault();
+            var delta = e.keyCode === 40 ? 1 : -1;
+
+            if (self.daysContainer && e.target.$i !== undefined) {
+              if (e.ctrlKey) {
+                changeYear(self.currentYear - delta);
+                focusOnDay(getFirstAvailableDay(1), 0);
+              } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
+            } else if (self.config.enableTime) {
+              if (!isTimeObj && self.hourElement) self.hourElement.focus();
+              updateTime(e);
+
+              self._debouncedChange();
+            }
+
+            break;
+
+          case 9:
+            if (!isTimeObj) {
+              self.element.focus();
+              break;
+            }
+
+            var elems = [self.hourElement, self.minuteElement, self.secondElement, self.amPM].filter(function (x) {
+              return x;
+            });
+            var i = elems.indexOf(e.target);
+
+            if (i !== -1) {
+              var target = elems[i + (e.shiftKey ? -1 : 1)];
+
+              if (target !== undefined) {
+                e.preventDefault();
+                target.focus();
+              } else {
+                self.element.focus();
+              }
+            }
+
+            break;
+
+          default:
+            break;
+        }
+      }
+
+      if (self.amPM !== undefined && e.target === self.amPM) {
+        switch (e.key) {
+          case self.l10n.amPM[0].charAt(0):
+          case self.l10n.amPM[0].charAt(0).toLowerCase():
+            self.amPM.textContent = self.l10n.amPM[0];
+            setHoursFromInputs();
+            updateValue();
+            break;
+
+          case self.l10n.amPM[1].charAt(0):
+          case self.l10n.amPM[1].charAt(0).toLowerCase():
+            self.amPM.textContent = self.l10n.amPM[1];
+            setHoursFromInputs();
+            updateValue();
+            break;
+        }
+      }
+
+      triggerEvent("onKeyDown", e);
+    }
+
+    function onMouseOver(elem) {
+      if (self.selectedDates.length !== 1 || elem && (!elem.classList.contains("flatpickr-day") || elem.classList.contains("disabled"))) return;
+      var hoverDate = elem ? elem.dateObj.getTime() : self.days.firstElementChild.dateObj.getTime(),
+          initialDate = self.parseDate(self.selectedDates[0], undefined, true).getTime(),
+          rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
+          rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime()),
+          lastDate = self.daysContainer.lastChild.lastChild.dateObj.getTime();
+      var containsDisabled = false;
+      var minRange = 0,
+          maxRange = 0;
+
+      for (var t = rangeStartDate; t < lastDate; t += duration.DAY) {
+        if (!isEnabled(new Date(t), true)) {
+          containsDisabled = containsDisabled || t > rangeStartDate && t < rangeEndDate;
+          if (t < initialDate && (!minRange || t > minRange)) minRange = t;else if (t > initialDate && (!maxRange || t < maxRange)) maxRange = t;
+        }
+      }
+
+      for (var m = 0; m < self.config.showMonths; m++) {
+        var month = self.daysContainer.children[m];
+        var prevMonth = self.daysContainer.children[m - 1];
+
+        var _loop = function _loop(i, l) {
+          var dayElem = month.children[i],
+              date = dayElem.dateObj;
+          var timestamp = date.getTime();
+          var outOfRange = minRange > 0 && timestamp < minRange || maxRange > 0 && timestamp > maxRange;
+
+          if (outOfRange) {
+            dayElem.classList.add("notAllowed");
+            ["inRange", "startRange", "endRange"].forEach(function (c) {
+              dayElem.classList.remove(c);
+            });
+            return "continue";
+          } else if (containsDisabled && !outOfRange) return "continue";
+
+          ["startRange", "inRange", "endRange", "notAllowed"].forEach(function (c) {
+            dayElem.classList.remove(c);
+          });
+
+          if (elem !== undefined) {
+            elem.classList.add(hoverDate < self.selectedDates[0].getTime() ? "startRange" : "endRange");
+
+            if (month.contains(elem) || !(m > 0 && prevMonth && prevMonth.lastChild.dateObj.getTime() >= timestamp)) {
+              if (initialDate < hoverDate && timestamp === initialDate) dayElem.classList.add("startRange");else if (initialDate > hoverDate && timestamp === initialDate) dayElem.classList.add("endRange");
+              if (timestamp >= minRange && (maxRange === 0 || timestamp <= maxRange) && isBetween(timestamp, initialDate, hoverDate)) dayElem.classList.add("inRange");
+            }
+          }
+        };
+
+        for (var i = 0, l = month.children.length; i < l; i++) {
+          var _ret = _loop(i, l);
+
+          if (_ret === "continue") continue;
+        }
+      }
+    }
+
+    function onResize() {
+      if (self.isOpen && !self.config.static && !self.config.inline) positionCalendar();
+    }
+
+    function open(e, positionElement) {
+      if (positionElement === void 0) {
+        positionElement = self._positionElement;
+      }
+
+      if (self.isMobile === true) {
+        if (e) {
+          e.preventDefault();
+          e.target && e.target.blur();
+        }
+
+        if (self.mobileInput !== undefined) {
+          self.mobileInput.focus();
+          self.mobileInput.click();
+        }
+
+        triggerEvent("onOpen");
+        return;
+      }
+
+      if (self._input.disabled || self.config.inline) return;
+      var wasOpen = self.isOpen;
+      self.isOpen = true;
+
+      if (!wasOpen) {
+        self.calendarContainer.classList.add("open");
+
+        self._input.classList.add("active");
+
+        triggerEvent("onOpen");
+        positionCalendar(positionElement);
+      }
+
+      if (self.config.enableTime === true && self.config.noCalendar === true) {
+        if (self.selectedDates.length === 0) {
+          self.setDate(self.config.minDate !== undefined ? new Date(self.config.minDate.getTime()) : new Date(), false);
+          setDefaultHours();
+          updateValue();
+        }
+
+        if (self.config.allowInput === false && (e === undefined || !self.timeContainer.contains(e.relatedTarget))) {
+          setTimeout(function () {
+            return self.hourElement.select();
+          }, 50);
+        }
+      }
+    }
+
+    function minMaxDateSetter(type) {
+      return function (date) {
+        var dateObj = self.config["_" + type + "Date"] = self.parseDate(date, self.config.dateFormat);
+        var inverseDateObj = self.config["_" + (type === "min" ? "max" : "min") + "Date"];
+
+        if (dateObj !== undefined) {
+          self[type === "min" ? "minDateHasTime" : "maxDateHasTime"] = dateObj.getHours() > 0 || dateObj.getMinutes() > 0 || dateObj.getSeconds() > 0;
+        }
+
+        if (self.selectedDates) {
+          self.selectedDates = self.selectedDates.filter(function (d) {
+            return isEnabled(d);
+          });
+          if (!self.selectedDates.length && type === "min") setHoursFromDate(dateObj);
+          updateValue();
+        }
+
+        if (self.daysContainer) {
+          redraw();
+          if (dateObj !== undefined) self.currentYearElement[type] = dateObj.getFullYear().toString();else self.currentYearElement.removeAttribute(type);
+          self.currentYearElement.disabled = !!inverseDateObj && dateObj !== undefined && inverseDateObj.getFullYear() === dateObj.getFullYear();
+        }
+      };
+    }
+
+    function parseConfig() {
+      var boolOpts = ["wrap", "weekNumbers", "allowInput", "clickOpens", "time_24hr", "enableTime", "noCalendar", "altInput", "shorthandCurrentMonth", "inline", "static", "enableSeconds", "disableMobile"];
+      var userConfig = Object.assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
+      var formats$$1 = {};
+      self.config.parseDate = userConfig.parseDate;
+      self.config.formatDate = userConfig.formatDate;
+      Object.defineProperty(self.config, "enable", {
+        get: function get() {
+          return self.config._enable;
+        },
+        set: function set(dates) {
+          self.config._enable = parseDateRules(dates);
+        }
+      });
+      Object.defineProperty(self.config, "disable", {
+        get: function get() {
+          return self.config._disable;
+        },
+        set: function set(dates) {
+          self.config._disable = parseDateRules(dates);
+        }
+      });
+      var timeMode = userConfig.mode === "time";
+
+      if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
+        formats$$1.dateFormat = userConfig.noCalendar || timeMode ? "H:i" + (userConfig.enableSeconds ? ":S" : "") : flatpickr.defaultConfig.dateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
+      }
+
+      if (userConfig.altInput && (userConfig.enableTime || timeMode) && !userConfig.altFormat) {
+        formats$$1.altFormat = userConfig.noCalendar || timeMode ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K") : flatpickr.defaultConfig.altFormat + (" h:i" + (userConfig.enableSeconds ? ":S" : "") + " K");
+      }
+
+      Object.defineProperty(self.config, "minDate", {
+        get: function get() {
+          return self.config._minDate;
+        },
+        set: minMaxDateSetter("min")
+      });
+      Object.defineProperty(self.config, "maxDate", {
+        get: function get() {
+          return self.config._maxDate;
+        },
+        set: minMaxDateSetter("max")
+      });
+
+      var minMaxTimeSetter = function minMaxTimeSetter(type) {
+        return function (val) {
+          self.config[type === "min" ? "_minTime" : "_maxTime"] = self.parseDate(val, "H:i");
+        };
+      };
+
+      Object.defineProperty(self.config, "minTime", {
+        get: function get() {
+          return self.config._minTime;
+        },
+        set: minMaxTimeSetter("min")
+      });
+      Object.defineProperty(self.config, "maxTime", {
+        get: function get() {
+          return self.config._maxTime;
+        },
+        set: minMaxTimeSetter("max")
+      });
+
+      if (userConfig.mode === "time") {
+        self.config.noCalendar = true;
+        self.config.enableTime = true;
+      }
+
+      Object.assign(self.config, formats$$1, userConfig);
+
+      for (var i = 0; i < boolOpts.length; i++) {
+        self.config[boolOpts[i]] = self.config[boolOpts[i]] === true || self.config[boolOpts[i]] === "true";
+      }
+
+      HOOKS.filter(function (hook) {
+        return self.config[hook] !== undefined;
+      }).forEach(function (hook) {
+        self.config[hook] = arrayify(self.config[hook] || []).map(bindToInstance);
+      });
+      self.isMobile = !self.config.disableMobile && !self.config.inline && self.config.mode === "single" && !self.config.disable.length && !self.config.enable.length && !self.config.weekNumbers && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+
+      for (var _i = 0; _i < self.config.plugins.length; _i++) {
+        var pluginConf = self.config.plugins[_i](self) || {};
+
+        for (var key in pluginConf) {
+          if (HOOKS.indexOf(key) > -1) {
+            self.config[key] = arrayify(pluginConf[key]).map(bindToInstance).concat(self.config[key]);
+          } else if (typeof userConfig[key] === "undefined") self.config[key] = pluginConf[key];
+        }
+      }
+
+      triggerEvent("onParseConfig");
+    }
+
+    function setupLocale() {
+      if (_typeof(self.config.locale) !== "object" && typeof flatpickr.l10ns[self.config.locale] === "undefined") self.config.errorHandler(new Error("flatpickr: invalid locale " + self.config.locale));
+      self.l10n = Object.assign({}, flatpickr.l10ns.default, _typeof(self.config.locale) === "object" ? self.config.locale : self.config.locale !== "default" ? flatpickr.l10ns[self.config.locale] : undefined);
+      tokenRegex.K = "(" + self.l10n.amPM[0] + "|" + self.l10n.amPM[1] + "|" + self.l10n.amPM[0].toLowerCase() + "|" + self.l10n.amPM[1].toLowerCase() + ")";
+      self.formatDate = createDateFormatter(self);
+      self.parseDate = createDateParser({
+        config: self.config,
+        l10n: self.l10n
+      });
+    }
+
+    function positionCalendar(customPositionElement) {
+      if (self.calendarContainer === undefined) return;
+      triggerEvent("onPreCalendarPosition");
+      var positionElement = customPositionElement || self._positionElement;
+      var calendarHeight = Array.prototype.reduce.call(self.calendarContainer.children, function (acc, child) {
+        return acc + child.offsetHeight;
+      }, 0),
+          calendarWidth = self.calendarContainer.offsetWidth,
+          configPos = self.config.position.split(" "),
+          configPosVertical = configPos[0],
+          configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
+          inputBounds = positionElement.getBoundingClientRect(),
+          distanceFromBottom = window.innerHeight - inputBounds.bottom,
+          showOnTop = configPosVertical === "above" || configPosVertical !== "below" && distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
+      var top = window.pageYOffset + inputBounds.top + (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
+      toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
+      toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
+      if (self.config.inline) return;
+      var left = window.pageXOffset + inputBounds.left - (configPosHorizontal != null && configPosHorizontal === "center" ? (calendarWidth - inputBounds.width) / 2 : 0);
+      var right = window.document.body.offsetWidth - inputBounds.right;
+      var rightMost = left + calendarWidth > window.document.body.offsetWidth;
+      toggleClass(self.calendarContainer, "rightMost", rightMost);
+      if (self.config.static) return;
+      self.calendarContainer.style.top = top + "px";
+
+      if (!rightMost) {
+        self.calendarContainer.style.left = left + "px";
+        self.calendarContainer.style.right = "auto";
+      } else {
+        self.calendarContainer.style.left = "auto";
+        self.calendarContainer.style.right = right + "px";
+      }
+    }
+
+    function redraw() {
+      if (self.config.noCalendar || self.isMobile) return;
+      updateNavigationCurrentMonth();
+      buildDays();
+    }
+
+    function focusAndClose() {
+      self._input.focus();
+
+      if (window.navigator.userAgent.indexOf("MSIE") !== -1 || navigator.msMaxTouchPoints !== undefined) {
+        setTimeout(self.close, 0);
+      } else {
+        self.close();
+      }
+    }
+
+    function selectDate(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      var isSelectable = function isSelectable(day) {
+        return day.classList && day.classList.contains("flatpickr-day") && !day.classList.contains("disabled") && !day.classList.contains("notAllowed");
+      };
+
+      var t = findParent(e.target, isSelectable);
+      if (t === undefined) return;
+      var target = t;
+      var selectedDate = self.latestSelectedDateObj = new Date(target.dateObj.getTime());
+      var shouldChangeMonth = (selectedDate.getMonth() < self.currentMonth || selectedDate.getMonth() > self.currentMonth + self.config.showMonths - 1) && self.config.mode !== "range";
+      self.selectedDateElem = target;
+      if (self.config.mode === "single") self.selectedDates = [selectedDate];else if (self.config.mode === "multiple") {
+        var selectedIndex = isDateSelected(selectedDate);
+        if (selectedIndex) self.selectedDates.splice(parseInt(selectedIndex), 1);else self.selectedDates.push(selectedDate);
+      } else if (self.config.mode === "range") {
+        if (self.selectedDates.length === 2) self.clear(false);
+        self.selectedDates.push(selectedDate);
+        if (compareDates(selectedDate, self.selectedDates[0], true) !== 0) self.selectedDates.sort(function (a, b) {
+          return a.getTime() - b.getTime();
+        });
+      }
+      setHoursFromInputs();
+
+      if (shouldChangeMonth) {
+        var isNewYear = self.currentYear !== selectedDate.getFullYear();
+        self.currentYear = selectedDate.getFullYear();
+        self.currentMonth = selectedDate.getMonth();
+        if (isNewYear) triggerEvent("onYearChange");
+        triggerEvent("onMonthChange");
+      }
+
+      updateNavigationCurrentMonth();
+      buildDays();
+      updateValue();
+      if (self.config.enableTime) setTimeout(function () {
+        return self.showTimeInput = true;
+      }, 50);
+      if (!shouldChangeMonth && self.config.mode !== "range" && self.config.showMonths === 1) focusOnDayElem(target);else self.selectedDateElem && self.selectedDateElem.focus();
+      if (self.hourElement !== undefined) setTimeout(function () {
+        return self.hourElement !== undefined && self.hourElement.select();
+      }, 451);
+
+      if (self.config.closeOnSelect) {
+        var single = self.config.mode === "single" && !self.config.enableTime;
+        var range = self.config.mode === "range" && self.selectedDates.length === 2 && !self.config.enableTime;
+
+        if (single || range) {
+          focusAndClose();
+        }
+      }
+
+      triggerChange();
+    }
+
+    var CALLBACKS = {
+      locale: [setupLocale, updateWeekdays],
+      showMonths: [buildMonths, setCalendarWidth, buildWeekdays]
+    };
+
+    function set(option, value) {
+      if (option !== null && (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === "object") Object.assign(self.config, option);else {
+        self.config[option] = value;
+        if (CALLBACKS[option] !== undefined) CALLBACKS[option].forEach(function (x) {
+          return x();
+        });else if (HOOKS.indexOf(option) > -1) self.config[option] = arrayify(value);
+      }
+      self.redraw();
+      jumpToDate();
+      updateValue(false);
+    }
+
+    function setSelectedDate(inputDate, format) {
+      var dates = [];
+      if (inputDate instanceof Array) dates = inputDate.map(function (d) {
+        return self.parseDate(d, format);
+      });else if (inputDate instanceof Date || typeof inputDate === "number") dates = [self.parseDate(inputDate, format)];else if (typeof inputDate === "string") {
+        switch (self.config.mode) {
+          case "single":
+          case "time":
+            dates = [self.parseDate(inputDate, format)];
+            break;
+
+          case "multiple":
+            dates = inputDate.split(self.config.conjunction).map(function (date) {
+              return self.parseDate(date, format);
+            });
+            break;
+
+          case "range":
+            dates = inputDate.split(self.l10n.rangeSeparator).map(function (date) {
+              return self.parseDate(date, format);
+            });
+            break;
+
+          default:
+            break;
+        }
+      } else self.config.errorHandler(new Error("Invalid date supplied: " + JSON.stringify(inputDate)));
+      self.selectedDates = dates.filter(function (d) {
+        return d instanceof Date && isEnabled(d, false);
+      });
+      if (self.config.mode === "range") self.selectedDates.sort(function (a, b) {
+        return a.getTime() - b.getTime();
+      });
+    }
+
+    function setDate(date, triggerChange, format) {
+      if (triggerChange === void 0) {
+        triggerChange = false;
+      }
+
+      if (format === void 0) {
+        format = self.config.dateFormat;
+      }
+
+      if (date !== 0 && !date || date instanceof Array && date.length === 0) return self.clear(triggerChange);
+      setSelectedDate(date, format);
+      self.showTimeInput = self.selectedDates.length > 0;
+      self.latestSelectedDateObj = self.selectedDates[0];
+      self.redraw();
+      jumpToDate();
+      setHoursFromDate();
+      updateValue(triggerChange);
+      if (triggerChange) triggerEvent("onChange");
+    }
+
+    function parseDateRules(arr) {
+      return arr.slice().map(function (rule) {
+        if (typeof rule === "string" || typeof rule === "number" || rule instanceof Date) {
+          return self.parseDate(rule, undefined, true);
+        } else if (rule && (typeof rule === 'undefined' ? 'undefined' : _typeof(rule)) === "object" && rule.from && rule.to) return {
+          from: self.parseDate(rule.from, undefined),
+          to: self.parseDate(rule.to, undefined)
+        };
+
+        return rule;
+      }).filter(function (x) {
+        return x;
+      });
+    }
+
+    function setupDates() {
+      self.selectedDates = [];
+      self.now = self.parseDate(self.config.now) || new Date();
+      var preloadedDate = self.config.defaultDate || ((self.input.nodeName === "INPUT" || self.input.nodeName === "TEXTAREA") && self.input.placeholder && self.input.value === self.input.placeholder ? null : self.input.value);
+      if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
+      var initialDate = self.selectedDates.length > 0 ? self.selectedDates[0] : self.config.minDate && self.config.minDate.getTime() > self.now.getTime() ? self.config.minDate : self.config.maxDate && self.config.maxDate.getTime() < self.now.getTime() ? self.config.maxDate : self.now;
+      self.currentYear = initialDate.getFullYear();
+      self.currentMonth = initialDate.getMonth();
+      if (self.selectedDates.length > 0) self.latestSelectedDateObj = self.selectedDates[0];
+      if (self.config.minTime !== undefined) self.config.minTime = self.parseDate(self.config.minTime, "H:i");
+      if (self.config.maxTime !== undefined) self.config.maxTime = self.parseDate(self.config.maxTime, "H:i");
+      self.minDateHasTime = !!self.config.minDate && (self.config.minDate.getHours() > 0 || self.config.minDate.getMinutes() > 0 || self.config.minDate.getSeconds() > 0);
+      self.maxDateHasTime = !!self.config.maxDate && (self.config.maxDate.getHours() > 0 || self.config.maxDate.getMinutes() > 0 || self.config.maxDate.getSeconds() > 0);
+      Object.defineProperty(self, "showTimeInput", {
+        get: function get() {
+          return self._showTimeInput;
+        },
+        set: function set(bool) {
+          self._showTimeInput = bool;
+          if (self.calendarContainer) toggleClass(self.calendarContainer, "showTimeInput", bool);
+          self.isOpen && positionCalendar();
+        }
+      });
+    }
+
+    function setupInputs() {
+      self.input = self.config.wrap ? element.querySelector("[data-input]") : element;
+
+      if (!self.input) {
+        self.config.errorHandler(new Error("Invalid input element specified"));
+        return;
+      }
+
+      self.input._type = self.input.type;
+      self.input.type = "text";
+      self.input.classList.add("flatpickr-input");
+      self._input = self.input;
+
+      if (self.config.altInput) {
+        self.altInput = createElement(self.input.nodeName, self.input.className + " " + self.config.altInputClass);
+        self._input = self.altInput;
+        self.altInput.placeholder = self.input.placeholder;
+        self.altInput.disabled = self.input.disabled;
+        self.altInput.required = self.input.required;
+        self.altInput.tabIndex = self.input.tabIndex;
+        self.altInput.type = "text";
+        self.input.setAttribute("type", "hidden");
+        if (!self.config.static && self.input.parentNode) self.input.parentNode.insertBefore(self.altInput, self.input.nextSibling);
+      }
+
+      if (!self.config.allowInput) self._input.setAttribute("readonly", "readonly");
+      self._positionElement = self.config.positionElement || self._input;
+    }
+
+    function setupMobile() {
+      var inputType = self.config.enableTime ? self.config.noCalendar ? "time" : "datetime-local" : "date";
+      self.mobileInput = createElement("input", self.input.className + " flatpickr-mobile");
+      self.mobileInput.step = self.input.getAttribute("step") || "any";
+      self.mobileInput.tabIndex = 1;
+      self.mobileInput.type = inputType;
+      self.mobileInput.disabled = self.input.disabled;
+      self.mobileInput.required = self.input.required;
+      self.mobileInput.placeholder = self.input.placeholder;
+      self.mobileFormatStr = inputType === "datetime-local" ? "Y-m-d\\TH:i:S" : inputType === "date" ? "Y-m-d" : "H:i:S";
+
+      if (self.selectedDates.length > 0) {
+        self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(self.selectedDates[0], self.mobileFormatStr);
+      }
+
+      if (self.config.minDate) self.mobileInput.min = self.formatDate(self.config.minDate, "Y-m-d");
+      if (self.config.maxDate) self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
+      self.input.type = "hidden";
+      if (self.altInput !== undefined) self.altInput.type = "hidden";
+
+      try {
+        if (self.input.parentNode) self.input.parentNode.insertBefore(self.mobileInput, self.input.nextSibling);
+      } catch (_a) {}
+
+      bind(self.mobileInput, "change", function (e) {
+        self.setDate(e.target.value, false, self.mobileFormatStr);
+        triggerEvent("onChange");
+        triggerEvent("onClose");
+      });
+    }
+
+    function toggle(e) {
+      if (self.isOpen === true) return self.close();
+      self.open(e);
+    }
+
+    function triggerEvent(event, data) {
+      if (self.config === undefined) return;
+      var hooks = self.config[event];
+
+      if (hooks !== undefined && hooks.length > 0) {
+        for (var i = 0; hooks[i] && i < hooks.length; i++) {
+          hooks[i](self.selectedDates, self.input.value, self, data);
+        }
+      }
+
+      if (event === "onChange") {
+        self.input.dispatchEvent(createEvent("change"));
+        self.input.dispatchEvent(createEvent("input"));
+      }
+    }
+
+    function createEvent(name) {
+      var e = document.createEvent("Event");
+      e.initEvent(name, true, true);
+      return e;
+    }
+
+    function isDateSelected(date) {
+      for (var i = 0; i < self.selectedDates.length; i++) {
+        if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
+      }
+
+      return false;
+    }
+
+    function isDateInRange(date) {
+      if (self.config.mode !== "range" || self.selectedDates.length < 2) return false;
+      return compareDates(date, self.selectedDates[0]) >= 0 && compareDates(date, self.selectedDates[1]) <= 0;
+    }
+
+    function updateNavigationCurrentMonth() {
+      if (self.config.noCalendar || self.isMobile || !self.monthNav) return;
+      self.yearElements.forEach(function (yearElement, i) {
+        var d = new Date(self.currentYear, self.currentMonth, 1);
+        d.setMonth(self.currentMonth + i);
+        self.monthElements[i].textContent = monthToStr(d.getMonth(), self.config.shorthandCurrentMonth, self.l10n) + " ";
+        yearElement.value = d.getFullYear().toString();
+      });
+      self._hidePrevMonthArrow = self.config.minDate !== undefined && (self.currentYear === self.config.minDate.getFullYear() ? self.currentMonth <= self.config.minDate.getMonth() : self.currentYear < self.config.minDate.getFullYear());
+      self._hideNextMonthArrow = self.config.maxDate !== undefined && (self.currentYear === self.config.maxDate.getFullYear() ? self.currentMonth + 1 > self.config.maxDate.getMonth() : self.currentYear > self.config.maxDate.getFullYear());
+    }
+
+    function getDateStr(format) {
+      return self.selectedDates.map(function (dObj) {
+        return self.formatDate(dObj, format);
+      }).filter(function (d, i, arr) {
+        return self.config.mode !== "range" || self.config.enableTime || arr.indexOf(d) === i;
+      }).join(self.config.mode !== "range" ? self.config.conjunction : self.l10n.rangeSeparator);
+    }
+
+    function updateValue(triggerChange) {
+      if (triggerChange === void 0) {
+        triggerChange = true;
+      }
+
+      if (self.selectedDates.length === 0) return self.clear(triggerChange);
+
+      if (self.mobileInput !== undefined && self.mobileFormatStr) {
+        self.mobileInput.value = self.latestSelectedDateObj !== undefined ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr) : "";
+      }
+
+      self.input.value = getDateStr(self.config.dateFormat);
+
+      if (self.altInput !== undefined) {
+        self.altInput.value = getDateStr(self.config.altFormat);
+      }
+
+      if (triggerChange !== false) triggerEvent("onValueUpdate");
+    }
+
+    function onMonthNavClick(e) {
+      e.preventDefault();
+      var isPrevMonth = self.prevMonthNav.contains(e.target);
+      var isNextMonth = self.nextMonthNav.contains(e.target);
+
+      if (isPrevMonth || isNextMonth) {
+        changeMonth(isPrevMonth ? -1 : 1);
+      } else if (self.yearElements.indexOf(e.target) >= 0) {
+        e.target.select();
+      } else if (e.target.classList.contains("arrowUp")) {
+        self.changeYear(self.currentYear + 1);
+      } else if (e.target.classList.contains("arrowDown")) {
+        self.changeYear(self.currentYear - 1);
+      }
+    }
+
+    function timeWrapper(e) {
+      e.preventDefault();
+      var isKeyDown = e.type === "keydown",
+          input = e.target;
+
+      if (self.amPM !== undefined && e.target === self.amPM) {
+        self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
+      }
+
+      var min = parseFloat(input.getAttribute("data-min")),
+          max = parseFloat(input.getAttribute("data-max")),
+          step = parseFloat(input.getAttribute("data-step")),
+          curValue = parseInt(input.value, 10),
+          delta = e.delta || (isKeyDown ? e.which === 38 ? 1 : -1 : 0);
+      var newValue = curValue + step * delta;
+
+      if (typeof input.value !== "undefined" && input.value.length === 2) {
+        var isHourElem = input === self.hourElement,
+            isMinuteElem = input === self.minuteElement;
+
+        if (newValue < min) {
+          newValue = max + newValue + int(!isHourElem) + (int(isHourElem) && int(!self.amPM));
+          if (isMinuteElem) incrementNumInput(undefined, -1, self.hourElement);
+        } else if (newValue > max) {
+          newValue = input === self.hourElement ? newValue - max - int(!self.amPM) : min;
+          if (isMinuteElem) incrementNumInput(undefined, 1, self.hourElement);
+        }
+
+        if (self.amPM && isHourElem && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) {
+          self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
+        }
+
+        input.value = pad(newValue);
+      }
+    }
+
+    init();
+    return self;
+  }
+
+  function _flatpickr(nodeList, config) {
+    var nodes = Array.prototype.slice.call(nodeList);
+    var instances = [];
+
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+
+      try {
+        if (node.getAttribute("data-fp-omit") !== null) continue;
+
+        if (node._flatpickr !== undefined) {
+          node._flatpickr.destroy();
+
+          node._flatpickr = undefined;
+        }
+
+        node._flatpickr = FlatpickrInstance(node, config || {});
+        instances.push(node._flatpickr);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    return instances.length === 1 ? instances[0] : instances;
+  }
+
+  if (typeof HTMLElement !== "undefined") {
+    HTMLCollection.prototype.flatpickr = NodeList.prototype.flatpickr = function (config) {
+      return _flatpickr(this, config);
+    };
+
+    HTMLElement.prototype.flatpickr = function (config) {
+      return _flatpickr([this], config);
+    };
+  }
+
+  var flatpickr = function flatpickr(selector, config) {
+    if (selector instanceof NodeList) return _flatpickr(selector, config);else if (typeof selector === "string") return _flatpickr(window.document.querySelectorAll(selector), config);
+    return _flatpickr([selector], config);
+  };
+
+  flatpickr.defaultConfig = defaults;
+  flatpickr.l10ns = {
+    en: Object.assign({}, english),
+    default: Object.assign({}, english)
+  };
+
+  flatpickr.localize = function (l10n) {
+    flatpickr.l10ns.default = Object.assign({}, flatpickr.l10ns.default, l10n);
+  };
+
+  flatpickr.setDefaults = function (config) {
+    flatpickr.defaultConfig = Object.assign({}, flatpickr.defaultConfig, config);
+  };
+
+  flatpickr.parseDate = createDateParser({});
+  flatpickr.formatDate = createDateFormatter({});
+  flatpickr.compareDates = compareDates;
+
+  if (typeof jQuery !== "undefined") {
+    jQuery.fn.flatpickr = function (config) {
+      return _flatpickr(this, config);
+    };
+  }
+
+  Date.prototype.fp_incr = function (days) {
+    return new Date(this.getFullYear(), this.getMonth(), this.getDate() + (typeof days === "string" ? parseInt(days, 10) : days));
+  };
+
+  if (typeof window !== "undefined") {
+    window.flatpickr = flatpickr;
+  }
+
+  return flatpickr;
 });
 
 /***/ }),
-/* 371 */
+/* 366 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VLoads; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_urls__ = __webpack_require__(148);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__action_parameter__ = __webpack_require__(73);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_urls__ = __webpack_require__(143);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__action_parameter__ = __webpack_require__(71);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -39832,15 +39491,15 @@ var VLoads = function (_VUrls) {
 }(__WEBPACK_IMPORTED_MODULE_0__utils_urls__["a" /* VUrls */]);
 
 /***/ }),
-/* 372 */
+/* 367 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPosts; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(74);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(58);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(73);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(373);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(72);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(55);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(71);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(368);
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -39968,10 +39627,6 @@ var VPosts = function (_VBase) {
 
             if (paramCount < 1) {
                 console.warn('Creating request with no data!' + ' Are you sure you\'ve hooked everything up correctly?');
-            } else {
-                // log dupes:
-                // TODO: remove me (debug)
-                console.table(Array.from(formData));
             }
 
             var httpRequest = new XMLHttpRequest();
@@ -40137,7 +39792,7 @@ var VPosts = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 373 */
+/* 368 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -40151,14 +39806,14 @@ function encode(value) {
 }
 
 /***/ }),
-/* 374 */
+/* 369 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VReplaces; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(73);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base__ = __webpack_require__(74);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__initialize__ = __webpack_require__(144);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(71);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base__ = __webpack_require__(72);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__initialize__ = __webpack_require__(139);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -40259,7 +39914,7 @@ var VReplaces = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */]);
 
 /***/ }),
-/* 375 */
+/* 370 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -40326,13 +39981,13 @@ var VToggleVisibility = function () {
 }();
 
 /***/ }),
-/* 376 */
+/* 371 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPromptIfDirty; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(74);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialog__ = __webpack_require__(149);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(72);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialog__ = __webpack_require__(144);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -40446,12 +40101,12 @@ var VPromptIfDirty = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 377 */
+/* 372 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VSnackbarEvent; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(73);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(71);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -40488,7 +40143,7 @@ var VSnackbarEvent = function () {
 }();
 
 /***/ }),
-/* 378 */
+/* 373 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -40554,7 +40209,7 @@ var VClears = function () {
 }();
 
 /***/ }),
-/* 379 */
+/* 374 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -40615,12 +40270,12 @@ var VRemoves = function () {
 }();
 
 /***/ }),
-/* 380 */
+/* 375 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VStepperEvent; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(74);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(72);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -40663,7 +40318,7 @@ var VStepperEvent = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 381 */
+/* 376 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -40698,7 +40353,7 @@ var VPluginEventAction = function () {
 }();
 
 /***/ }),
-/* 382 */
+/* 377 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -40713,7 +40368,7 @@ function getRoot(element) {
 }
 
 /***/ }),
-/* 383 */
+/* 378 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -40919,17 +40574,17 @@ function initLists(e) {
 }
 
 /***/ }),
-/* 384 */
+/* 379 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDrawer;
 /* unused harmony export VModalDrawer */
 /* unused harmony export VDismissibleDrawer */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(385);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(380);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_drawer__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -41006,7 +40661,7 @@ var VDismissibleDrawer = function (_VDrawer2) {
 }(VDrawer);
 
 /***/ }),
-/* 385 */
+/* 380 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -44333,15 +43988,15 @@ var VDismissibleDrawer = function (_VDrawer2) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 386 */
+/* 381 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initHeader;
 /* unused harmony export VHeader */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(387);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(382);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -44378,19 +44033,19 @@ var VHeader = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 387 */
+/* 382 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCTopAppBar; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(56);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(150);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(388);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(57);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(75);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(391);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(392);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(393);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(53);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(145);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(383);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(54);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(73);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(386);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(387);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(388);
 /* unused harmony reexport MDCTopAppBarBaseFoundation */
 /* unused harmony reexport MDCTopAppBarFoundation */
 /* unused harmony reexport MDCFixedTopAppBarFoundation */
@@ -44597,16 +44252,16 @@ var MDCTopAppBar = function (_MDCComponent) {
 
 
 /***/ }),
-/* 388 */
+/* 383 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCRipple; });
 /* unused harmony export RippleCapableSurface */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(150);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(151);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(389);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(152);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(145);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(146);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(384);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(147);
 /* unused harmony reexport MDCRippleFoundation */
 /* unused harmony reexport util */
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -44854,14 +44509,14 @@ RippleCapableSurface.prototype.disabled;
 
 
 /***/ }),
-/* 389 */
+/* 384 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(107);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(151);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(390);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(152);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(104);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(146);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(385);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(147);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -45641,7 +45296,7 @@ var MDCRippleFoundation = function (_MDCFoundation) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCRippleFoundation);
 
 /***/ }),
-/* 390 */
+/* 385 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -45702,13 +45357,13 @@ var numbers = {
 
 
 /***/ }),
-/* 391 */
+/* 386 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(57);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(56);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(75);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(54);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(53);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(73);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -45814,13 +45469,13 @@ var MDCFixedTopAppBarFoundation = function (_MDCTopAppBarFoundati) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCFixedTopAppBarFoundation);
 
 /***/ }),
-/* 392 */
+/* 387 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(56);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(75);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(57);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(53);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(73);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(54);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -45936,13 +45591,13 @@ var MDCShortTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCShortTopAppBarFoundation);
 
 /***/ }),
-/* 393 */
+/* 388 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(56);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(75);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(57);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(53);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(73);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(54);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -46209,15 +45864,15 @@ var MDCTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCTopAppBarFoundation);
 
 /***/ }),
-/* 394 */
+/* 389 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initIconToggles;
 /* unused harmony export VIconToggle */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(76);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(395);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(74);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(390);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -46247,7 +45902,7 @@ var VIconToggle = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 395 */
+/* 390 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -49033,16 +48688,16 @@ var VIconToggle = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 396 */
+/* 391 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initMenus;
 /* unused harmony export VMenu */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(153);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(148);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_menu__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -49089,17 +48744,17 @@ var VMenu = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 397 */
+/* 392 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSelects;
 /* unused harmony export VSelect */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(398);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(393);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_select__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(106);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(103);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -49177,7 +48832,7 @@ var VSelect = function (_visibilityObserverMi) {
 }(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 398 */
+/* 393 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -59409,17 +59064,17 @@ var VSelect = function (_visibilityObserverMi) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 399 */
+/* 394 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initChips;
 /* unused harmony export VChip */
 /* unused harmony export VChipSet */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(154);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(149);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_chips__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -59496,14 +59151,14 @@ var VChipSet = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 400 */
+/* 395 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initCards;
 /* unused harmony export VCard */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(46);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(45);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -59531,15 +59186,15 @@ var VCard = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 401 */
+/* 396 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initForms;
 /* unused harmony export VForm */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_container__ = __webpack_require__(46);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__ = __webpack_require__(10);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_container__ = __webpack_require__(45);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -59568,15 +59223,15 @@ var VForm = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 402 */
+/* 397 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSnackbar;
 /* unused harmony export VSnackbar */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(403);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(398);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_snackbar__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -59623,7 +59278,7 @@ var VSnackbar = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 403 */
+/* 398 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -61157,15 +60812,15 @@ var VSnackbar = function (_VBaseComponent) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 404 */
+/* 399 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initCheckboxes;
 /* unused harmony export VCheckbox */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(76);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(405);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(74);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(400);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_checkbox__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -61207,7 +60862,7 @@ var VCheckbox = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 405 */
+/* 400 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -64323,15 +63978,15 @@ var VCheckbox = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 406 */
+/* 401 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSwitches;
 /* unused harmony export VSwitch */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(76);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(407);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(74);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(402);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_switch__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -64370,7 +64025,7 @@ var VSwitch = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 407 */
+/* 402 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -67015,16 +66670,16 @@ var VSwitch = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 408 */
+/* 403 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRichTextArea;
 /* unused harmony export VRichTextArea */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(409);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(404);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -67118,7 +66773,7 @@ var VRichTextArea = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 409 */
+/* 404 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(Buffer, module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof2 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -80045,10 +79700,10 @@ var VRichTextArea = function (_eventHandlerMixin) {
     /******/)["default"]
   );
 });
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(410).Buffer, __webpack_require__(12)(module)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(405).Buffer, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 410 */
+/* 405 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -80062,9 +79717,9 @@ var VRichTextArea = function (_eventHandlerMixin) {
 
 
 
-var base64 = __webpack_require__(411);
-var ieee754 = __webpack_require__(412);
-var isArray = __webpack_require__(413);
+var base64 = __webpack_require__(406);
+var ieee754 = __webpack_require__(407);
+var isArray = __webpack_require__(408);
 
 exports.Buffer = Buffer;
 exports.SlowBuffer = SlowBuffer;
@@ -81789,10 +81444,10 @@ function blitBuffer(src, dst, offset, length) {
 function isnan(val) {
   return val !== val; // eslint-disable-line no-self-compare
 }
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(77)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(75)))
 
 /***/ }),
-/* 411 */
+/* 406 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -81919,7 +81574,7 @@ function fromByteArray(uint8) {
 }
 
 /***/ }),
-/* 412 */
+/* 407 */
 /***/ (function(module, exports) {
 
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
@@ -82008,7 +81663,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 };
 
 /***/ }),
-/* 413 */
+/* 408 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -82018,15 +81673,15 @@ module.exports = Array.isArray || function (arr) {
 };
 
 /***/ }),
-/* 414 */
+/* 409 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSteppers;
 /* unused harmony export VStepper */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_container__ = __webpack_require__(46);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__ = __webpack_require__(10);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_container__ = __webpack_require__(45);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -82098,15 +81753,15 @@ var VStepper = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 415 */
+/* 410 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRadios;
 /* unused harmony export VRadio */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(76);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(416);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(74);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(411);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_radio__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -82145,7 +81800,7 @@ var VRadio = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 416 */
+/* 411 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -84722,18 +84377,18 @@ var VRadio = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 417 */
+/* 412 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSliders;
 /* unused harmony export VSlider */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(418);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(413);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_slider__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(106);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(147);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(103);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(142);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -84822,7 +84477,7 @@ var VSlider = function (_visibilityObserverMi) {
 }(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 418 */
+/* 413 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -86892,13 +86547,13 @@ var VSlider = function (_visibilityObserverMi) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 419 */
+/* 414 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initHiddenFields;
 /* unused harmony export VHiddenField */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -86962,15 +86617,15 @@ var VHiddenField = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 420 */
+/* 415 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initContent;
 /* unused harmony export VContent */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(46);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(45);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -87002,16 +86657,16 @@ var VContent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 421 */
+/* 416 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initGrid;
 /* unused harmony export VGrid */
 /* unused harmony export VColumn */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(46);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(45);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(10);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -87053,15 +86708,15 @@ var VColumn = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 422 */
+/* 417 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initTabBars;
 /* unused harmony export VTabBar */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(423);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(418);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_tab_bar__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -87091,7 +86746,7 @@ var VTabBar = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 423 */
+/* 418 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -93563,7 +93218,7 @@ var VTabBar = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 424 */
+/* 419 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -93693,14 +93348,14 @@ function initTables(e) {
 }
 
 /***/ }),
-/* 425 */
+/* 420 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initFileInputs;
 /* unused harmony export VFileInput */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -93825,15 +93480,15 @@ var VFileInput = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 426 */
+/* 421 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initFormFields;
 /* unused harmony export VFormField */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(46);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(427);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(45);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(422);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_form_field__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -93865,7 +93520,7 @@ var VFormField = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 427 */
+/* 422 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -96370,14 +96025,14 @@ var VFormField = function (_VBaseContainer) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 428 */
+/* 423 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initImages;
 /* unused harmony export VImage */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -96415,14 +96070,14 @@ var VImage = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 429 */
+/* 424 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initTypography;
 /* unused harmony export VTypography */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -96465,14 +96120,14 @@ var VTypography = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 430 */
+/* 425 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initPlugins;
 /* unused harmony export VPluginComponent */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(3);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(10);
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -39926,9 +39926,6 @@ var VPosts = function (_VBase) {
 
                     formData.append(_name, Object(__WEBPACK_IMPORTED_MODULE_3__encode__["a" /* encode */])(_value));
                 }
-
-                // log dupes:
-                // TODO: remove me (debug)
             } catch (err) {
                 _didIteratorError2 = true;
                 _iteratorError2 = err;
@@ -39944,40 +39941,14 @@ var VPosts = function (_VBase) {
                 }
             }
 
-            var _iteratorNormalCompletion3 = true;
-            var _didIteratorError3 = false;
-            var _iteratorError3 = undefined;
-
-            try {
-                for (var _iterator3 = formData[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-                    var _ref5 = _step3.value;
-
-                    var _ref6 = _slicedToArray(_ref5, 2);
-
-                    var k = _ref6[0];
-                    var v = _ref6[1];
-
-                    console.log(k + ': ' + v);
-                }
-            } catch (err) {
-                _didIteratorError3 = true;
-                _iteratorError3 = err;
-            } finally {
-                try {
-                    if (!_iteratorNormalCompletion3 && _iterator3.return) {
-                        _iterator3.return();
-                    }
-                } finally {
-                    if (_didIteratorError3) {
-                        throw _iteratorError3;
-                    }
-                }
-            }
-
             var paramCount = Array.from(formData).length;
 
             if (paramCount < 1) {
                 console.warn('Creating request with no data!' + ' Are you sure you\'ve hooked everything up correctly?');
+            } else {
+                // log dupes:
+                // TODO: remove me (debug)
+                console.table(Array.from(formData));
             }
 
             var httpRequest = new XMLHttpRequest();
@@ -39989,11 +39960,20 @@ var VPosts = function (_VBase) {
             }
 
             var snackbarCallback = function snackbarCallback(contentType, response) {
-                var snackbar = root.querySelector('.mdc-snackbar').vComponent;
-                if (contentType && contentType.indexOf('application/json') !== -1) {
+                var element = root.querySelector('.mdc-snackbar');
+
+                if (!(element && element.vComponent)) {
+                    return;
+                }
+
+                var snackbar = element.vComponent;
+
+                if (contentType && contentType.includes('application/json')) {
                     var messages = JSON.parse(response).messages;
-                    if (snackbar && messages && messages.snackbar) {
+
+                    if (messages && messages.snackbar) {
                         var message = messages.snackbar.join('<br/>');
+
                         if (message !== '') {
                             snackbar.display(message);
                         }
@@ -40048,63 +40028,63 @@ var VPosts = function (_VBase) {
 
                 var configHeaders = __WEBPACK_IMPORTED_MODULE_1__config__["a" /* default */].get('request.headers.POST', {});
 
-                var _iteratorNormalCompletion4 = true;
-                var _didIteratorError4 = false;
-                var _iteratorError4 = undefined;
+                var _iteratorNormalCompletion3 = true;
+                var _didIteratorError3 = false;
+                var _iteratorError3 = undefined;
 
                 try {
-                    for (var _iterator4 = Object.entries(configHeaders)[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-                        var _ref7 = _step4.value;
+                    for (var _iterator3 = Object.entries(configHeaders)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                        var _ref5 = _step3.value;
 
-                        var _ref8 = _slicedToArray(_ref7, 2);
+                        var _ref6 = _slicedToArray(_ref5, 2);
 
-                        var key = _ref8[0];
-                        var _value2 = _ref8[1];
+                        var key = _ref6[0];
+                        var _value2 = _ref6[1];
 
                         httpRequest.setRequestHeader(key, _value2);
                     }
                 } catch (err) {
-                    _didIteratorError4 = true;
-                    _iteratorError4 = err;
+                    _didIteratorError3 = true;
+                    _iteratorError3 = err;
                 } finally {
                     try {
-                        if (!_iteratorNormalCompletion4 && _iterator4.return) {
-                            _iterator4.return();
+                        if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                            _iterator3.return();
                         }
                     } finally {
-                        if (_didIteratorError4) {
-                            throw _iteratorError4;
+                        if (_didIteratorError3) {
+                            throw _iteratorError3;
                         }
                     }
                 }
 
                 if (callHeaders) {
-                    var _iteratorNormalCompletion5 = true;
-                    var _didIteratorError5 = false;
-                    var _iteratorError5 = undefined;
+                    var _iteratorNormalCompletion4 = true;
+                    var _didIteratorError4 = false;
+                    var _iteratorError4 = undefined;
 
                     try {
-                        for (var _iterator5 = Object.entries(callHeaders)[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-                            var _ref9 = _step5.value;
+                        for (var _iterator4 = Object.entries(callHeaders)[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                            var _ref7 = _step4.value;
 
-                            var _ref10 = _slicedToArray(_ref9, 2);
+                            var _ref8 = _slicedToArray(_ref7, 2);
 
-                            var _key = _ref10[0];
-                            var _value3 = _ref10[1];
+                            var _key = _ref8[0];
+                            var _value3 = _ref8[1];
 
                             httpRequest.setRequestHeader(_key, _value3);
                         }
                     } catch (err) {
-                        _didIteratorError5 = true;
-                        _iteratorError5 = err;
+                        _didIteratorError4 = true;
+                        _iteratorError4 = err;
                     } finally {
                         try {
-                            if (!_iteratorNormalCompletion5 && _iterator5.return) {
-                                _iterator5.return();
+                            if (!_iteratorNormalCompletion4 && _iterator4.return) {
+                                _iterator4.return();
                             }
                         } finally {
-                            if (_didIteratorError5) {
-                                throw _iteratorError5;
+                            if (_didIteratorError4) {
+                                throw _iteratorError4;
                             }
                         }
                     }

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -2606,8 +2606,6 @@ function expandParams(results, o) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__utils_urls__ = __webpack_require__(148);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -2667,49 +2665,74 @@ var VBase = function (_VUrls) {
         }
 
         /**
-         * inputs retrieves relevant elements for this event.
+         * inputs retrieves relevant input elements for this event. The resulting
+         * array of elements is guaranteed to be unique.
          *
-         * 1. If an `input_tag` has been provided, all matching elements are
-         *    included.
-         * 2. If this component is an element, it is included.
-         * 3. If this component has inputs, its elements are included. If not,
-         *    the elements of the nearest content container are included.
+         * - If an `input_tag` has been provided, all matching tagged elements are
+         *   included.
+         * - If this component is a input element, it is included.
+         * - If this component has input elements, its input elements are included.
+         *   If not, the input elements of the nearest container (dialog or content)
+         *   are included.
          * @return {Array<HTMLElement>}
          */
 
     }, {
         key: 'inputs',
         value: function inputs() {
-            var elements = [];
+            var components = [];
 
-            // Collect tagged elements, if applicable:
+            // Collect tagged components, if applicable:
             if (this.options.input_tag) {
-                elements = Array.from(this.taggedInputs());
+                var taggedComponents = Array.from(this.taggedInputs()).filter(function (element) {
+                    return element.vComponent;
+                }).map(function (element) {
+                    return element.vComponent;
+                });
+
+                components.push(taggedComponents);
             }
 
             var comp = this.component();
 
             if (comp) {
-                // Include ourselves if we're a form component (but not a
-                // container):
+                // Include ourselves if we're a form field component, but not a
+                // container:
                 if (comp.respondTo('prepareSubmit') && !comp.respondTo('inputs')) {
-                    elements.push(comp.element);
+                    components.push(comp);
                 } else if (!comp.respondTo('inputs')) {
-                    // Defer to the component's closest content container if the
-                    // component itself does not respond to `inputs`:
+                    // Defer to the component's closest container (dialog or
+                    // content) if the component itself does not respond to
+                    // `inputs`:
                     comp = this.closestContainer();
                 }
             }
 
-            if (comp && comp.respondTo('inputs')
-            // skip if we've previously grabbed elements via input_tag:
-            && comp.element.dataset.inputTag !== this.options.input_tag) {
-                var _elements;
-
-                elements = (_elements = elements).concat.apply(_elements, _toConsumableArray(comp.inputs()));
+            if (comp && comp.respondTo('inputs')) {
+                components.push(comp);
             }
 
-            return elements;
+            // Map components to elements.
+            // Containers are mapped to their child elements.
+            // Form field components are mapped to their own element.
+            var elements = components.flat().flatMap(function (comp) {
+                if (comp.respondTo('inputs')) {
+                    return Array.from(comp.inputs());
+                } else if (comp.respondTo('prepareSubmit')) {
+                    return comp.element;
+                }
+            });
+
+            // Deduplicate:
+            var uniques = Array.from(new Set(elements));
+
+            if (uniques.length > 0) {
+                console.table(uniques.map(function (e) {
+                    return e.id;
+                }));
+            }
+
+            return uniques;
         }
 
         /**

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -1511,10 +1511,7 @@ var VBaseContainer = function (_VBaseComponent) {
     function VBaseContainer(element, mdcComponent) {
         _classCallCheck(this, VBaseContainer);
 
-        var _this = _possibleConstructorReturn(this, (VBaseContainer.__proto__ || Object.getPrototypeOf(VBaseContainer)).call(this, element, mdcComponent));
-
-        element.dataset.isContainer = true;
-        return _this;
+        return _possibleConstructorReturn(this, (VBaseContainer.__proto__ || Object.getPrototypeOf(VBaseContainer)).call(this, element, mdcComponent));
     }
 
     _createClass(VBaseContainer, [{
@@ -2700,7 +2697,7 @@ var VBase = function (_VUrls) {
                 } else if (!comp.respondTo('inputs')) {
                     // Defer to the component's closest content container if the
                     // component itself does not respond to `inputs`:
-                    comp = this.closestContent();
+                    comp = this.closestContainer();
                 }
             }
 
@@ -2769,9 +2766,9 @@ var VBase = function (_VUrls) {
             return [];
         }
     }, {
-        key: 'closestContent',
-        value: function closestContent() {
-            var element = this.closestContentElement();
+        key: 'closestContainer',
+        value: function closestContainer() {
+            var element = this.closestContainerElement();
 
             if (!element) {
                 return null;
@@ -2780,15 +2777,15 @@ var VBase = function (_VUrls) {
             return element.vComponent;
         }
     }, {
-        key: 'closestContentElement',
-        value: function closestContentElement() {
+        key: 'closestContainerElement',
+        value: function closestContainerElement() {
             var comp = this.component();
 
             if (!(comp && comp.element)) {
                 return null;
             }
 
-            return comp.element.closest('.v-content');
+            return comp.element.closest('[data-is-container]');
         }
     }]);
 
@@ -39987,14 +39984,13 @@ var VPosts = function (_VBase) {
             var url = this.url;
             var callHeaders = this.headers;
             var root = this.root;
-
             if (!httpRequest) {
                 throw new Error('Cannot talk to server! Please upgrade your browser to one that supports XMLHttpRequest.');
             }
 
             var snackbarCallback = function snackbarCallback(contentType, response) {
                 var snackbar = root.querySelector('.mdc-snackbar').vComponent;
-                if (contentType && contentType.includes('application/json')) {
+                if (contentType && contentType.indexOf('application/json') !== -1) {
                     var messages = JSON.parse(response).messages;
                     if (snackbar && messages && messages.snackbar) {
                         var message = messages.snackbar.join('<br/>');
@@ -40022,7 +40018,7 @@ var VPosts = function (_VBase) {
                             snackbarCallback(contentType, httpRequest.responseText);
                             resolve(results);
                             // Response is an html error page
-                        } else if (contentType && contentType.includes('text/html')) {
+                        } else if (contentType && contentType.indexOf('text/html') !== -1) {
                             root.open(contentType);
                             root.write(httpRequest.responseText);
                             root.close();
@@ -86993,7 +86989,10 @@ var VContent = function (_eventHandlerMixin) {
     function VContent(element, mdcComponent) {
         _classCallCheck(this, VContent);
 
-        return _possibleConstructorReturn(this, (VContent.__proto__ || Object.getPrototypeOf(VContent)).call(this, element, mdcComponent));
+        var _this = _possibleConstructorReturn(this, (VContent.__proto__ || Object.getPrototypeOf(VContent)).call(this, element, mdcComponent));
+
+        element.setAttribute('data-is-container', '');
+        return _this;
     }
 
     return VContent;

--- a/public/style-bundle.js
+++ b/public/style-bundle.js
@@ -65,9 +65,9 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports) {
 
-module.exports = __webpack_require__.p + "../../public/bundle.css";
+throw new Error("Module build failed: Error: Missing binding /Users/nickmiller/Projects/jadefish/presenters/views/mdc/node_modules/node-sass/vendor/darwin-x64-64/binding.node\nNode Sass could not find a binding for your current environment: OS X 64-bit with Node.js 10.x\n\nFound bindings for the following environments:\n  - OS X 64-bit with Node.js 5.x\n\nThis usually happens because your environment has changed since running `npm install`.\nRun `npm rebuild node-sass` to download the binding for your current environment.\n    at module.exports (/Users/nickmiller/Projects/jadefish/presenters/views/mdc/node_modules/node-sass/lib/binding.js:15:13)\n    at Object.<anonymous> (/Users/nickmiller/Projects/jadefish/presenters/views/mdc/node_modules/node-sass/lib/index.js:14:35)\n    at Module._compile (internal/modules/cjs/loader.js:701:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)\n    at Module.load (internal/modules/cjs/loader.js:600:32)\n    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)\n    at Function.Module._load (internal/modules/cjs/loader.js:531:3)\n    at Module.require (internal/modules/cjs/loader.js:637:17)\n    at require (internal/modules/cjs/helpers.js:22:18)\n    at Object.sassLoader (/Users/nickmiller/Projects/jadefish/presenters/views/mdc/node_modules/sass-loader/lib/loader.js:46:72)");
 
 /***/ })
 /******/ ]);

--- a/public/style-bundle.js
+++ b/public/style-bundle.js
@@ -65,9 +65,9 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-throw new Error("Module build failed: Error: Missing binding /Users/nickmiller/Projects/jadefish/presenters/views/mdc/node_modules/node-sass/vendor/darwin-x64-64/binding.node\nNode Sass could not find a binding for your current environment: OS X 64-bit with Node.js 10.x\n\nFound bindings for the following environments:\n  - OS X 64-bit with Node.js 5.x\n\nThis usually happens because your environment has changed since running `npm install`.\nRun `npm rebuild node-sass` to download the binding for your current environment.\n    at module.exports (/Users/nickmiller/Projects/jadefish/presenters/views/mdc/node_modules/node-sass/lib/binding.js:15:13)\n    at Object.<anonymous> (/Users/nickmiller/Projects/jadefish/presenters/views/mdc/node_modules/node-sass/lib/index.js:14:35)\n    at Module._compile (internal/modules/cjs/loader.js:701:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)\n    at Module.load (internal/modules/cjs/loader.js:600:32)\n    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)\n    at Function.Module._load (internal/modules/cjs/loader.js:531:3)\n    at Module.require (internal/modules/cjs/loader.js:637:17)\n    at require (internal/modules/cjs/helpers.js:22:18)\n    at Object.sassLoader (/Users/nickmiller/Projects/jadefish/presenters/views/mdc/node_modules/sass-loader/lib/loader.js:46:72)");
+module.exports = __webpack_require__.p + "../../public/bundle.css";
 
 /***/ })
 /******/ ]);

--- a/public/wc.js
+++ b/public/wc.js
@@ -224,10 +224,7 @@ var VBaseContainer = function (_VBaseComponent) {
     function VBaseContainer(element, mdcComponent) {
         _classCallCheck(this, VBaseContainer);
 
-        var _this = _possibleConstructorReturn(this, (VBaseContainer.__proto__ || Object.getPrototypeOf(VBaseContainer)).call(this, element, mdcComponent));
-
-        element.dataset.isContainer = true;
-        return _this;
+        return _possibleConstructorReturn(this, (VBaseContainer.__proto__ || Object.getPrototypeOf(VBaseContainer)).call(this, element, mdcComponent));
     }
 
     _createClass(VBaseContainer, [{
@@ -774,7 +771,7 @@ var VBase = function (_VUrls) {
                 } else if (!comp.respondTo('inputs')) {
                     // Defer to the component's closest content container if the
                     // component itself does not respond to `inputs`:
-                    comp = this.closestContent();
+                    comp = this.closestContainer();
                 }
             }
 
@@ -843,9 +840,9 @@ var VBase = function (_VUrls) {
             return [];
         }
     }, {
-        key: 'closestContent',
-        value: function closestContent() {
-            var element = this.closestContentElement();
+        key: 'closestContainer',
+        value: function closestContainer() {
+            var element = this.closestContainerElement();
 
             if (!element) {
                 return null;
@@ -854,15 +851,15 @@ var VBase = function (_VUrls) {
             return element.vComponent;
         }
     }, {
-        key: 'closestContentElement',
-        value: function closestContentElement() {
+        key: 'closestContainerElement',
+        value: function closestContainerElement() {
             var comp = this.component();
 
             if (!(comp && comp.element)) {
                 return null;
             }
 
-            return comp.element.closest('.v-content');
+            return comp.element.closest('[data-is-container]');
         }
     }]);
 
@@ -25481,14 +25478,13 @@ var VPosts = function (_VBase) {
             var url = this.url;
             var callHeaders = this.headers;
             var root = this.root;
-
             if (!httpRequest) {
                 throw new Error('Cannot talk to server! Please upgrade your browser to one that supports XMLHttpRequest.');
             }
 
             var snackbarCallback = function snackbarCallback(contentType, response) {
                 var snackbar = root.querySelector('.mdc-snackbar').vComponent;
-                if (contentType && contentType.includes('application/json')) {
+                if (contentType && contentType.indexOf('application/json') !== -1) {
                     var messages = JSON.parse(response).messages;
                     if (snackbar && messages && messages.snackbar) {
                         var message = messages.snackbar.join('<br/>');
@@ -25516,7 +25512,7 @@ var VPosts = function (_VBase) {
                             snackbarCallback(contentType, httpRequest.responseText);
                             resolve(results);
                             // Response is an html error page
-                        } else if (contentType && contentType.includes('text/html')) {
+                        } else if (contentType && contentType.indexOf('text/html') !== -1) {
                             root.open(contentType);
                             root.write(httpRequest.responseText);
                             root.close();
@@ -72487,7 +72483,10 @@ var VContent = function (_eventHandlerMixin) {
     function VContent(element, mdcComponent) {
         _classCallCheck(this, VContent);
 
-        return _possibleConstructorReturn(this, (VContent.__proto__ || Object.getPrototypeOf(VContent)).call(this, element, mdcComponent));
+        var _this = _possibleConstructorReturn(this, (VContent.__proto__ || Object.getPrototypeOf(VContent)).call(this, element, mdcComponent));
+
+        element.setAttribute('data-is-container', '');
+        return _this;
     }
 
     return VContent;

--- a/public/wc.js
+++ b/public/wc.js
@@ -739,8 +739,7 @@ var VBase = function (_VUrls) {
         }
 
         /**
-         * inputs retrieves relevant input elements for this event. The resulting
-         * array of elements is guaranteed to be unique.
+         * inputs retrieves relevant input elements for this event.
          *
          * - If an `input_tag` has been provided, all matching tagged elements are
          *   included.
@@ -798,15 +797,7 @@ var VBase = function (_VUrls) {
             });
 
             // Deduplicate:
-            var uniques = Array.from(new Set(elements));
-
-            if (uniques.length > 0) {
-                console.table(uniques.map(function (e) {
-                    return e.id;
-                }));
-            }
-
-            return uniques;
+            return Array.from(new Set(elements));
         }
 
         /**
@@ -23073,2101 +23064,2181 @@ var VDateTime = function (_VTextField) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-/* flatpickr v4.5.7, @license MIT */
+/* flatpickr v4.5.2, @license MIT */
 (function (global, factory) {
-    ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = factory() :  true ? !(__WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = factory() :  true ? !(__WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) :
 				__WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : (global = global || self, global.flatpickr = factory());
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : global.flatpickr = factory();
 })(this, function () {
-    'use strict';
+  'use strict';
 
-    /*! *****************************************************************************
-    Copyright (c) Microsoft Corporation. All rights reserved.
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-    this file except in compliance with the License. You may obtain a copy of the
-    License at http://www.apache.org/licenses/LICENSE-2.0
-      THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-    WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-    MERCHANTABLITY OR NON-INFRINGEMENT.
-      See the Apache Version 2.0 License for specific language governing permissions
-    and limitations under the License.
-    ***************************************************************************** */
+  var pad = function pad(number) {
+    return ("0" + number).slice(-2);
+  };
+  var int = function int(bool) {
+    return bool === true ? 1 : 0;
+  };
+  function debounce(func, wait, immediate) {
+    if (immediate === void 0) {
+      immediate = false;
+    }
 
-    var _assign = function __assign() {
-        _assign = Object.assign || function __assign(t) {
-            for (var s, i = 1, n = arguments.length; i < n; i++) {
-                s = arguments[i];
-                for (var p in s) {
-                    if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
-                }
-            }
-            return t;
-        };
-        return _assign.apply(this, arguments);
+    var timeout;
+    return function () {
+      var context = this,
+          args = arguments;
+      timeout !== null && clearTimeout(timeout);
+      timeout = window.setTimeout(function () {
+        timeout = null;
+        if (!immediate) func.apply(context, args);
+      }, wait);
+      if (immediate && !timeout) func.apply(context, args);
     };
+  }
+  var arrayify = function arrayify(obj) {
+    return obj instanceof Array ? obj : [obj];
+  };
 
-    var HOOKS = ["onChange", "onClose", "onDayCreate", "onDestroy", "onKeyDown", "onMonthChange", "onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange", "onPreCalendarPosition"];
-    var defaults = {
-        _disable: [],
-        _enable: [],
-        allowInput: false,
-        altFormat: "F j, Y",
-        altInput: false,
-        altInputClass: "form-control input",
-        animate: (typeof window === 'undefined' ? 'undefined' : _typeof(window)) === "object" && window.navigator.userAgent.indexOf("MSIE") === -1,
-        ariaDateFormat: "F j, Y",
-        clickOpens: true,
-        closeOnSelect: true,
-        conjunction: ", ",
-        dateFormat: "Y-m-d",
-        defaultHour: 12,
-        defaultMinute: 0,
-        defaultSeconds: 0,
-        disable: [],
-        disableMobile: false,
-        enable: [],
-        enableSeconds: false,
-        enableTime: false,
-        errorHandler: function errorHandler(err) {
-            return typeof console !== "undefined" && console.warn(err);
-        },
-        getWeek: function getWeek(givenDate) {
-            var date = new Date(givenDate.getTime());
-            date.setHours(0, 0, 0, 0);
-            // Thursday in current week decides the year.
-            date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
-            // January 4 is always in week 1.
-            var week1 = new Date(date.getFullYear(), 0, 4);
-            // Adjust to Thursday in week 1 and count number of weeks from date to week1.
-            return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getDay() + 6) % 7) / 7);
-        },
-        hourIncrement: 1,
-        ignoredFocusElements: [],
-        inline: false,
-        locale: "default",
-        minuteIncrement: 5,
-        mode: "single",
-        nextArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
-        noCalendar: false,
-        now: new Date(),
-        onChange: [],
-        onClose: [],
-        onDayCreate: [],
-        onDestroy: [],
-        onKeyDown: [],
-        onMonthChange: [],
-        onOpen: [],
-        onParseConfig: [],
-        onReady: [],
-        onValueUpdate: [],
-        onYearChange: [],
-        onPreCalendarPosition: [],
-        plugins: [],
-        position: "auto",
-        positionElement: undefined,
-        prevArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
-        shorthandCurrentMonth: false,
-        showMonths: 1,
-        static: false,
-        time_24hr: false,
-        weekNumbers: false,
-        wrap: false
-    };
+  var do_nothing = function do_nothing() {
+    return undefined;
+  };
 
-    var english = {
-        weekdays: {
-            shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-            longhand: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-        },
-        months: {
-            shorthand: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-            longhand: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-        },
-        daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-        firstDayOfWeek: 0,
-        ordinal: function ordinal(nth) {
-            var s = nth % 100;
-            if (s > 3 && s < 21) return "th";
-            switch (s % 10) {
-                case 1:
-                    return "st";
-                case 2:
-                    return "nd";
-                case 3:
-                    return "rd";
-                default:
-                    return "th";
-            }
-        },
-        rangeSeparator: " to ",
-        weekAbbreviation: "Wk",
-        scrollTitle: "Scroll to increment",
-        toggleTitle: "Click to toggle",
-        amPM: ["AM", "PM"],
-        yearAriaLabel: "Year"
-    };
+  var monthToStr = function monthToStr(monthNumber, shorthand, locale) {
+    return locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
+  };
+  var revFormat = {
+    D: do_nothing,
+    F: function F(dateObj, monthName, locale) {
+      dateObj.setMonth(locale.months.longhand.indexOf(monthName));
+    },
+    G: function G(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    H: function H(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    J: function J(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    K: function K(dateObj, amPM, locale) {
+      dateObj.setHours(dateObj.getHours() % 12 + 12 * int(new RegExp(locale.amPM[1], "i").test(amPM)));
+    },
+    M: function M(dateObj, shortMonth, locale) {
+      dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
+    },
+    S: function S(dateObj, seconds) {
+      dateObj.setSeconds(parseFloat(seconds));
+    },
+    U: function U(_, unixSeconds) {
+      return new Date(parseFloat(unixSeconds) * 1000);
+    },
+    W: function W(dateObj, weekNum) {
+      var weekNumber = parseInt(weekNum);
+      return new Date(dateObj.getFullYear(), 0, 2 + (weekNumber - 1) * 7, 0, 0, 0, 0);
+    },
+    Y: function Y(dateObj, year) {
+      dateObj.setFullYear(parseFloat(year));
+    },
+    Z: function Z(_, ISODate) {
+      return new Date(ISODate);
+    },
+    d: function d(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    h: function h(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    i: function i(dateObj, minutes) {
+      dateObj.setMinutes(parseFloat(minutes));
+    },
+    j: function j(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    l: do_nothing,
+    m: function m(dateObj, month) {
+      dateObj.setMonth(parseFloat(month) - 1);
+    },
+    n: function n(dateObj, month) {
+      dateObj.setMonth(parseFloat(month) - 1);
+    },
+    s: function s(dateObj, seconds) {
+      dateObj.setSeconds(parseFloat(seconds));
+    },
+    w: do_nothing,
+    y: function y(dateObj, year) {
+      dateObj.setFullYear(2000 + parseFloat(year));
+    }
+  };
+  var tokenRegex = {
+    D: "(\\w+)",
+    F: "(\\w+)",
+    G: "(\\d\\d|\\d)",
+    H: "(\\d\\d|\\d)",
+    J: "(\\d\\d|\\d)\\w+",
+    K: "",
+    M: "(\\w+)",
+    S: "(\\d\\d|\\d)",
+    U: "(.+)",
+    W: "(\\d\\d|\\d)",
+    Y: "(\\d{4})",
+    Z: "(.+)",
+    d: "(\\d\\d|\\d)",
+    h: "(\\d\\d|\\d)",
+    i: "(\\d\\d|\\d)",
+    j: "(\\d\\d|\\d)",
+    l: "(\\w+)",
+    m: "(\\d\\d|\\d)",
+    n: "(\\d\\d|\\d)",
+    s: "(\\d\\d|\\d)",
+    w: "(\\d\\d|\\d)",
+    y: "(\\d{2})"
+  };
+  var formats = {
+    Z: function Z(date) {
+      return date.toISOString();
+    },
+    D: function D(date, locale, options) {
+      return locale.weekdays.shorthand[formats.w(date, locale, options)];
+    },
+    F: function F(date, locale, options) {
+      return monthToStr(formats.n(date, locale, options) - 1, false, locale);
+    },
+    G: function G(date, locale, options) {
+      return pad(formats.h(date, locale, options));
+    },
+    H: function H(date) {
+      return pad(date.getHours());
+    },
+    J: function J(date, locale) {
+      return locale.ordinal !== undefined ? date.getDate() + locale.ordinal(date.getDate()) : date.getDate();
+    },
+    K: function K(date, locale) {
+      return locale.amPM[int(date.getHours() > 11)];
+    },
+    M: function M(date, locale) {
+      return monthToStr(date.getMonth(), true, locale);
+    },
+    S: function S(date) {
+      return pad(date.getSeconds());
+    },
+    U: function U(date) {
+      return date.getTime() / 1000;
+    },
+    W: function W(date, _, options) {
+      return options.getWeek(date);
+    },
+    Y: function Y(date) {
+      return date.getFullYear();
+    },
+    d: function d(date) {
+      return pad(date.getDate());
+    },
+    h: function h(date) {
+      return date.getHours() % 12 ? date.getHours() % 12 : 12;
+    },
+    i: function i(date) {
+      return pad(date.getMinutes());
+    },
+    j: function j(date) {
+      return date.getDate();
+    },
+    l: function l(date, locale) {
+      return locale.weekdays.longhand[date.getDay()];
+    },
+    m: function m(date) {
+      return pad(date.getMonth() + 1);
+    },
+    n: function n(date) {
+      return date.getMonth() + 1;
+    },
+    s: function s(date) {
+      return date.getSeconds();
+    },
+    w: function w(date) {
+      return date.getDay();
+    },
+    y: function y(date) {
+      return String(date.getFullYear()).substring(2);
+    }
+  };
 
-    var pad = function pad(number) {
-        return ("0" + number).slice(-2);
+  var english = {
+    weekdays: {
+      shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+      longhand: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    },
+    months: {
+      shorthand: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+      longhand: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+    },
+    daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+    firstDayOfWeek: 0,
+    ordinal: function ordinal(nth) {
+      var s = nth % 100;
+      if (s > 3 && s < 21) return "th";
+
+      switch (s % 10) {
+        case 1:
+          return "st";
+
+        case 2:
+          return "nd";
+
+        case 3:
+          return "rd";
+
+        default:
+          return "th";
+      }
+    },
+    rangeSeparator: " to ",
+    weekAbbreviation: "Wk",
+    scrollTitle: "Scroll to increment",
+    toggleTitle: "Click to toggle",
+    amPM: ["AM", "PM"],
+    yearAriaLabel: "Year"
+  };
+
+  var createDateFormatter = function createDateFormatter(_ref) {
+    var _ref$config = _ref.config,
+        config = _ref$config === void 0 ? defaults : _ref$config,
+        _ref$l10n = _ref.l10n,
+        l10n = _ref$l10n === void 0 ? english : _ref$l10n;
+    return function (dateObj, frmt, overrideLocale) {
+      var locale = overrideLocale || l10n;
+
+      if (config.formatDate !== undefined) {
+        return config.formatDate(dateObj, frmt, locale);
+      }
+
+      return frmt.split("").map(function (c, i, arr) {
+        return formats[c] && arr[i - 1] !== "\\" ? formats[c](dateObj, locale, config) : c !== "\\" ? c : "";
+      }).join("");
     };
-    var int = function int(bool) {
-        return bool === true ? 1 : 0;
-    };
-    /* istanbul ignore next */
-    function debounce(func, wait, immediate) {
-        if (immediate === void 0) {
-            immediate = false;
+  };
+  var createDateParser = function createDateParser(_ref2) {
+    var _ref2$config = _ref2.config,
+        config = _ref2$config === void 0 ? defaults : _ref2$config,
+        _ref2$l10n = _ref2.l10n,
+        l10n = _ref2$l10n === void 0 ? english : _ref2$l10n;
+    return function (date, givenFormat, timeless, customLocale) {
+      if (date !== 0 && !date) return undefined;
+      var locale = customLocale || l10n;
+      var parsedDate;
+      var date_orig = date;
+      if (date instanceof Date) parsedDate = new Date(date.getTime());else if (typeof date !== "string" && date.toFixed !== undefined) parsedDate = new Date(date);else if (typeof date === "string") {
+        var format = givenFormat || (config || defaults).dateFormat;
+        var datestr = String(date).trim();
+
+        if (datestr === "today") {
+          parsedDate = new Date();
+          timeless = true;
+        } else if (/Z$/.test(datestr) || /GMT$/.test(datestr)) parsedDate = new Date(date);else if (config && config.parseDate) parsedDate = config.parseDate(date, format);else {
+          parsedDate = !config || !config.noCalendar ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0) : new Date(new Date().setHours(0, 0, 0, 0));
+          var matched,
+              ops = [];
+
+          for (var i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
+            var token = format[i];
+            var isBackSlash = token === "\\";
+            var escaped = format[i - 1] === "\\" || isBackSlash;
+
+            if (tokenRegex[token] && !escaped) {
+              regexStr += tokenRegex[token];
+              var match = new RegExp(regexStr).exec(date);
+
+              if (match && (matched = true)) {
+                ops[token !== "Y" ? "push" : "unshift"]({
+                  fn: revFormat[token],
+                  val: match[++matchIndex]
+                });
+              }
+            } else if (!isBackSlash) regexStr += ".";
+
+            ops.forEach(function (_ref3) {
+              var fn = _ref3.fn,
+                  val = _ref3.val;
+              return parsedDate = fn(parsedDate, val, locale) || parsedDate;
+            });
+          }
+
+          parsedDate = matched ? parsedDate : undefined;
         }
-        var timeout;
-        return function () {
-            var context = this,
-                args = arguments;
-            timeout !== null && clearTimeout(timeout);
-            timeout = window.setTimeout(function () {
-                timeout = null;
-                if (!immediate) func.apply(context, args);
-            }, wait);
-            if (immediate && !timeout) func.apply(context, args);
-        };
-    }
-    var arrayify = function arrayify(obj) {
-        return obj instanceof Array ? obj : [obj];
-    };
+      }
 
-    function toggleClass(elem, className, bool) {
-        if (bool === true) return elem.classList.add(className);
-        elem.classList.remove(className);
-    }
-    function createElement(tag, className, content) {
-        var e = window.document.createElement(tag);
-        className = className || "";
-        content = content || "";
-        e.className = className;
-        if (content !== undefined) e.textContent = content;
-        return e;
-    }
-    function clearNode(node) {
-        while (node.firstChild) {
-            node.removeChild(node.firstChild);
-        }
-    }
-    function findParent(node, condition) {
-        if (condition(node)) return node;else if (node.parentNode) return findParent(node.parentNode, condition);
-        return undefined; // nothing found
-    }
-    function createNumberInput(inputClassName, opts) {
-        var wrapper = createElement("div", "numInputWrapper"),
-            numInput = createElement("input", "numInput " + inputClassName),
-            arrowUp = createElement("span", "arrowUp"),
-            arrowDown = createElement("span", "arrowDown");
-        if (navigator.userAgent.indexOf("MSIE 9.0") === -1) {
-            numInput.type = "number";
-        } else {
-            numInput.type = "text";
-            numInput.pattern = "\\d*";
-        }
-        if (opts !== undefined) for (var key in opts) {
-            numInput.setAttribute(key, opts[key]);
-        }wrapper.appendChild(numInput);
-        wrapper.appendChild(arrowUp);
-        wrapper.appendChild(arrowDown);
-        return wrapper;
-    }
-    function getEventTarget(event) {
-        if (typeof event.composedPath === "function") {
-            var path = event.composedPath();
-            return path[0];
-        }
-        return event.target;
-    }
-
-    var do_nothing = function do_nothing() {
+      if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
+        config.errorHandler(new Error("Invalid date provided: " + date_orig));
         return undefined;
-    };
-    var monthToStr = function monthToStr(monthNumber, shorthand, locale) {
-        return locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
-    };
-    var revFormat = {
-        D: do_nothing,
-        F: function F(dateObj, monthName, locale) {
-            dateObj.setMonth(locale.months.longhand.indexOf(monthName));
-        },
-        G: function G(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        H: function H(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        J: function J(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        K: function K(dateObj, amPM, locale) {
-            dateObj.setHours(dateObj.getHours() % 12 + 12 * int(new RegExp(locale.amPM[1], "i").test(amPM)));
-        },
-        M: function M(dateObj, shortMonth, locale) {
-            dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
-        },
-        S: function S(dateObj, seconds) {
-            dateObj.setSeconds(parseFloat(seconds));
-        },
-        U: function U(_, unixSeconds) {
-            return new Date(parseFloat(unixSeconds) * 1000);
-        },
-        W: function W(dateObj, weekNum) {
-            var weekNumber = parseInt(weekNum);
-            return new Date(dateObj.getFullYear(), 0, 2 + (weekNumber - 1) * 7, 0, 0, 0, 0);
-        },
-        Y: function Y(dateObj, year) {
-            dateObj.setFullYear(parseFloat(year));
-        },
-        Z: function Z(_, ISODate) {
-            return new Date(ISODate);
-        },
-        d: function d(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        h: function h(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        i: function i(dateObj, minutes) {
-            dateObj.setMinutes(parseFloat(minutes));
-        },
-        j: function j(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        l: do_nothing,
-        m: function m(dateObj, month) {
-            dateObj.setMonth(parseFloat(month) - 1);
-        },
-        n: function n(dateObj, month) {
-            dateObj.setMonth(parseFloat(month) - 1);
-        },
-        s: function s(dateObj, seconds) {
-            dateObj.setSeconds(parseFloat(seconds));
-        },
-        u: function u(_, unixMillSeconds) {
-            return new Date(parseFloat(unixMillSeconds));
-        },
-        w: do_nothing,
-        y: function y(dateObj, year) {
-            dateObj.setFullYear(2000 + parseFloat(year));
-        }
-    };
-    var tokenRegex = {
-        D: "(\\w+)",
-        F: "(\\w+)",
-        G: "(\\d\\d|\\d)",
-        H: "(\\d\\d|\\d)",
-        J: "(\\d\\d|\\d)\\w+",
-        K: "",
-        M: "(\\w+)",
-        S: "(\\d\\d|\\d)",
-        U: "(.+)",
-        W: "(\\d\\d|\\d)",
-        Y: "(\\d{4})",
-        Z: "(.+)",
-        d: "(\\d\\d|\\d)",
-        h: "(\\d\\d|\\d)",
-        i: "(\\d\\d|\\d)",
-        j: "(\\d\\d|\\d)",
-        l: "(\\w+)",
-        m: "(\\d\\d|\\d)",
-        n: "(\\d\\d|\\d)",
-        s: "(\\d\\d|\\d)",
-        u: "(.+)",
-        w: "(\\d\\d|\\d)",
-        y: "(\\d{2})"
-    };
-    var formats = {
-        // get the date in UTC
-        Z: function Z(date) {
-            return date.toISOString();
-        },
-        // weekday name, short, e.g. Thu
-        D: function D(date, locale, options) {
-            return locale.weekdays.shorthand[formats.w(date, locale, options)];
-        },
-        // full month name e.g. January
-        F: function F(date, locale, options) {
-            return monthToStr(formats.n(date, locale, options) - 1, false, locale);
-        },
-        // padded hour 1-12
-        G: function G(date, locale, options) {
-            return pad(formats.h(date, locale, options));
-        },
-        // hours with leading zero e.g. 03
-        H: function H(date) {
-            return pad(date.getHours());
-        },
-        // day (1-30) with ordinal suffix e.g. 1st, 2nd
-        J: function J(date, locale) {
-            return locale.ordinal !== undefined ? date.getDate() + locale.ordinal(date.getDate()) : date.getDate();
-        },
-        // AM/PM
-        K: function K(date, locale) {
-            return locale.amPM[int(date.getHours() > 11)];
-        },
-        // shorthand month e.g. Jan, Sep, Oct, etc
-        M: function M(date, locale) {
-            return monthToStr(date.getMonth(), true, locale);
-        },
-        // seconds 00-59
-        S: function S(date) {
-            return pad(date.getSeconds());
-        },
-        // unix timestamp
-        U: function U(date) {
-            return date.getTime() / 1000;
-        },
-        W: function W(date, _, options) {
-            return options.getWeek(date);
-        },
-        // full year e.g. 2016
-        Y: function Y(date) {
-            return date.getFullYear();
-        },
-        // day in month, padded (01-30)
-        d: function d(date) {
-            return pad(date.getDate());
-        },
-        // hour from 1-12 (am/pm)
-        h: function h(date) {
-            return date.getHours() % 12 ? date.getHours() % 12 : 12;
-        },
-        // minutes, padded with leading zero e.g. 09
-        i: function i(date) {
-            return pad(date.getMinutes());
-        },
-        // day in month (1-30)
-        j: function j(date) {
-            return date.getDate();
-        },
-        // weekday name, full, e.g. Thursday
-        l: function l(date, locale) {
-            return locale.weekdays.longhand[date.getDay()];
-        },
-        // padded month number (01-12)
-        m: function m(date) {
-            return pad(date.getMonth() + 1);
-        },
-        // the month number (1-12)
-        n: function n(date) {
-            return date.getMonth() + 1;
-        },
-        // seconds 0-59
-        s: function s(date) {
-            return date.getSeconds();
-        },
-        // Unix Milliseconds
-        u: function u(date) {
-            return date.getTime();
-        },
-        // number of the day of the week
-        w: function w(date) {
-            return date.getDay();
-        },
-        // last two digits of year e.g. 16 for 2016
-        y: function y(date) {
-            return String(date.getFullYear()).substring(2);
-        }
-    };
+      }
 
-    var createDateFormatter = function createDateFormatter(_a) {
-        var _b = _a.config,
-            config = _b === void 0 ? defaults : _b,
-            _c = _a.l10n,
-            l10n = _c === void 0 ? english : _c;
-        return function (dateObj, frmt, overrideLocale) {
-            var locale = overrideLocale || l10n;
-            if (config.formatDate !== undefined) {
-                return config.formatDate(dateObj, frmt, locale);
-            }
-            return frmt.split("").map(function (c, i, arr) {
-                return formats[c] && arr[i - 1] !== "\\" ? formats[c](dateObj, locale, config) : c !== "\\" ? c : "";
-            }).join("");
-        };
+      if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
+      return parsedDate;
     };
-    var createDateParser = function createDateParser(_a) {
-        var _b = _a.config,
-            config = _b === void 0 ? defaults : _b,
-            _c = _a.l10n,
-            l10n = _c === void 0 ? english : _c;
-        return function (date, givenFormat, timeless, customLocale) {
-            if (date !== 0 && !date) return undefined;
-            var locale = customLocale || l10n;
-            var parsedDate;
-            var date_orig = date;
-            if (date instanceof Date) parsedDate = new Date(date.getTime());else if (typeof date !== "string" && date.toFixed !== undefined // timestamp
-            )
-                // create a copy
-                parsedDate = new Date(date);else if (typeof date === "string") {
-                // date string
-                var format = givenFormat || (config || defaults).dateFormat;
-                var datestr = String(date).trim();
-                if (datestr === "today") {
-                    parsedDate = new Date();
-                    timeless = true;
-                } else if (/Z$/.test(datestr) || /GMT$/.test(datestr) // datestrings w/ timezone
-                ) parsedDate = new Date(date);else if (config && config.parseDate) parsedDate = config.parseDate(date, format);else {
-                    parsedDate = !config || !config.noCalendar ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0) : new Date(new Date().setHours(0, 0, 0, 0));
-                    var matched = void 0,
-                        ops = [];
-                    for (var i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
-                        var token_1 = format[i];
-                        var isBackSlash = token_1 === "\\";
-                        var escaped = format[i - 1] === "\\" || isBackSlash;
-                        if (tokenRegex[token_1] && !escaped) {
-                            regexStr += tokenRegex[token_1];
-                            var match = new RegExp(regexStr).exec(date);
-                            if (match && (matched = true)) {
-                                ops[token_1 !== "Y" ? "push" : "unshift"]({
-                                    fn: revFormat[token_1],
-                                    val: match[++matchIndex]
-                                });
-                            }
-                        } else if (!isBackSlash) regexStr += "."; // don't really care
-                        ops.forEach(function (_a) {
-                            var fn = _a.fn,
-                                val = _a.val;
-                            return parsedDate = fn(parsedDate, val, locale) || parsedDate;
-                        });
-                    }
-                    parsedDate = matched ? parsedDate : undefined;
-                }
-            }
-            /* istanbul ignore next */
-            if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
-                config.errorHandler(new Error("Invalid date provided: " + date_orig));
-                return undefined;
-            }
-            if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
-            return parsedDate;
-        };
-    };
-    /**
-     * Compute the difference in dates, measured in ms
-     */
-    function compareDates(date1, date2, timeless) {
-        if (timeless === void 0) {
-            timeless = true;
-        }
-        if (timeless !== false) {
-            return new Date(date1.getTime()).setHours(0, 0, 0, 0) - new Date(date2.getTime()).setHours(0, 0, 0, 0);
-        }
-        return date1.getTime() - date2.getTime();
-    }
-    var isBetween = function isBetween(ts, ts1, ts2) {
-        return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
-    };
-    var duration = {
-        DAY: 86400000
-    };
-
-    if (typeof Object.assign !== "function") {
-        Object.assign = function (target) {
-            var args = [];
-            for (var _i = 1; _i < arguments.length; _i++) {
-                args[_i - 1] = arguments[_i];
-            }
-            if (!target) {
-                throw TypeError("Cannot convert undefined or null to object");
-            }
-            var _loop_1 = function _loop_1(source) {
-                if (source) {
-                    Object.keys(source).forEach(function (key) {
-                        return target[key] = source[key];
-                    });
-                }
-            };
-            for (var _a = 0, args_1 = args; _a < args_1.length; _a++) {
-                var source = args_1[_a];
-                _loop_1(source);
-            }
-            return target;
-        };
+  };
+  function compareDates(date1, date2, timeless) {
+    if (timeless === void 0) {
+      timeless = true;
     }
 
-    var DEBOUNCED_CHANGE_MS = 300;
-    function FlatpickrInstance(element, instanceConfig) {
-        var self = {
-            config: _assign({}, flatpickr.defaultConfig),
-            l10n: english
-        };
-        self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
-        self._handlers = [];
-        self._bind = bind;
-        self._setHoursFromDate = setHoursFromDate;
-        self._positionCalendar = positionCalendar;
-        self.changeMonth = changeMonth;
-        self.changeYear = changeYear;
-        self.clear = clear;
-        self.close = close;
-        self._createElement = createElement;
-        self.destroy = destroy;
-        self.isEnabled = isEnabled;
-        self.jumpToDate = jumpToDate;
-        self.open = open;
-        self.redraw = redraw;
-        self.set = set;
-        self.setDate = setDate;
-        self.toggle = toggle;
-        function setupHelperFunctions() {
-            self.utils = {
-                getDaysInMonth: function getDaysInMonth(month, yr) {
-                    if (month === void 0) {
-                        month = self.currentMonth;
-                    }
-                    if (yr === void 0) {
-                        yr = self.currentYear;
-                    }
-                    if (month === 1 && (yr % 4 === 0 && yr % 100 !== 0 || yr % 400 === 0)) return 29;
-                    return self.l10n.daysInMonth[month];
-                }
-            };
-        }
-        function init() {
-            self.element = self.input = element;
-            self.isOpen = false;
-            parseConfig();
-            setupLocale();
-            setupInputs();
-            setupDates();
-            setupHelperFunctions();
-            if (!self.isMobile) build();
-            bindEvents();
-            if (self.selectedDates.length || self.config.noCalendar) {
-                if (self.config.enableTime) {
-                    setHoursFromDate(self.config.noCalendar ? self.latestSelectedDateObj || self.config.minDate : undefined);
-                }
-                updateValue(false);
-            }
-            setCalendarWidth();
-            self.showTimeInput = self.selectedDates.length > 0 || self.config.noCalendar;
-            var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            /* TODO: investigate this further
-                       Currently, there is weird positioning behavior in safari causing pages
-              to scroll up. https://github.com/chmln/flatpickr/issues/563
-                       However, most browsers are not Safari and positioning is expensive when used
-              in scale. https://github.com/chmln/flatpickr/issues/1096
-            */
-            if (!self.isMobile && isSafari) {
-                positionCalendar();
-            }
-            triggerEvent("onReady");
-        }
-        function bindToInstance(fn) {
-            return fn.bind(self);
-        }
-        function setCalendarWidth() {
-            var config = self.config;
-            if (config.weekNumbers === false && config.showMonths === 1) return;else if (config.noCalendar !== true) {
-                window.requestAnimationFrame(function () {
-                    if (self.calendarContainer !== undefined) {
-                        self.calendarContainer.style.visibility = "hidden";
-                        self.calendarContainer.style.display = "block";
-                    }
-                    if (self.daysContainer !== undefined) {
-                        var daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
-                        self.daysContainer.style.width = daysWidth + "px";
-                        self.calendarContainer.style.width = daysWidth + (self.weekWrapper !== undefined ? self.weekWrapper.offsetWidth : 0) + "px";
-                        self.calendarContainer.style.removeProperty("visibility");
-                        self.calendarContainer.style.removeProperty("display");
-                    }
-                });
-            }
-        }
-        /**
-         * The handler for all events targeting the time inputs
-         */
-        function updateTime(e) {
-            if (self.selectedDates.length === 0) {
-                setDefaultTime();
-            }
-            if (e !== undefined && e.type !== "blur") {
-                timeWrapper(e);
-            }
-            var prevValue = self._input.value;
-            setHoursFromInputs();
-            updateValue();
-            if (self._input.value !== prevValue) {
-                self._debouncedChange();
-            }
-        }
-        function ampm2military(hour, amPM) {
-            return hour % 12 + 12 * int(amPM === self.l10n.amPM[1]);
-        }
-        function military2ampm(hour) {
-            switch (hour % 24) {
-                case 0:
-                case 12:
-                    return 12;
-                default:
-                    return hour % 12;
-            }
-        }
-        /**
-         * Syncs the selected date object time with user's time input
-         */
-        function setHoursFromInputs() {
-            if (self.hourElement === undefined || self.minuteElement === undefined) return;
-            var hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
-                minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
-                seconds = self.secondElement !== undefined ? (parseInt(self.secondElement.value, 10) || 0) % 60 : 0;
-            if (self.amPM !== undefined) {
-                hours = ampm2military(hours, self.amPM.textContent);
-            }
-            var limitMinHours = self.config.minTime !== undefined || self.config.minDate && self.minDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.minDate, true) === 0;
-            var limitMaxHours = self.config.maxTime !== undefined || self.config.maxDate && self.maxDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.maxDate, true) === 0;
-            if (limitMaxHours) {
-                var maxTime = self.config.maxTime !== undefined ? self.config.maxTime : self.config.maxDate;
-                hours = Math.min(hours, maxTime.getHours());
-                if (hours === maxTime.getHours()) minutes = Math.min(minutes, maxTime.getMinutes());
-                if (minutes === maxTime.getMinutes()) seconds = Math.min(seconds, maxTime.getSeconds());
-            }
-            if (limitMinHours) {
-                var minTime = self.config.minTime !== undefined ? self.config.minTime : self.config.minDate;
-                hours = Math.max(hours, minTime.getHours());
-                if (hours === minTime.getHours()) minutes = Math.max(minutes, minTime.getMinutes());
-                if (minutes === minTime.getMinutes()) seconds = Math.max(seconds, minTime.getSeconds());
-            }
-            setHours(hours, minutes, seconds);
-        }
-        /**
-         * Syncs time input values with a date
-         */
-        function setHoursFromDate(dateObj) {
-            var date = dateObj || self.latestSelectedDateObj;
-            if (date) setHours(date.getHours(), date.getMinutes(), date.getSeconds());
-        }
-        function setDefaultHours() {
-            var hours = self.config.defaultHour;
-            var minutes = self.config.defaultMinute;
-            var seconds = self.config.defaultSeconds;
-            if (self.config.minDate !== undefined) {
-                var min_hr = self.config.minDate.getHours();
-                var min_minutes = self.config.minDate.getMinutes();
-                hours = Math.max(hours, min_hr);
-                if (hours === min_hr) minutes = Math.max(min_minutes, minutes);
-                if (hours === min_hr && minutes === min_minutes) seconds = self.config.minDate.getSeconds();
-            }
-            if (self.config.maxDate !== undefined) {
-                var max_hr = self.config.maxDate.getHours();
-                var max_minutes = self.config.maxDate.getMinutes();
-                hours = Math.min(hours, max_hr);
-                if (hours === max_hr) minutes = Math.min(max_minutes, minutes);
-                if (hours === max_hr && minutes === max_minutes) seconds = self.config.maxDate.getSeconds();
-            }
-            setHours(hours, minutes, seconds);
-        }
-        /**
-         * Sets the hours, minutes, and optionally seconds
-         * of the latest selected date object and the
-         * corresponding time inputs
-         * @param {Number} hours the hour. whether its military
-         *                 or am-pm gets inferred from config
-         * @param {Number} minutes the minutes
-         * @param {Number} seconds the seconds (optional)
-         */
-        function setHours(hours, minutes, seconds) {
-            if (self.latestSelectedDateObj !== undefined) {
-                self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
-            }
-            if (!self.hourElement || !self.minuteElement || self.isMobile) return;
-            self.hourElement.value = pad(!self.config.time_24hr ? (12 + hours) % 12 + 12 * int(hours % 12 === 0) : hours);
-            self.minuteElement.value = pad(minutes);
-            if (self.amPM !== undefined) self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
-            if (self.secondElement !== undefined) self.secondElement.value = pad(seconds);
-        }
-        /**
-         * Handles the year input and incrementing events
-         * @param {Event} event the keyup or increment event
-         */
-        function onYearInput(event) {
-            var year = parseInt(event.target.value) + (event.delta || 0);
-            if (year / 1000 > 1 || event.key === "Enter" && !/[^\d]/.test(year.toString())) {
-                changeYear(year);
-            }
-        }
-        /**
-         * Essentially addEventListener + tracking
-         * @param {Element} element the element to addEventListener to
-         * @param {String} event the event name
-         * @param {Function} handler the event handler
-         */
-        function bind(element, event, handler, options) {
-            if (event instanceof Array) return event.forEach(function (ev) {
-                return bind(element, ev, handler, options);
-            });
-            if (element instanceof Array) return element.forEach(function (el) {
-                return bind(el, event, handler, options);
-            });
-            element.addEventListener(event, handler, options);
-            self._handlers.push({
-                element: element,
-                event: event,
-                handler: handler,
-                options: options
-            });
-        }
-        /**
-         * A mousedown handler which mimics click.
-         * Minimizes latency, since we don't need to wait for mouseup in most cases.
-         * Also, avoids handling right clicks.
-         *
-         * @param {Function} handler the event handler
-         */
-        function onClick(handler) {
-            return function (evt) {
-                evt.which === 1 && handler(evt);
-            };
-        }
-        function triggerChange() {
-            triggerEvent("onChange");
-        }
-        /**
-         * Adds all the necessary event listeners
-         */
-        function bindEvents() {
-            if (self.config.wrap) {
-                ["open", "close", "toggle", "clear"].forEach(function (evt) {
-                    Array.prototype.forEach.call(self.element.querySelectorAll("[data-" + evt + "]"), function (el) {
-                        return bind(el, "click", self[evt]);
-                    });
-                });
-            }
-            if (self.isMobile) {
-                setupMobile();
-                return;
-            }
-            var debouncedResize = debounce(onResize, 50);
-            self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
-            if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent)) bind(self.daysContainer, "mouseover", function (e) {
-                if (self.config.mode === "range") onMouseOver(e.target);
-            });
-            bind(window.document.body, "keydown", onKeyDown);
-            if (!self.config.static) bind(self._input, "keydown", onKeyDown);
-            if (!self.config.inline && !self.config.static) bind(window, "resize", debouncedResize);
-            if (window.ontouchstart !== undefined) bind(window.document, "click", documentClick);else bind(window.document, "mousedown", onClick(documentClick));
-            bind(window.document, "focus", documentClick, { capture: true });
-            if (self.config.clickOpens === true) {
-                bind(self._input, "focus", self.open);
-                bind(self._input, "mousedown", onClick(self.open));
-            }
-            if (self.daysContainer !== undefined) {
-                bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
-                bind(self.monthNav, ["keyup", "increment"], onYearInput);
-                bind(self.daysContainer, "mousedown", onClick(selectDate));
-            }
-            if (self.timeContainer !== undefined && self.minuteElement !== undefined && self.hourElement !== undefined) {
-                var selText = function selText(e) {
-                    return e.target.select();
-                };
-                bind(self.timeContainer, ["increment"], updateTime);
-                bind(self.timeContainer, "blur", updateTime, { capture: true });
-                bind(self.timeContainer, "mousedown", onClick(timeIncrement));
-                bind([self.hourElement, self.minuteElement], ["focus", "click"], selText);
-                if (self.secondElement !== undefined) bind(self.secondElement, "focus", function () {
-                    return self.secondElement && self.secondElement.select();
-                });
-                if (self.amPM !== undefined) {
-                    bind(self.amPM, "mousedown", onClick(function (e) {
-                        updateTime(e);
-                        triggerChange();
-                    }));
-                }
-            }
-        }
-        /**
-         * Set the calendar view to a particular date.
-         * @param {Date} jumpDate the date to set the view to
-         */
-        function jumpToDate(jumpDate) {
-            var jumpTo = jumpDate !== undefined ? self.parseDate(jumpDate) : self.latestSelectedDateObj || (self.config.minDate && self.config.minDate > self.now ? self.config.minDate : self.config.maxDate && self.config.maxDate < self.now ? self.config.maxDate : self.now);
-            try {
-                if (jumpTo !== undefined) {
-                    self.currentYear = jumpTo.getFullYear();
-                    self.currentMonth = jumpTo.getMonth();
-                }
-            } catch (e) {
-                /* istanbul ignore next */
-                e.message = "Invalid date supplied: " + jumpTo;
-                self.config.errorHandler(e);
-            }
-            self.redraw();
-        }
-        /**
-         * The up/down arrow handler for time inputs
-         * @param {Event} e the click event
-         */
-        function timeIncrement(e) {
-            if (~e.target.className.indexOf("arrow")) incrementNumInput(e, e.target.classList.contains("arrowUp") ? 1 : -1);
-        }
-        /**
-         * Increments/decrements the value of input associ-
-         * ated with the up/down arrow by dispatching an
-         * "increment" event on the input.
-         *
-         * @param {Event} e the click event
-         * @param {Number} delta the diff (usually 1 or -1)
-         * @param {Element} inputElem the input element
-         */
-        function incrementNumInput(e, delta, inputElem) {
-            var target = e && e.target;
-            var input = inputElem || target && target.parentNode && target.parentNode.firstChild;
-            var event = createEvent("increment");
-            event.delta = delta;
-            input && input.dispatchEvent(event);
-        }
-        function build() {
-            var fragment = window.document.createDocumentFragment();
-            self.calendarContainer = createElement("div", "flatpickr-calendar");
-            self.calendarContainer.tabIndex = -1;
-            if (!self.config.noCalendar) {
-                fragment.appendChild(buildMonthNav());
-                self.innerContainer = createElement("div", "flatpickr-innerContainer");
-                if (self.config.weekNumbers) {
-                    var _a = buildWeeks(),
-                        weekWrapper = _a.weekWrapper,
-                        weekNumbers = _a.weekNumbers;
-                    self.innerContainer.appendChild(weekWrapper);
-                    self.weekNumbers = weekNumbers;
-                    self.weekWrapper = weekWrapper;
-                }
-                self.rContainer = createElement("div", "flatpickr-rContainer");
-                self.rContainer.appendChild(buildWeekdays());
-                if (!self.daysContainer) {
-                    self.daysContainer = createElement("div", "flatpickr-days");
-                    self.daysContainer.tabIndex = -1;
-                }
-                buildDays();
-                self.rContainer.appendChild(self.daysContainer);
-                self.innerContainer.appendChild(self.rContainer);
-                fragment.appendChild(self.innerContainer);
-            }
-            if (self.config.enableTime) {
-                fragment.appendChild(buildTime());
-            }
-            toggleClass(self.calendarContainer, "rangeMode", self.config.mode === "range");
-            toggleClass(self.calendarContainer, "animate", self.config.animate === true);
-            toggleClass(self.calendarContainer, "multiMonth", self.config.showMonths > 1);
-            self.calendarContainer.appendChild(fragment);
-            var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType !== undefined;
-            if (self.config.inline || self.config.static) {
-                self.calendarContainer.classList.add(self.config.inline ? "inline" : "static");
-                if (self.config.inline) {
-                    if (!customAppend && self.element.parentNode) self.element.parentNode.insertBefore(self.calendarContainer, self._input.nextSibling);else if (self.config.appendTo !== undefined) self.config.appendTo.appendChild(self.calendarContainer);
-                }
-                if (self.config.static) {
-                    var wrapper = createElement("div", "flatpickr-wrapper");
-                    if (self.element.parentNode) self.element.parentNode.insertBefore(wrapper, self.element);
-                    wrapper.appendChild(self.element);
-                    if (self.altInput) wrapper.appendChild(self.altInput);
-                    wrapper.appendChild(self.calendarContainer);
-                }
-            }
-            if (!self.config.static && !self.config.inline) (self.config.appendTo !== undefined ? self.config.appendTo : window.document.body).appendChild(self.calendarContainer);
-        }
-        function createDay(className, date, dayNumber, i) {
-            var dateIsEnabled = isEnabled(date, true),
-                dayElement = createElement("span", "flatpickr-day " + className, date.getDate().toString());
-            dayElement.dateObj = date;
-            dayElement.$i = i;
-            dayElement.setAttribute("aria-label", self.formatDate(date, self.config.ariaDateFormat));
-            if (className.indexOf("hidden") === -1 && compareDates(date, self.now) === 0) {
-                self.todayDateElem = dayElement;
-                dayElement.classList.add("today");
-                dayElement.setAttribute("aria-current", "date");
-            }
-            if (dateIsEnabled) {
-                dayElement.tabIndex = -1;
-                if (isDateSelected(date)) {
-                    dayElement.classList.add("selected");
-                    self.selectedDateElem = dayElement;
-                    if (self.config.mode === "range") {
-                        toggleClass(dayElement, "startRange", self.selectedDates[0] && compareDates(date, self.selectedDates[0], true) === 0);
-                        toggleClass(dayElement, "endRange", self.selectedDates[1] && compareDates(date, self.selectedDates[1], true) === 0);
-                        if (className === "nextMonthDay") dayElement.classList.add("inRange");
-                    }
-                }
-            } else {
-                dayElement.classList.add("disabled");
-            }
-            if (self.config.mode === "range") {
-                if (isDateInRange(date) && !isDateSelected(date)) dayElement.classList.add("inRange");
-            }
-            if (self.weekNumbers && self.config.showMonths === 1 && className !== "prevMonthDay" && dayNumber % 7 === 1) {
-                self.weekNumbers.insertAdjacentHTML("beforeend", "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>");
-            }
-            triggerEvent("onDayCreate", dayElement);
-            return dayElement;
-        }
-        function focusOnDayElem(targetNode) {
-            targetNode.focus();
-            if (self.config.mode === "range") onMouseOver(targetNode);
-        }
-        function getFirstAvailableDay(delta) {
-            var startMonth = delta > 0 ? 0 : self.config.showMonths - 1;
-            var endMonth = delta > 0 ? self.config.showMonths : -1;
-            for (var m = startMonth; m != endMonth; m += delta) {
-                var month = self.daysContainer.children[m];
-                var startIndex = delta > 0 ? 0 : month.children.length - 1;
-                var endIndex = delta > 0 ? month.children.length : -1;
-                for (var i = startIndex; i != endIndex; i += delta) {
-                    var c = month.children[i];
-                    if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj)) return c;
-                }
-            }
-            return undefined;
-        }
-        function getNextAvailableDay(current, delta) {
-            var givenMonth = current.className.indexOf("Month") === -1 ? current.dateObj.getMonth() : self.currentMonth;
-            var endMonth = delta > 0 ? self.config.showMonths : -1;
-            var loopDelta = delta > 0 ? 1 : -1;
-            for (var m = givenMonth - self.currentMonth; m != endMonth; m += loopDelta) {
-                var month = self.daysContainer.children[m];
-                var startIndex = givenMonth - self.currentMonth === m ? current.$i + delta : delta < 0 ? month.children.length - 1 : 0;
-                var numMonthDays = month.children.length;
-                for (var i = startIndex; i >= 0 && i < numMonthDays && i != (delta > 0 ? numMonthDays : -1); i += loopDelta) {
-                    var c = month.children[i];
-                    if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj) && Math.abs(current.$i - i) >= Math.abs(delta)) return focusOnDayElem(c);
-                }
-            }
-            self.changeMonth(loopDelta);
-            focusOnDay(getFirstAvailableDay(loopDelta), 0);
-            return undefined;
-        }
-        function focusOnDay(current, offset) {
-            var dayFocused = isInView(document.activeElement || document.body);
-            var startElem = current !== undefined ? current : dayFocused ? document.activeElement : self.selectedDateElem !== undefined && isInView(self.selectedDateElem) ? self.selectedDateElem : self.todayDateElem !== undefined && isInView(self.todayDateElem) ? self.todayDateElem : getFirstAvailableDay(offset > 0 ? 1 : -1);
-            if (startElem === undefined) return self._input.focus();
-            if (!dayFocused) return focusOnDayElem(startElem);
-            getNextAvailableDay(startElem, offset);
-        }
-        function buildMonthDays(year, month) {
-            var firstOfMonth = (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
-            var prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12);
-            var daysInMonth = self.utils.getDaysInMonth(month),
-                days = window.document.createDocumentFragment(),
-                isMultiMonth = self.config.showMonths > 1,
-                prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
-                nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
-            var dayNumber = prevMonthDays + 1 - firstOfMonth,
-                dayIndex = 0;
-            // prepend days from the ending of previous month
-            for (; dayNumber <= prevMonthDays; dayNumber++, dayIndex++) {
-                days.appendChild(createDay(prevMonthDayClass, new Date(year, month - 1, dayNumber), dayNumber, dayIndex));
-            }
-            // Start at 1 since there is no 0th day
-            for (dayNumber = 1; dayNumber <= daysInMonth; dayNumber++, dayIndex++) {
-                days.appendChild(createDay("", new Date(year, month, dayNumber), dayNumber, dayIndex));
-            }
-            // append days from the next month
-            for (var dayNum = daysInMonth + 1; dayNum <= 42 - firstOfMonth && (self.config.showMonths === 1 || dayIndex % 7 !== 0); dayNum++, dayIndex++) {
-                days.appendChild(createDay(nextMonthDayClass, new Date(year, month + 1, dayNum % daysInMonth), dayNum, dayIndex));
-            }
-            //updateNavigationCurrentMonth();
-            var dayContainer = createElement("div", "dayContainer");
-            dayContainer.appendChild(days);
-            return dayContainer;
-        }
-        function buildDays() {
-            if (self.daysContainer === undefined) {
-                return;
-            }
-            clearNode(self.daysContainer);
-            // TODO: week numbers for each month
-            if (self.weekNumbers) clearNode(self.weekNumbers);
-            var frag = document.createDocumentFragment();
-            for (var i = 0; i < self.config.showMonths; i++) {
-                var d = new Date(self.currentYear, self.currentMonth, 1);
-                d.setMonth(self.currentMonth + i);
-                frag.appendChild(buildMonthDays(d.getFullYear(), d.getMonth()));
-            }
-            self.daysContainer.appendChild(frag);
-            self.days = self.daysContainer.firstChild;
-            if (self.config.mode === "range" && self.selectedDates.length === 1) {
-                onMouseOver();
-            }
-        }
-        function buildMonth() {
-            var container = createElement("div", "flatpickr-month");
-            var monthNavFragment = window.document.createDocumentFragment();
-            var monthElement = createElement("span", "cur-month");
-            var yearInput = createNumberInput("cur-year", { tabindex: "-1" });
-            var yearElement = yearInput.getElementsByTagName("input")[0];
-            yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
-            if (self.config.minDate) {
-                yearElement.setAttribute("min", self.config.minDate.getFullYear().toString());
-            }
-            if (self.config.maxDate) {
-                yearElement.setAttribute("max", self.config.maxDate.getFullYear().toString());
-                yearElement.disabled = !!self.config.minDate && self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
-            }
-            var currentMonth = createElement("div", "flatpickr-current-month");
-            currentMonth.appendChild(monthElement);
-            currentMonth.appendChild(yearInput);
-            monthNavFragment.appendChild(currentMonth);
-            container.appendChild(monthNavFragment);
-            return {
-                container: container,
-                yearElement: yearElement,
-                monthElement: monthElement
-            };
-        }
-        function buildMonths() {
-            clearNode(self.monthNav);
-            self.monthNav.appendChild(self.prevMonthNav);
-            if (self.config.showMonths) {
-                self.yearElements = [];
-                self.monthElements = [];
-            }
-            for (var m = self.config.showMonths; m--;) {
-                var month = buildMonth();
-                self.yearElements.push(month.yearElement);
-                self.monthElements.push(month.monthElement);
-                self.monthNav.appendChild(month.container);
-            }
-            self.monthNav.appendChild(self.nextMonthNav);
-        }
-        function buildMonthNav() {
-            self.monthNav = createElement("div", "flatpickr-months");
-            self.yearElements = [];
-            self.monthElements = [];
-            self.prevMonthNav = createElement("span", "flatpickr-prev-month");
-            self.prevMonthNav.innerHTML = self.config.prevArrow;
-            self.nextMonthNav = createElement("span", "flatpickr-next-month");
-            self.nextMonthNav.innerHTML = self.config.nextArrow;
-            buildMonths();
-            Object.defineProperty(self, "_hidePrevMonthArrow", {
-                get: function get() {
-                    return self.__hidePrevMonthArrow;
-                },
-                set: function set(bool) {
-                    if (self.__hidePrevMonthArrow !== bool) {
-                        toggleClass(self.prevMonthNav, "disabled", bool);
-                        self.__hidePrevMonthArrow = bool;
-                    }
-                }
-            });
-            Object.defineProperty(self, "_hideNextMonthArrow", {
-                get: function get() {
-                    return self.__hideNextMonthArrow;
-                },
-                set: function set(bool) {
-                    if (self.__hideNextMonthArrow !== bool) {
-                        toggleClass(self.nextMonthNav, "disabled", bool);
-                        self.__hideNextMonthArrow = bool;
-                    }
-                }
-            });
-            self.currentYearElement = self.yearElements[0];
-            updateNavigationCurrentMonth();
-            return self.monthNav;
-        }
-        function buildTime() {
-            self.calendarContainer.classList.add("hasTime");
-            if (self.config.noCalendar) self.calendarContainer.classList.add("noCalendar");
-            self.timeContainer = createElement("div", "flatpickr-time");
-            self.timeContainer.tabIndex = -1;
-            var separator = createElement("span", "flatpickr-time-separator", ":");
-            var hourInput = createNumberInput("flatpickr-hour");
-            self.hourElement = hourInput.getElementsByTagName("input")[0];
-            var minuteInput = createNumberInput("flatpickr-minute");
-            self.minuteElement = minuteInput.getElementsByTagName("input")[0];
-            self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
-            self.hourElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getHours() : self.config.time_24hr ? self.config.defaultHour : military2ampm(self.config.defaultHour));
-            self.minuteElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getMinutes() : self.config.defaultMinute);
-            self.hourElement.setAttribute("step", self.config.hourIncrement.toString());
-            self.minuteElement.setAttribute("step", self.config.minuteIncrement.toString());
-            self.hourElement.setAttribute("min", self.config.time_24hr ? "0" : "1");
-            self.hourElement.setAttribute("max", self.config.time_24hr ? "23" : "12");
-            self.minuteElement.setAttribute("min", "0");
-            self.minuteElement.setAttribute("max", "59");
-            self.timeContainer.appendChild(hourInput);
-            self.timeContainer.appendChild(separator);
-            self.timeContainer.appendChild(minuteInput);
-            if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
-            if (self.config.enableSeconds) {
-                self.timeContainer.classList.add("hasSeconds");
-                var secondInput = createNumberInput("flatpickr-second");
-                self.secondElement = secondInput.getElementsByTagName("input")[0];
-                self.secondElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getSeconds() : self.config.defaultSeconds);
-                self.secondElement.setAttribute("step", self.minuteElement.getAttribute("step"));
-                self.secondElement.setAttribute("min", "0");
-                self.secondElement.setAttribute("max", "59");
-                self.timeContainer.appendChild(createElement("span", "flatpickr-time-separator", ":"));
-                self.timeContainer.appendChild(secondInput);
-            }
-            if (!self.config.time_24hr) {
-                // add self.amPM if appropriate
-                self.amPM = createElement("span", "flatpickr-am-pm", self.l10n.amPM[int((self.latestSelectedDateObj ? self.hourElement.value : self.config.defaultHour) > 11)]);
-                self.amPM.title = self.l10n.toggleTitle;
-                self.amPM.tabIndex = -1;
-                self.timeContainer.appendChild(self.amPM);
-            }
-            return self.timeContainer;
-        }
-        function buildWeekdays() {
-            if (!self.weekdayContainer) self.weekdayContainer = createElement("div", "flatpickr-weekdays");else clearNode(self.weekdayContainer);
-            for (var i = self.config.showMonths; i--;) {
-                var container = createElement("div", "flatpickr-weekdaycontainer");
-                self.weekdayContainer.appendChild(container);
-            }
-            updateWeekdays();
-            return self.weekdayContainer;
-        }
-        function updateWeekdays() {
-            var firstDayOfWeek = self.l10n.firstDayOfWeek;
-            var weekdays = self.l10n.weekdays.shorthand.slice();
-            if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {
-                weekdays = weekdays.splice(firstDayOfWeek, weekdays.length).concat(weekdays.splice(0, firstDayOfWeek));
-            }
-            for (var i = self.config.showMonths; i--;) {
-                self.weekdayContainer.children[i].innerHTML = "\n      <span class='flatpickr-weekday'>\n        " + weekdays.join("</span><span class='flatpickr-weekday'>") + "\n      </span>\n      ";
-            }
-        }
-        /* istanbul ignore next */
-        function buildWeeks() {
-            self.calendarContainer.classList.add("hasWeeks");
-            var weekWrapper = createElement("div", "flatpickr-weekwrapper");
-            weekWrapper.appendChild(createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation));
-            var weekNumbers = createElement("div", "flatpickr-weeks");
-            weekWrapper.appendChild(weekNumbers);
-            return {
-                weekWrapper: weekWrapper,
-                weekNumbers: weekNumbers
-            };
-        }
-        function changeMonth(value, is_offset) {
-            if (is_offset === void 0) {
-                is_offset = true;
-            }
-            var delta = is_offset ? value : value - self.currentMonth;
-            if (delta < 0 && self._hidePrevMonthArrow === true || delta > 0 && self._hideNextMonthArrow === true) return;
-            self.currentMonth += delta;
-            if (self.currentMonth < 0 || self.currentMonth > 11) {
-                self.currentYear += self.currentMonth > 11 ? 1 : -1;
-                self.currentMonth = (self.currentMonth + 12) % 12;
-                triggerEvent("onYearChange");
-            }
-            buildDays();
-            triggerEvent("onMonthChange");
-            updateNavigationCurrentMonth();
-        }
-        function clear(triggerChangeEvent, toInitial) {
-            if (triggerChangeEvent === void 0) {
-                triggerChangeEvent = true;
-            }
-            if (toInitial === void 0) {
-                toInitial = true;
-            }
-            self.input.value = "";
-            if (self.altInput !== undefined) self.altInput.value = "";
-            if (self.mobileInput !== undefined) self.mobileInput.value = "";
-            self.selectedDates = [];
-            self.latestSelectedDateObj = undefined;
-            if (toInitial === true) {
-                self.currentYear = self._initialDate.getFullYear();
-                self.currentMonth = self._initialDate.getMonth();
-            }
-            self.showTimeInput = false;
-            if (self.config.enableTime === true) {
-                setDefaultHours();
-            }
-            self.redraw();
-            if (triggerChangeEvent)
-                // triggerChangeEvent is true (default) or an Event
-                triggerEvent("onChange");
-        }
-        function close() {
-            self.isOpen = false;
-            if (!self.isMobile) {
-                if (self.calendarContainer !== undefined) {
-                    self.calendarContainer.classList.remove("open");
-                }
-                if (self._input !== undefined) {
-                    self._input.classList.remove("active");
-                }
-            }
-            triggerEvent("onClose");
-        }
-        function destroy() {
-            if (self.config !== undefined) triggerEvent("onDestroy");
-            for (var i = self._handlers.length; i--;) {
-                var h = self._handlers[i];
-                h.element.removeEventListener(h.event, h.handler, h.options);
-            }
-            self._handlers = [];
-            if (self.mobileInput) {
-                if (self.mobileInput.parentNode) self.mobileInput.parentNode.removeChild(self.mobileInput);
-                self.mobileInput = undefined;
-            } else if (self.calendarContainer && self.calendarContainer.parentNode) {
-                if (self.config.static && self.calendarContainer.parentNode) {
-                    var wrapper = self.calendarContainer.parentNode;
-                    wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
-                    if (wrapper.parentNode) {
-                        while (wrapper.firstChild) {
-                            wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
-                        }wrapper.parentNode.removeChild(wrapper);
-                    }
-                } else self.calendarContainer.parentNode.removeChild(self.calendarContainer);
-            }
-            if (self.altInput) {
-                self.input.type = "text";
-                if (self.altInput.parentNode) self.altInput.parentNode.removeChild(self.altInput);
-                delete self.altInput;
-            }
-            if (self.input) {
-                self.input.type = self.input._type;
-                self.input.classList.remove("flatpickr-input");
-                self.input.removeAttribute("readonly");
-                self.input.value = "";
-            }
-            ["_showTimeInput", "latestSelectedDateObj", "_hideNextMonthArrow", "_hidePrevMonthArrow", "__hideNextMonthArrow", "__hidePrevMonthArrow", "isMobile", "isOpen", "selectedDateElem", "minDateHasTime", "maxDateHasTime", "days", "daysContainer", "_input", "_positionElement", "innerContainer", "rContainer", "monthNav", "todayDateElem", "calendarContainer", "weekdayContainer", "prevMonthNav", "nextMonthNav", "currentMonthElement", "currentYearElement", "navigationCurrentMonth", "selectedDateElem", "config"].forEach(function (k) {
-                try {
-                    delete self[k];
-                } catch (_) {}
-            });
-        }
-        function isCalendarElem(elem) {
-            if (self.config.appendTo && self.config.appendTo.contains(elem)) return true;
-            return self.calendarContainer.contains(elem);
-        }
-        function documentClick(e) {
-            if (self.isOpen && !self.config.inline) {
-                var eventTarget_1 = getEventTarget(e);
-                var isCalendarElement = isCalendarElem(eventTarget_1);
-                var isInput = eventTarget_1 === self.input || eventTarget_1 === self.altInput || self.element.contains(eventTarget_1) ||
-                // web components
-                // e.path is not present in all browsers. circumventing typechecks
-                e.path && e.path.indexOf && (~e.path.indexOf(self.input) || ~e.path.indexOf(self.altInput));
-                var lostFocus = e.type === "blur" ? isInput && e.relatedTarget && !isCalendarElem(e.relatedTarget) : !isInput && !isCalendarElement && !isCalendarElem(e.relatedTarget);
-                var isIgnored = !self.config.ignoredFocusElements.some(function (elem) {
-                    return elem.contains(eventTarget_1);
-                });
-                if (lostFocus && isIgnored) {
-                    self.close();
-                    if (self.config.mode === "range" && self.selectedDates.length === 1) {
-                        self.clear(false);
-                        self.redraw();
-                    }
-                }
-            }
-        }
-        function changeYear(newYear) {
-            if (!newYear || self.config.minDate && newYear < self.config.minDate.getFullYear() || self.config.maxDate && newYear > self.config.maxDate.getFullYear()) return;
-            var newYearNum = newYear,
-                isNewYear = self.currentYear !== newYearNum;
-            self.currentYear = newYearNum || self.currentYear;
-            if (self.config.maxDate && self.currentYear === self.config.maxDate.getFullYear()) {
-                self.currentMonth = Math.min(self.config.maxDate.getMonth(), self.currentMonth);
-            } else if (self.config.minDate && self.currentYear === self.config.minDate.getFullYear()) {
-                self.currentMonth = Math.max(self.config.minDate.getMonth(), self.currentMonth);
-            }
-            if (isNewYear) {
-                self.redraw();
-                triggerEvent("onYearChange");
-            }
-        }
-        function isEnabled(date, timeless) {
-            if (timeless === void 0) {
-                timeless = true;
-            }
-            var dateToCheck = self.parseDate(date, undefined, timeless); // timeless
-            if (self.config.minDate && dateToCheck && compareDates(dateToCheck, self.config.minDate, timeless !== undefined ? timeless : !self.minDateHasTime) < 0 || self.config.maxDate && dateToCheck && compareDates(dateToCheck, self.config.maxDate, timeless !== undefined ? timeless : !self.maxDateHasTime) > 0) return false;
-            if (self.config.enable.length === 0 && self.config.disable.length === 0) return true;
-            if (dateToCheck === undefined) return false;
-            var bool = self.config.enable.length > 0,
-                array = bool ? self.config.enable : self.config.disable;
-            for (var i = 0, d = void 0; i < array.length; i++) {
-                d = array[i];
-                if (typeof d === "function" && d(dateToCheck) // disabled by function
-                ) return bool;else if (d instanceof Date && dateToCheck !== undefined && d.getTime() === dateToCheck.getTime())
-                    // disabled by date
-                    return bool;else if (typeof d === "string" && dateToCheck !== undefined) {
-                    // disabled by date string
-                    var parsed = self.parseDate(d, undefined, true);
-                    return parsed && parsed.getTime() === dateToCheck.getTime() ? bool : !bool;
-                } else if (
-                // disabled by range
-                (typeof d === 'undefined' ? 'undefined' : _typeof(d)) === "object" && dateToCheck !== undefined && d.from && d.to && dateToCheck.getTime() >= d.from.getTime() && dateToCheck.getTime() <= d.to.getTime()) return bool;
-            }
-            return !bool;
-        }
-        function isInView(elem) {
-            if (self.daysContainer !== undefined) return elem.className.indexOf("hidden") === -1 && self.daysContainer.contains(elem);
-            return false;
-        }
-        function onKeyDown(e) {
-            // e.key                      e.keyCode
-            // "Backspace"                        8
-            // "Tab"                              9
-            // "Enter"                           13
-            // "Escape"     (IE "Esc")           27
-            // "ArrowLeft"  (IE "Left")          37
-            // "ArrowUp"    (IE "Up")            38
-            // "ArrowRight" (IE "Right")         39
-            // "ArrowDown"  (IE "Down")          40
-            // "Delete"     (IE "Del")           46
-            var isInput = e.target === self._input;
-            var allowInput = self.config.allowInput;
-            var allowKeydown = self.isOpen && (!allowInput || !isInput);
-            var allowInlineKeydown = self.config.inline && isInput && !allowInput;
-            if (e.keyCode === 13 && isInput) {
-                if (allowInput) {
-                    self.setDate(self._input.value, true, e.target === self.altInput ? self.config.altFormat : self.config.dateFormat);
-                    return e.target.blur();
-                } else self.open();
-            } else if (isCalendarElem(e.target) || allowKeydown || allowInlineKeydown) {
-                var isTimeObj = !!self.timeContainer && self.timeContainer.contains(e.target);
-                switch (e.keyCode) {
-                    case 13:
-                        if (isTimeObj) {
-                            updateTime();
-                            focusAndClose();
-                        } else selectDate(e);
-                        break;
-                    case 27:
-                        // escape
-                        e.preventDefault();
-                        focusAndClose();
-                        break;
-                    case 8:
-                    case 46:
-                        if (isInput && !self.config.allowInput) {
-                            e.preventDefault();
-                            self.clear();
-                        }
-                        break;
-                    case 37:
-                    case 39:
-                        if (!isTimeObj) {
-                            e.preventDefault();
-                            if (self.daysContainer !== undefined && (allowInput === false || document.activeElement && isInView(document.activeElement))) {
-                                var delta_1 = e.keyCode === 39 ? 1 : -1;
-                                if (!e.ctrlKey) focusOnDay(undefined, delta_1);else {
-                                    e.stopPropagation();
-                                    changeMonth(delta_1);
-                                    focusOnDay(getFirstAvailableDay(1), 0);
-                                }
-                            }
-                        } else if (self.hourElement) self.hourElement.focus();
-                        break;
-                    case 38:
-                    case 40:
-                        e.preventDefault();
-                        var delta = e.keyCode === 40 ? 1 : -1;
-                        if (self.daysContainer && e.target.$i !== undefined || e.target === self.input) {
-                            if (e.ctrlKey) {
-                                e.stopPropagation();
-                                changeYear(self.currentYear - delta);
-                                focusOnDay(getFirstAvailableDay(1), 0);
-                            } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
-                        } else if (self.config.enableTime) {
-                            if (!isTimeObj && self.hourElement) self.hourElement.focus();
-                            updateTime(e);
-                            self._debouncedChange();
-                        }
-                        break;
-                    case 9:
-                        if (isTimeObj) {
-                            var elems = [self.hourElement, self.minuteElement, self.secondElement, self.amPM].filter(function (x) {
-                                return x;
-                            });
-                            var i = elems.indexOf(e.target);
-                            if (i !== -1) {
-                                var target = elems[i + (e.shiftKey ? -1 : 1)];
-                                if (target !== undefined) {
-                                    e.preventDefault();
-                                    target.focus();
-                                } else if (e.shiftKey) {
-                                    e.preventDefault();
-                                    self._input.focus();
-                                }
-                            }
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            if (self.amPM !== undefined && e.target === self.amPM) {
-                switch (e.key) {
-                    case self.l10n.amPM[0].charAt(0):
-                    case self.l10n.amPM[0].charAt(0).toLowerCase():
-                        self.amPM.textContent = self.l10n.amPM[0];
-                        setHoursFromInputs();
-                        updateValue();
-                        break;
-                    case self.l10n.amPM[1].charAt(0):
-                    case self.l10n.amPM[1].charAt(0).toLowerCase():
-                        self.amPM.textContent = self.l10n.amPM[1];
-                        setHoursFromInputs();
-                        updateValue();
-                        break;
-                }
-            }
-            triggerEvent("onKeyDown", e);
-        }
-        function onMouseOver(elem) {
-            if (self.selectedDates.length !== 1 || elem && (!elem.classList.contains("flatpickr-day") || elem.classList.contains("disabled"))) return;
-            var hoverDate = elem ? elem.dateObj.getTime() : self.days.firstElementChild.dateObj.getTime(),
-                initialDate = self.parseDate(self.selectedDates[0], undefined, true).getTime(),
-                rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
-                rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime()),
-                lastDate = self.daysContainer.lastChild.lastChild.dateObj.getTime();
-            var containsDisabled = false;
-            var minRange = 0,
-                maxRange = 0;
-            for (var t = rangeStartDate; t < lastDate; t += duration.DAY) {
-                if (!isEnabled(new Date(t), true)) {
-                    containsDisabled = containsDisabled || t > rangeStartDate && t < rangeEndDate;
-                    if (t < initialDate && (!minRange || t > minRange)) minRange = t;else if (t > initialDate && (!maxRange || t < maxRange)) maxRange = t;
-                }
-            }
-            for (var m = 0; m < self.config.showMonths; m++) {
-                var month = self.daysContainer.children[m];
-                var prevMonth = self.daysContainer.children[m - 1];
-                var _loop_1 = function _loop_1(i, l) {
-                    var dayElem = month.children[i],
-                        date = dayElem.dateObj;
-                    var timestamp = date.getTime();
-                    var outOfRange = minRange > 0 && timestamp < minRange || maxRange > 0 && timestamp > maxRange;
-                    if (outOfRange) {
-                        dayElem.classList.add("notAllowed");
-                        ["inRange", "startRange", "endRange"].forEach(function (c) {
-                            dayElem.classList.remove(c);
-                        });
-                        return "continue";
-                    } else if (containsDisabled && !outOfRange) return "continue";
-                    ["startRange", "inRange", "endRange", "notAllowed"].forEach(function (c) {
-                        dayElem.classList.remove(c);
-                    });
-                    if (elem !== undefined) {
-                        elem.classList.add(hoverDate < self.selectedDates[0].getTime() ? "startRange" : "endRange");
-                        if (month.contains(elem) || !(m > 0 && prevMonth && prevMonth.lastChild.dateObj.getTime() >= timestamp)) {
-                            if (initialDate < hoverDate && timestamp === initialDate) dayElem.classList.add("startRange");else if (initialDate > hoverDate && timestamp === initialDate) dayElem.classList.add("endRange");
-                            if (timestamp >= minRange && (maxRange === 0 || timestamp <= maxRange) && isBetween(timestamp, initialDate, hoverDate)) dayElem.classList.add("inRange");
-                        }
-                    }
-                };
-                for (var i = 0, l = month.children.length; i < l; i++) {
-                    _loop_1(i, l);
-                }
-            }
-        }
-        function onResize() {
-            if (self.isOpen && !self.config.static && !self.config.inline) positionCalendar();
-        }
-        function setDefaultTime() {
-            self.setDate(self.config.minDate !== undefined ? new Date(self.config.minDate.getTime()) : new Date(), false);
-            setDefaultHours();
-            updateValue();
-        }
-        function open(e, positionElement) {
-            if (positionElement === void 0) {
-                positionElement = self._positionElement;
-            }
-            if (self.isMobile === true) {
-                if (e) {
-                    e.preventDefault();
-                    e.target && e.target.blur();
-                }
-                if (self.mobileInput !== undefined) {
-                    self.mobileInput.focus();
-                    self.mobileInput.click();
-                }
-                triggerEvent("onOpen");
-                return;
-            }
-            if (self._input.disabled || self.config.inline) return;
-            var wasOpen = self.isOpen;
-            self.isOpen = true;
-            if (!wasOpen) {
-                self.calendarContainer.classList.add("open");
-                self._input.classList.add("active");
-                triggerEvent("onOpen");
-                positionCalendar(positionElement);
-            }
-            if (self.config.enableTime === true && self.config.noCalendar === true) {
-                if (self.selectedDates.length === 0) {
-                    setDefaultTime();
-                }
-                if (self.config.allowInput === false && (e === undefined || !self.timeContainer.contains(e.relatedTarget))) {
-                    setTimeout(function () {
-                        return self.hourElement.select();
-                    }, 50);
-                }
-            }
-        }
-        function minMaxDateSetter(type) {
-            return function (date) {
-                var dateObj = self.config["_" + type + "Date"] = self.parseDate(date, self.config.dateFormat);
-                var inverseDateObj = self.config["_" + (type === "min" ? "max" : "min") + "Date"];
-                if (dateObj !== undefined) {
-                    self[type === "min" ? "minDateHasTime" : "maxDateHasTime"] = dateObj.getHours() > 0 || dateObj.getMinutes() > 0 || dateObj.getSeconds() > 0;
-                }
-                if (self.selectedDates) {
-                    self.selectedDates = self.selectedDates.filter(function (d) {
-                        return isEnabled(d);
-                    });
-                    if (!self.selectedDates.length && type === "min") setHoursFromDate(dateObj);
-                    updateValue();
-                }
-                if (self.daysContainer) {
-                    redraw();
-                    if (dateObj !== undefined) self.currentYearElement[type] = dateObj.getFullYear().toString();else self.currentYearElement.removeAttribute(type);
-                    self.currentYearElement.disabled = !!inverseDateObj && dateObj !== undefined && inverseDateObj.getFullYear() === dateObj.getFullYear();
-                }
-            };
-        }
-        function parseConfig() {
-            var boolOpts = ["wrap", "weekNumbers", "allowInput", "clickOpens", "time_24hr", "enableTime", "noCalendar", "altInput", "shorthandCurrentMonth", "inline", "static", "enableSeconds", "disableMobile"];
-            var userConfig = _assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
-            var formats = {};
-            self.config.parseDate = userConfig.parseDate;
-            self.config.formatDate = userConfig.formatDate;
-            Object.defineProperty(self.config, "enable", {
-                get: function get() {
-                    return self.config._enable;
-                },
-                set: function set(dates) {
-                    self.config._enable = parseDateRules(dates);
-                }
-            });
-            Object.defineProperty(self.config, "disable", {
-                get: function get() {
-                    return self.config._disable;
-                },
-                set: function set(dates) {
-                    self.config._disable = parseDateRules(dates);
-                }
-            });
-            var timeMode = userConfig.mode === "time";
-            if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
-                formats.dateFormat = userConfig.noCalendar || timeMode ? "H:i" + (userConfig.enableSeconds ? ":S" : "") : flatpickr.defaultConfig.dateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
-            }
-            if (userConfig.altInput && (userConfig.enableTime || timeMode) && !userConfig.altFormat) {
-                formats.altFormat = userConfig.noCalendar || timeMode ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K") : flatpickr.defaultConfig.altFormat + (" h:i" + (userConfig.enableSeconds ? ":S" : "") + " K");
-            }
-            Object.defineProperty(self.config, "minDate", {
-                get: function get() {
-                    return self.config._minDate;
-                },
-                set: minMaxDateSetter("min")
-            });
-            Object.defineProperty(self.config, "maxDate", {
-                get: function get() {
-                    return self.config._maxDate;
-                },
-                set: minMaxDateSetter("max")
-            });
-            var minMaxTimeSetter = function minMaxTimeSetter(type) {
-                return function (val) {
-                    self.config[type === "min" ? "_minTime" : "_maxTime"] = self.parseDate(val, "H:i");
-                };
-            };
-            Object.defineProperty(self.config, "minTime", {
-                get: function get() {
-                    return self.config._minTime;
-                },
-                set: minMaxTimeSetter("min")
-            });
-            Object.defineProperty(self.config, "maxTime", {
-                get: function get() {
-                    return self.config._maxTime;
-                },
-                set: minMaxTimeSetter("max")
-            });
-            if (userConfig.mode === "time") {
-                self.config.noCalendar = true;
-                self.config.enableTime = true;
-            }
-            Object.assign(self.config, formats, userConfig);
-            for (var i = 0; i < boolOpts.length; i++) {
-                self.config[boolOpts[i]] = self.config[boolOpts[i]] === true || self.config[boolOpts[i]] === "true";
-            }HOOKS.filter(function (hook) {
-                return self.config[hook] !== undefined;
-            }).forEach(function (hook) {
-                self.config[hook] = arrayify(self.config[hook] || []).map(bindToInstance);
-            });
-            self.isMobile = !self.config.disableMobile && !self.config.inline && self.config.mode === "single" && !self.config.disable.length && !self.config.enable.length && !self.config.weekNumbers && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-            for (var i = 0; i < self.config.plugins.length; i++) {
-                var pluginConf = self.config.plugins[i](self) || {};
-                for (var key in pluginConf) {
-                    if (HOOKS.indexOf(key) > -1) {
-                        self.config[key] = arrayify(pluginConf[key]).map(bindToInstance).concat(self.config[key]);
-                    } else if (typeof userConfig[key] === "undefined") self.config[key] = pluginConf[key];
-                }
-            }
-            triggerEvent("onParseConfig");
-        }
-        function setupLocale() {
-            if (_typeof(self.config.locale) !== "object" && typeof flatpickr.l10ns[self.config.locale] === "undefined") self.config.errorHandler(new Error("flatpickr: invalid locale " + self.config.locale));
-            self.l10n = _assign({}, flatpickr.l10ns["default"], _typeof(self.config.locale) === "object" ? self.config.locale : self.config.locale !== "default" ? flatpickr.l10ns[self.config.locale] : undefined);
-            tokenRegex.K = "(" + self.l10n.amPM[0] + "|" + self.l10n.amPM[1] + "|" + self.l10n.amPM[0].toLowerCase() + "|" + self.l10n.amPM[1].toLowerCase() + ")";
-            self.formatDate = createDateFormatter(self);
-            self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
-        }
-        function positionCalendar(customPositionElement) {
-            if (self.calendarContainer === undefined) return;
-            triggerEvent("onPreCalendarPosition");
-            var positionElement = customPositionElement || self._positionElement;
-            var calendarHeight = Array.prototype.reduce.call(self.calendarContainer.children, function (acc, child) {
-                return acc + child.offsetHeight;
-            }, 0),
-                calendarWidth = self.calendarContainer.offsetWidth,
-                configPos = self.config.position.split(" "),
-                configPosVertical = configPos[0],
-                configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
-                inputBounds = positionElement.getBoundingClientRect(),
-                distanceFromBottom = window.innerHeight - inputBounds.bottom,
-                showOnTop = configPosVertical === "above" || configPosVertical !== "below" && distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
-            var top = window.pageYOffset + inputBounds.top + (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
-            toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
-            toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
-            if (self.config.inline) return;
-            var left = window.pageXOffset + inputBounds.left - (configPosHorizontal != null && configPosHorizontal === "center" ? (calendarWidth - inputBounds.width) / 2 : 0);
-            var right = window.document.body.offsetWidth - inputBounds.right;
-            var rightMost = left + calendarWidth > window.document.body.offsetWidth;
-            var centerMost = right + calendarWidth > window.document.body.offsetWidth;
-            toggleClass(self.calendarContainer, "rightMost", rightMost);
-            if (self.config.static) return;
-            self.calendarContainer.style.top = top + "px";
-            if (!rightMost) {
-                self.calendarContainer.style.left = left + "px";
-                self.calendarContainer.style.right = "auto";
-            } else if (!centerMost) {
-                self.calendarContainer.style.left = "auto";
-                self.calendarContainer.style.right = right + "px";
-            } else {
-                var doc = document.styleSheets[0];
-                // some testing environments don't have css support
-                if (doc === undefined) return;
-                var bodyWidth = window.document.body.offsetWidth;
-                var centerLeft = Math.max(0, bodyWidth / 2 - calendarWidth / 2);
-                var centerBefore = ".flatpickr-calendar.centerMost:before";
-                var centerAfter = ".flatpickr-calendar.centerMost:after";
-                var centerIndex = doc.cssRules.length;
-                var centerStyle = "{left:" + inputBounds.left + "px;right:auto;}";
-                toggleClass(self.calendarContainer, "rightMost", false);
-                toggleClass(self.calendarContainer, "centerMost", true);
-                doc.insertRule(centerBefore + "," + centerAfter + centerStyle, centerIndex);
-                self.calendarContainer.style.left = centerLeft + "px";
-                self.calendarContainer.style.right = "auto";
-            }
-        }
-        function redraw() {
-            if (self.config.noCalendar || self.isMobile) return;
-            updateNavigationCurrentMonth();
-            buildDays();
-        }
-        function focusAndClose() {
-            self._input.focus();
-            if (window.navigator.userAgent.indexOf("MSIE") !== -1 || navigator.msMaxTouchPoints !== undefined) {
-                // hack - bugs in the way IE handles focus keeps the calendar open
-                setTimeout(self.close, 0);
-            } else {
-                self.close();
-            }
-        }
-        function selectDate(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            var isSelectable = function isSelectable(day) {
-                return day.classList && day.classList.contains("flatpickr-day") && !day.classList.contains("disabled") && !day.classList.contains("notAllowed");
-            };
-            var t = findParent(e.target, isSelectable);
-            if (t === undefined) return;
-            var target = t;
-            var selectedDate = self.latestSelectedDateObj = new Date(target.dateObj.getTime());
-            var shouldChangeMonth = (selectedDate.getMonth() < self.currentMonth || selectedDate.getMonth() > self.currentMonth + self.config.showMonths - 1) && self.config.mode !== "range";
-            self.selectedDateElem = target;
-            if (self.config.mode === "single") self.selectedDates = [selectedDate];else if (self.config.mode === "multiple") {
-                var selectedIndex = isDateSelected(selectedDate);
-                if (selectedIndex) self.selectedDates.splice(parseInt(selectedIndex), 1);else self.selectedDates.push(selectedDate);
-            } else if (self.config.mode === "range") {
-                if (self.selectedDates.length === 2) {
-                    self.clear(false, false);
-                }
-                self.latestSelectedDateObj = selectedDate;
-                self.selectedDates.push(selectedDate);
-                // unless selecting same date twice, sort ascendingly
-                if (compareDates(selectedDate, self.selectedDates[0], true) !== 0) self.selectedDates.sort(function (a, b) {
-                    return a.getTime() - b.getTime();
-                });
-            }
-            setHoursFromInputs();
-            if (shouldChangeMonth) {
-                var isNewYear = self.currentYear !== selectedDate.getFullYear();
-                self.currentYear = selectedDate.getFullYear();
-                self.currentMonth = selectedDate.getMonth();
-                if (isNewYear) triggerEvent("onYearChange");
-                triggerEvent("onMonthChange");
-            }
-            updateNavigationCurrentMonth();
-            buildDays();
-            updateValue();
-            if (self.config.enableTime) setTimeout(function () {
-                return self.showTimeInput = true;
-            }, 50);
-            // maintain focus
-            if (!shouldChangeMonth && self.config.mode !== "range" && self.config.showMonths === 1) focusOnDayElem(target);else if (self.selectedDateElem !== undefined && self.hourElement === undefined) {
-                self.selectedDateElem && self.selectedDateElem.focus();
-            }
-            if (self.hourElement !== undefined) self.hourElement !== undefined && self.hourElement.focus();
-            if (self.config.closeOnSelect) {
-                var single = self.config.mode === "single" && !self.config.enableTime;
-                var range = self.config.mode === "range" && self.selectedDates.length === 2 && !self.config.enableTime;
-                if (single || range) {
-                    focusAndClose();
-                }
-            }
-            triggerChange();
-        }
-        var CALLBACKS = {
-            locale: [setupLocale, updateWeekdays],
-            showMonths: [buildMonths, setCalendarWidth, buildWeekdays]
-        };
-        function set(option, value) {
-            if (option !== null && (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === "object") Object.assign(self.config, option);else {
-                self.config[option] = value;
-                if (CALLBACKS[option] !== undefined) CALLBACKS[option].forEach(function (x) {
-                    return x();
-                });else if (HOOKS.indexOf(option) > -1) self.config[option] = arrayify(value);
-            }
-            self.redraw();
-            updateValue(false);
-        }
-        function setSelectedDate(inputDate, format) {
-            var dates = [];
-            if (inputDate instanceof Array) dates = inputDate.map(function (d) {
-                return self.parseDate(d, format);
-            });else if (inputDate instanceof Date || typeof inputDate === "number") dates = [self.parseDate(inputDate, format)];else if (typeof inputDate === "string") {
-                switch (self.config.mode) {
-                    case "single":
-                    case "time":
-                        dates = [self.parseDate(inputDate, format)];
-                        break;
-                    case "multiple":
-                        dates = inputDate.split(self.config.conjunction).map(function (date) {
-                            return self.parseDate(date, format);
-                        });
-                        break;
-                    case "range":
-                        dates = inputDate.split(self.l10n.rangeSeparator).map(function (date) {
-                            return self.parseDate(date, format);
-                        });
-                        break;
-                    default:
-                        break;
-                }
-            } else self.config.errorHandler(new Error("Invalid date supplied: " + JSON.stringify(inputDate)));
-            self.selectedDates = dates.filter(function (d) {
-                return d instanceof Date && isEnabled(d, false);
-            });
-            if (self.config.mode === "range") self.selectedDates.sort(function (a, b) {
-                return a.getTime() - b.getTime();
-            });
-        }
-        function setDate(date, triggerChange, format) {
-            if (triggerChange === void 0) {
-                triggerChange = false;
-            }
-            if (format === void 0) {
-                format = self.config.dateFormat;
-            }
-            if (date !== 0 && !date || date instanceof Array && date.length === 0) return self.clear(triggerChange);
-            setSelectedDate(date, format);
-            self.showTimeInput = self.selectedDates.length > 0;
-            self.latestSelectedDateObj = self.selectedDates[0];
-            self.redraw();
-            jumpToDate();
-            setHoursFromDate();
-            updateValue(triggerChange);
-            if (triggerChange) triggerEvent("onChange");
-        }
-        function parseDateRules(arr) {
-            return arr.slice().map(function (rule) {
-                if (typeof rule === "string" || typeof rule === "number" || rule instanceof Date) {
-                    return self.parseDate(rule, undefined, true);
-                } else if (rule && (typeof rule === 'undefined' ? 'undefined' : _typeof(rule)) === "object" && rule.from && rule.to) return {
-                    from: self.parseDate(rule.from, undefined),
-                    to: self.parseDate(rule.to, undefined)
-                };
-                return rule;
-            }).filter(function (x) {
-                return x;
-            }); // remove falsy values
-        }
-        function setupDates() {
-            self.selectedDates = [];
-            self.now = self.parseDate(self.config.now) || new Date();
-            // Workaround IE11 setting placeholder as the input's value
-            var preloadedDate = self.config.defaultDate || ((self.input.nodeName === "INPUT" || self.input.nodeName === "TEXTAREA") && self.input.placeholder && self.input.value === self.input.placeholder ? null : self.input.value);
-            if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
-            self._initialDate = self.selectedDates.length > 0 ? self.selectedDates[0] : self.config.minDate && self.config.minDate.getTime() > self.now.getTime() ? self.config.minDate : self.config.maxDate && self.config.maxDate.getTime() < self.now.getTime() ? self.config.maxDate : self.now;
-            self.currentYear = self._initialDate.getFullYear();
-            self.currentMonth = self._initialDate.getMonth();
-            if (self.selectedDates.length > 0) self.latestSelectedDateObj = self.selectedDates[0];
-            if (self.config.minTime !== undefined) self.config.minTime = self.parseDate(self.config.minTime, "H:i");
-            if (self.config.maxTime !== undefined) self.config.maxTime = self.parseDate(self.config.maxTime, "H:i");
-            self.minDateHasTime = !!self.config.minDate && (self.config.minDate.getHours() > 0 || self.config.minDate.getMinutes() > 0 || self.config.minDate.getSeconds() > 0);
-            self.maxDateHasTime = !!self.config.maxDate && (self.config.maxDate.getHours() > 0 || self.config.maxDate.getMinutes() > 0 || self.config.maxDate.getSeconds() > 0);
-            Object.defineProperty(self, "showTimeInput", {
-                get: function get() {
-                    return self._showTimeInput;
-                },
-                set: function set(bool) {
-                    self._showTimeInput = bool;
-                    if (self.calendarContainer) toggleClass(self.calendarContainer, "showTimeInput", bool);
-                    self.isOpen && positionCalendar();
-                }
-            });
-        }
-        function setupInputs() {
-            self.input = self.config.wrap ? element.querySelector("[data-input]") : element;
-            /* istanbul ignore next */
-            if (!self.input) {
-                self.config.errorHandler(new Error("Invalid input element specified"));
-                return;
-            }
-            // hack: store previous type to restore it after destroy()
-            self.input._type = self.input.type;
-            self.input.type = "text";
-            self.input.classList.add("flatpickr-input");
-            self._input = self.input;
-            if (self.config.altInput) {
-                // replicate self.element
-                self.altInput = createElement(self.input.nodeName, self.input.className + " " + self.config.altInputClass);
-                self._input = self.altInput;
-                self.altInput.placeholder = self.input.placeholder;
-                self.altInput.disabled = self.input.disabled;
-                self.altInput.required = self.input.required;
-                self.altInput.tabIndex = self.input.tabIndex;
-                self.altInput.type = "text";
-                self.input.setAttribute("type", "hidden");
-                if (!self.config.static && self.input.parentNode) self.input.parentNode.insertBefore(self.altInput, self.input.nextSibling);
-            }
-            if (!self.config.allowInput) self._input.setAttribute("readonly", "readonly");
-            self._positionElement = self.config.positionElement || self._input;
-        }
-        function setupMobile() {
-            var inputType = self.config.enableTime ? self.config.noCalendar ? "time" : "datetime-local" : "date";
-            self.mobileInput = createElement("input", self.input.className + " flatpickr-mobile");
-            self.mobileInput.step = self.input.getAttribute("step") || "any";
-            self.mobileInput.tabIndex = 1;
-            self.mobileInput.type = inputType;
-            self.mobileInput.disabled = self.input.disabled;
-            self.mobileInput.required = self.input.required;
-            self.mobileInput.placeholder = self.input.placeholder;
-            self.mobileFormatStr = inputType === "datetime-local" ? "Y-m-d\\TH:i:S" : inputType === "date" ? "Y-m-d" : "H:i:S";
-            if (self.selectedDates.length > 0) {
-                self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(self.selectedDates[0], self.mobileFormatStr);
-            }
-            if (self.config.minDate) self.mobileInput.min = self.formatDate(self.config.minDate, "Y-m-d");
-            if (self.config.maxDate) self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
-            self.input.type = "hidden";
-            if (self.altInput !== undefined) self.altInput.type = "hidden";
-            try {
-                if (self.input.parentNode) self.input.parentNode.insertBefore(self.mobileInput, self.input.nextSibling);
-            } catch (_a) {}
-            bind(self.mobileInput, "change", function (e) {
-                self.setDate(e.target.value, false, self.mobileFormatStr);
-                triggerEvent("onChange");
-                triggerEvent("onClose");
-            });
-        }
-        function toggle(e) {
-            if (self.isOpen === true) return self.close();
-            self.open(e);
-        }
-        function triggerEvent(event, data) {
-            // If the instance has been destroyed already, all hooks have been removed
-            if (self.config === undefined) return;
-            var hooks = self.config[event];
-            if (hooks !== undefined && hooks.length > 0) {
-                for (var i = 0; hooks[i] && i < hooks.length; i++) {
-                    hooks[i](self.selectedDates, self.input.value, self, data);
-                }
-            }
-            if (event === "onChange") {
-                self.input.dispatchEvent(createEvent("change"));
-                // many front-end frameworks bind to the input event
-                self.input.dispatchEvent(createEvent("input"));
-            }
-        }
-        function createEvent(name) {
-            var e = document.createEvent("Event");
-            e.initEvent(name, true, true);
-            return e;
-        }
-        function isDateSelected(date) {
-            for (var i = 0; i < self.selectedDates.length; i++) {
-                if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
-            }
-            return false;
-        }
-        function isDateInRange(date) {
-            if (self.config.mode !== "range" || self.selectedDates.length < 2) return false;
-            return compareDates(date, self.selectedDates[0]) >= 0 && compareDates(date, self.selectedDates[1]) <= 0;
-        }
-        function updateNavigationCurrentMonth() {
-            if (self.config.noCalendar || self.isMobile || !self.monthNav) return;
-            self.yearElements.forEach(function (yearElement, i) {
-                var d = new Date(self.currentYear, self.currentMonth, 1);
-                d.setMonth(self.currentMonth + i);
-                self.monthElements[i].textContent = monthToStr(d.getMonth(), self.config.shorthandCurrentMonth, self.l10n) + " ";
-                yearElement.value = d.getFullYear().toString();
-            });
-            self._hidePrevMonthArrow = self.config.minDate !== undefined && (self.currentYear === self.config.minDate.getFullYear() ? self.currentMonth <= self.config.minDate.getMonth() : self.currentYear < self.config.minDate.getFullYear());
-            self._hideNextMonthArrow = self.config.maxDate !== undefined && (self.currentYear === self.config.maxDate.getFullYear() ? self.currentMonth + 1 > self.config.maxDate.getMonth() : self.currentYear > self.config.maxDate.getFullYear());
-        }
-        function getDateStr(format) {
-            return self.selectedDates.map(function (dObj) {
-                return self.formatDate(dObj, format);
-            }).filter(function (d, i, arr) {
-                return self.config.mode !== "range" || self.config.enableTime || arr.indexOf(d) === i;
-            }).join(self.config.mode !== "range" ? self.config.conjunction : self.l10n.rangeSeparator);
-        }
-        /**
-         * Updates the values of inputs associated with the calendar
-         */
-        function updateValue(triggerChange) {
-            if (triggerChange === void 0) {
-                triggerChange = true;
-            }
-            if (self.selectedDates.length === 0) return self.clear(triggerChange);
-            if (self.mobileInput !== undefined && self.mobileFormatStr) {
-                self.mobileInput.value = self.latestSelectedDateObj !== undefined ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr) : "";
-            }
-            self.input.value = getDateStr(self.config.dateFormat);
-            if (self.altInput !== undefined) {
-                self.altInput.value = getDateStr(self.config.altFormat);
-            }
-            if (triggerChange !== false) triggerEvent("onValueUpdate");
-        }
-        function onMonthNavClick(e) {
-            e.preventDefault();
-            var isPrevMonth = self.prevMonthNav.contains(e.target);
-            var isNextMonth = self.nextMonthNav.contains(e.target);
-            if (isPrevMonth || isNextMonth) {
-                changeMonth(isPrevMonth ? -1 : 1);
-            } else if (self.yearElements.indexOf(e.target) >= 0) {
-                e.target.select();
-            } else if (e.target.classList.contains("arrowUp")) {
-                self.changeYear(self.currentYear + 1);
-            } else if (e.target.classList.contains("arrowDown")) {
-                self.changeYear(self.currentYear - 1);
-            }
-        }
-        function timeWrapper(e) {
-            e.preventDefault();
-            var isKeyDown = e.type === "keydown",
-                input = e.target;
-            if (self.amPM !== undefined && e.target === self.amPM) {
-                self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
-            }
-            var min = parseFloat(input.getAttribute("min")),
-                max = parseFloat(input.getAttribute("max")),
-                step = parseFloat(input.getAttribute("step")),
-                curValue = parseInt(input.value, 10),
-                delta = e.delta || (isKeyDown ? e.which === 38 ? 1 : -1 : 0);
-            var newValue = curValue + step * delta;
-            if (typeof input.value !== "undefined" && input.value.length === 2) {
-                var isHourElem = input === self.hourElement,
-                    isMinuteElem = input === self.minuteElement;
-                if (newValue < min) {
-                    newValue = max + newValue + int(!isHourElem) + (int(isHourElem) && int(!self.amPM));
-                    if (isMinuteElem) incrementNumInput(undefined, -1, self.hourElement);
-                } else if (newValue > max) {
-                    newValue = input === self.hourElement ? newValue - max - int(!self.amPM) : min;
-                    if (isMinuteElem) incrementNumInput(undefined, 1, self.hourElement);
-                }
-                if (self.amPM && isHourElem && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) {
-                    self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
-                }
-                input.value = pad(newValue);
-            }
-        }
-        init();
-        return self;
+    if (timeless !== false) {
+      return new Date(date1.getTime()).setHours(0, 0, 0, 0) - new Date(date2.getTime()).setHours(0, 0, 0, 0);
     }
-    /* istanbul ignore next */
-    function _flatpickr(nodeList, config) {
-        // static list
-        var nodes = Array.prototype.slice.call(nodeList).filter(function (x) {
-            return x instanceof HTMLElement;
+
+    return date1.getTime() - date2.getTime();
+  }
+  var getWeek = function getWeek(givenDate) {
+    var date = new Date(givenDate.getTime());
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
+    var week1 = new Date(date.getFullYear(), 0, 4);
+    return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getDay() + 6) % 7) / 7);
+  };
+  var isBetween = function isBetween(ts, ts1, ts2) {
+    return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
+  };
+  var duration = {
+    DAY: 86400000
+  };
+
+  var HOOKS = ["onChange", "onClose", "onDayCreate", "onDestroy", "onKeyDown", "onMonthChange", "onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange", "onPreCalendarPosition"];
+  var defaults = {
+    _disable: [],
+    _enable: [],
+    allowInput: false,
+    altFormat: "F j, Y",
+    altInput: false,
+    altInputClass: "form-control input",
+    animate: (typeof window === 'undefined' ? 'undefined' : _typeof(window)) === "object" && window.navigator.userAgent.indexOf("MSIE") === -1,
+    ariaDateFormat: "F j, Y",
+    clickOpens: true,
+    closeOnSelect: true,
+    conjunction: ", ",
+    dateFormat: "Y-m-d",
+    defaultHour: 12,
+    defaultMinute: 0,
+    defaultSeconds: 0,
+    disable: [],
+    disableMobile: false,
+    enable: [],
+    enableSeconds: false,
+    enableTime: false,
+    errorHandler: function errorHandler(err) {
+      return typeof console !== "undefined" && console.warn(err);
+    },
+    getWeek: getWeek,
+    hourIncrement: 1,
+    ignoredFocusElements: [],
+    inline: false,
+    locale: "default",
+    minuteIncrement: 5,
+    mode: "single",
+    nextArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
+    noCalendar: false,
+    now: new Date(),
+    onChange: [],
+    onClose: [],
+    onDayCreate: [],
+    onDestroy: [],
+    onKeyDown: [],
+    onMonthChange: [],
+    onOpen: [],
+    onParseConfig: [],
+    onReady: [],
+    onValueUpdate: [],
+    onYearChange: [],
+    onPreCalendarPosition: [],
+    plugins: [],
+    position: "auto",
+    positionElement: undefined,
+    prevArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
+    shorthandCurrentMonth: false,
+    showMonths: 1,
+    static: false,
+    time_24hr: false,
+    weekNumbers: false,
+    wrap: false
+  };
+
+  function toggleClass(elem, className, bool) {
+    if (bool === true) return elem.classList.add(className);
+    elem.classList.remove(className);
+  }
+  function createElement(tag, className, content) {
+    var e = window.document.createElement(tag);
+    className = className || "";
+    content = content || "";
+    e.className = className;
+    if (content !== undefined) e.textContent = content;
+    return e;
+  }
+  function clearNode(node) {
+    while (node.firstChild) {
+      node.removeChild(node.firstChild);
+    }
+  }
+  function findParent(node, condition) {
+    if (condition(node)) return node;else if (node.parentNode) return findParent(node.parentNode, condition);
+    return undefined;
+  }
+  function createNumberInput(inputClassName, opts) {
+    var wrapper = createElement("div", "numInputWrapper"),
+        numInput = createElement("input", "numInput " + inputClassName),
+        arrowUp = createElement("span", "arrowUp"),
+        arrowDown = createElement("span", "arrowDown");
+    numInput.type = "text";
+    numInput.pattern = "\\d*";
+    if (opts !== undefined) for (var key in opts) {
+      numInput.setAttribute(key, opts[key]);
+    }
+    wrapper.appendChild(numInput);
+    wrapper.appendChild(arrowUp);
+    wrapper.appendChild(arrowDown);
+    return wrapper;
+  }
+
+  if (typeof Object.assign !== "function") {
+    Object.assign = function (target) {
+      if (!target) {
+        throw TypeError("Cannot convert undefined or null to object");
+      }
+
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      var _loop = function _loop() {
+        var source = args[_i];
+
+        if (source) {
+          Object.keys(source).forEach(function (key) {
+            return target[key] = source[key];
+          });
+        }
+      };
+
+      for (var _i = 0; _i < args.length; _i++) {
+        _loop();
+      }
+
+      return target;
+    };
+  }
+
+  var DEBOUNCED_CHANGE_MS = 300;
+
+  function FlatpickrInstance(element, instanceConfig) {
+    var self = {
+      config: Object.assign({}, flatpickr.defaultConfig),
+      l10n: english
+    };
+    self.parseDate = createDateParser({
+      config: self.config,
+      l10n: self.l10n
+    });
+    self._handlers = [];
+    self._bind = bind;
+    self._setHoursFromDate = setHoursFromDate;
+    self._positionCalendar = positionCalendar;
+    self.changeMonth = changeMonth;
+    self.changeYear = changeYear;
+    self.clear = clear;
+    self.close = close;
+    self._createElement = createElement;
+    self.destroy = destroy;
+    self.isEnabled = isEnabled;
+    self.jumpToDate = jumpToDate;
+    self.open = open;
+    self.redraw = redraw;
+    self.set = set;
+    self.setDate = setDate;
+    self.toggle = toggle;
+
+    function setupHelperFunctions() {
+      self.utils = {
+        getDaysInMonth: function getDaysInMonth(month, yr) {
+          if (month === void 0) {
+            month = self.currentMonth;
+          }
+
+          if (yr === void 0) {
+            yr = self.currentYear;
+          }
+
+          if (month === 1 && (yr % 4 === 0 && yr % 100 !== 0 || yr % 400 === 0)) return 29;
+          return self.l10n.daysInMonth[month];
+        }
+      };
+    }
+
+    function init() {
+      self.element = self.input = element;
+      self.isOpen = false;
+      parseConfig();
+      setupLocale();
+      setupInputs();
+      setupDates();
+      setupHelperFunctions();
+      if (!self.isMobile) build();
+      bindEvents();
+
+      if (self.selectedDates.length || self.config.noCalendar) {
+        if (self.config.enableTime) {
+          setHoursFromDate(self.config.noCalendar ? self.latestSelectedDateObj || self.config.minDate : undefined);
+        }
+
+        updateValue(false);
+      }
+
+      setCalendarWidth();
+      self.showTimeInput = self.selectedDates.length > 0 || self.config.noCalendar;
+      var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+      if (!self.isMobile && isSafari) {
+        positionCalendar();
+      }
+
+      triggerEvent("onReady");
+    }
+
+    function bindToInstance(fn) {
+      return fn.bind(self);
+    }
+
+    function setCalendarWidth() {
+      var config = self.config;
+      if (config.weekNumbers === false && config.showMonths === 1) return;else if (config.noCalendar !== true) {
+        window.requestAnimationFrame(function () {
+          self.calendarContainer.style.visibility = "hidden";
+          self.calendarContainer.style.display = "block";
+
+          if (self.daysContainer !== undefined) {
+            var daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
+            self.daysContainer.style.width = daysWidth + "px";
+            self.calendarContainer.style.width = daysWidth + (self.weekWrapper !== undefined ? self.weekWrapper.offsetWidth : 0) + "px";
+            self.calendarContainer.style.removeProperty("visibility");
+            self.calendarContainer.style.removeProperty("display");
+          }
         });
-        var instances = [];
-        for (var i = 0; i < nodes.length; i++) {
-            var node = nodes[i];
-            try {
-                if (node.getAttribute("data-fp-omit") !== null) continue;
-                if (node._flatpickr !== undefined) {
-                    node._flatpickr.destroy();
-                    node._flatpickr = undefined;
-                }
-                node._flatpickr = FlatpickrInstance(node, config || {});
-                instances.push(node._flatpickr);
-            } catch (e) {
-                console.error(e);
-            }
-        }
-        return instances.length === 1 ? instances[0] : instances;
-    }
-    /* istanbul ignore next */
-    if (typeof HTMLElement !== "undefined") {
-        // browser env
-        HTMLCollection.prototype.flatpickr = NodeList.prototype.flatpickr = function (config) {
-            return _flatpickr(this, config);
-        };
-        HTMLElement.prototype.flatpickr = function (config) {
-            return _flatpickr([this], config);
-        };
-    }
-    /* istanbul ignore next */
-    var flatpickr = function flatpickr(selector, config) {
-        if (typeof selector === "string") {
-            return _flatpickr(window.document.querySelectorAll(selector), config);
-        } else if (selector instanceof Node) {
-            return _flatpickr([selector], config);
-        } else {
-            return _flatpickr(selector, config);
-        }
-    };
-    /* istanbul ignore next */
-    flatpickr.defaultConfig = defaults;
-    flatpickr.l10ns = {
-        en: _assign({}, english),
-        "default": _assign({}, english)
-    };
-    flatpickr.localize = function (l10n) {
-        flatpickr.l10ns["default"] = _assign({}, flatpickr.l10ns["default"], l10n);
-    };
-    flatpickr.setDefaults = function (config) {
-        flatpickr.defaultConfig = _assign({}, flatpickr.defaultConfig, config);
-    };
-    flatpickr.parseDate = createDateParser({});
-    flatpickr.formatDate = createDateFormatter({});
-    flatpickr.compareDates = compareDates;
-    /* istanbul ignore next */
-    if (typeof jQuery !== "undefined") {
-        jQuery.fn.flatpickr = function (config) {
-            return _flatpickr(this, config);
-        };
-    }
-    Date.prototype.fp_incr = function (days) {
-        return new Date(this.getFullYear(), this.getMonth(), this.getDate() + (typeof days === "string" ? parseInt(days, 10) : days));
-    };
-    if (typeof window !== "undefined") {
-        window.flatpickr = flatpickr;
+      }
     }
 
-    return flatpickr;
+    function updateTime(e) {
+      if (self.selectedDates.length === 0) return;
+
+      if (e !== undefined && e.type !== "blur") {
+        timeWrapper(e);
+      }
+
+      var prevValue = self._input.value;
+      setHoursFromInputs();
+      updateValue();
+
+      if (self._input.value !== prevValue) {
+        self._debouncedChange();
+      }
+    }
+
+    function ampm2military(hour, amPM) {
+      return hour % 12 + 12 * int(amPM === self.l10n.amPM[1]);
+    }
+
+    function military2ampm(hour) {
+      switch (hour % 24) {
+        case 0:
+        case 12:
+          return 12;
+
+        default:
+          return hour % 12;
+      }
+    }
+
+    function setHoursFromInputs() {
+      if (self.hourElement === undefined || self.minuteElement === undefined) return;
+      var hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
+          minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
+          seconds = self.secondElement !== undefined ? (parseInt(self.secondElement.value, 10) || 0) % 60 : 0;
+
+      if (self.amPM !== undefined) {
+        hours = ampm2military(hours, self.amPM.textContent);
+      }
+
+      var limitMinHours = self.config.minTime !== undefined || self.config.minDate && self.minDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.minDate, true) === 0;
+      var limitMaxHours = self.config.maxTime !== undefined || self.config.maxDate && self.maxDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.maxDate, true) === 0;
+
+      if (limitMaxHours) {
+        var maxTime = self.config.maxTime !== undefined ? self.config.maxTime : self.config.maxDate;
+        hours = Math.min(hours, maxTime.getHours());
+        if (hours === maxTime.getHours()) minutes = Math.min(minutes, maxTime.getMinutes());
+        if (minutes === maxTime.getMinutes()) seconds = Math.min(seconds, maxTime.getSeconds());
+      }
+
+      if (limitMinHours) {
+        var minTime = self.config.minTime !== undefined ? self.config.minTime : self.config.minDate;
+        hours = Math.max(hours, minTime.getHours());
+        if (hours === minTime.getHours()) minutes = Math.max(minutes, minTime.getMinutes());
+        if (minutes === minTime.getMinutes()) seconds = Math.max(seconds, minTime.getSeconds());
+      }
+
+      setHours(hours, minutes, seconds);
+    }
+
+    function setHoursFromDate(dateObj) {
+      var date = dateObj || self.latestSelectedDateObj;
+      if (date) setHours(date.getHours(), date.getMinutes(), date.getSeconds());
+    }
+
+    function setDefaultHours() {
+      var hours = self.config.defaultHour;
+      var minutes = self.config.defaultMinute;
+      var seconds = self.config.defaultSeconds;
+
+      if (self.config.minDate !== undefined) {
+        var min_hr = self.config.minDate.getHours();
+        var min_minutes = self.config.minDate.getMinutes();
+        hours = Math.max(hours, min_hr);
+        if (hours === min_hr) minutes = Math.max(min_minutes, minutes);
+        if (hours === min_hr && minutes === min_minutes) seconds = self.config.minDate.getSeconds();
+      }
+
+      if (self.config.maxDate !== undefined) {
+        var max_hr = self.config.maxDate.getHours();
+        var max_minutes = self.config.maxDate.getMinutes();
+        hours = Math.min(hours, max_hr);
+        if (hours === max_hr) minutes = Math.min(max_minutes, minutes);
+        if (hours === max_hr && minutes === max_minutes) seconds = self.config.maxDate.getSeconds();
+      }
+
+      setHours(hours, minutes, seconds);
+    }
+
+    function setHours(hours, minutes, seconds) {
+      if (self.latestSelectedDateObj !== undefined) {
+        self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
+      }
+
+      if (!self.hourElement || !self.minuteElement || self.isMobile) return;
+      self.hourElement.value = pad(!self.config.time_24hr ? (12 + hours) % 12 + 12 * int(hours % 12 === 0) : hours);
+      self.minuteElement.value = pad(minutes);
+      if (self.amPM !== undefined) self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
+      if (self.secondElement !== undefined) self.secondElement.value = pad(seconds);
+    }
+
+    function onYearInput(event) {
+      var year = parseInt(event.target.value) + (event.delta || 0);
+
+      if (year / 1000 > 1 || event.key === "Enter" && !/[^\d]/.test(year.toString())) {
+        changeYear(year);
+      }
+    }
+
+    function bind(element, event, handler, options) {
+      if (event instanceof Array) return event.forEach(function (ev) {
+        return bind(element, ev, handler, options);
+      });
+      if (element instanceof Array) return element.forEach(function (el) {
+        return bind(el, event, handler, options);
+      });
+      element.addEventListener(event, handler, options);
+
+      self._handlers.push({
+        element: element,
+        event: event,
+        handler: handler,
+        options: options
+      });
+    }
+
+    function onClick(handler) {
+      return function (evt) {
+        evt.which === 1 && handler(evt);
+      };
+    }
+
+    function triggerChange() {
+      triggerEvent("onChange");
+    }
+
+    function bindEvents() {
+      if (self.config.wrap) {
+        ["open", "close", "toggle", "clear"].forEach(function (evt) {
+          Array.prototype.forEach.call(self.element.querySelectorAll("[data-" + evt + "]"), function (el) {
+            return bind(el, "click", self[evt]);
+          });
+        });
+      }
+
+      if (self.isMobile) {
+        setupMobile();
+        return;
+      }
+
+      var debouncedResize = debounce(onResize, 50);
+      self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
+      if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent)) bind(self.daysContainer, "mouseover", function (e) {
+        if (self.config.mode === "range") onMouseOver(e.target);
+      });
+      bind(window.document.body, "keydown", onKeyDown);
+      if (!self.config.static) bind(self._input, "keydown", onKeyDown);
+      if (!self.config.inline && !self.config.static) bind(window, "resize", debouncedResize);
+      if (window.ontouchstart !== undefined) bind(window.document, "click", documentClick);else bind(window.document, "mousedown", onClick(documentClick));
+      bind(window.document, "focus", documentClick, {
+        capture: true
+      });
+
+      if (self.config.clickOpens === true) {
+        bind(self._input, "focus", self.open);
+        bind(self._input, "mousedown", onClick(self.open));
+      }
+
+      if (self.daysContainer !== undefined) {
+        bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
+        bind(self.monthNav, ["keyup", "increment"], onYearInput);
+        bind(self.daysContainer, "mousedown", onClick(selectDate));
+      }
+
+      if (self.timeContainer !== undefined && self.minuteElement !== undefined && self.hourElement !== undefined) {
+        var selText = function selText(e) {
+          return e.target.select();
+        };
+
+        bind(self.timeContainer, ["increment"], updateTime);
+        bind(self.timeContainer, "blur", updateTime, {
+          capture: true
+        });
+        bind(self.timeContainer, "mousedown", onClick(timeIncrement));
+        bind([self.hourElement, self.minuteElement], ["focus", "click"], selText);
+        if (self.secondElement !== undefined) bind(self.secondElement, "focus", function () {
+          return self.secondElement && self.secondElement.select();
+        });
+
+        if (self.amPM !== undefined) {
+          bind(self.amPM, "mousedown", onClick(function (e) {
+            updateTime(e);
+            triggerChange();
+          }));
+        }
+      }
+    }
+
+    function jumpToDate(jumpDate) {
+      var jumpTo = jumpDate !== undefined ? self.parseDate(jumpDate) : self.latestSelectedDateObj || (self.config.minDate && self.config.minDate > self.now ? self.config.minDate : self.config.maxDate && self.config.maxDate < self.now ? self.config.maxDate : self.now);
+
+      try {
+        if (jumpTo !== undefined) {
+          self.currentYear = jumpTo.getFullYear();
+          self.currentMonth = jumpTo.getMonth();
+        }
+      } catch (e) {
+        e.message = "Invalid date supplied: " + jumpTo;
+        self.config.errorHandler(e);
+      }
+
+      self.redraw();
+    }
+
+    function timeIncrement(e) {
+      if (~e.target.className.indexOf("arrow")) incrementNumInput(e, e.target.classList.contains("arrowUp") ? 1 : -1);
+    }
+
+    function incrementNumInput(e, delta, inputElem) {
+      var target = e && e.target;
+      var input = inputElem || target && target.parentNode && target.parentNode.firstChild;
+      var event = createEvent("increment");
+      event.delta = delta;
+      input && input.dispatchEvent(event);
+    }
+
+    function build() {
+      var fragment = window.document.createDocumentFragment();
+      self.calendarContainer = createElement("div", "flatpickr-calendar");
+      self.calendarContainer.tabIndex = -1;
+
+      if (!self.config.noCalendar) {
+        fragment.appendChild(buildMonthNav());
+        self.innerContainer = createElement("div", "flatpickr-innerContainer");
+
+        if (self.config.weekNumbers) {
+          var _buildWeeks = buildWeeks(),
+              weekWrapper = _buildWeeks.weekWrapper,
+              weekNumbers = _buildWeeks.weekNumbers;
+
+          self.innerContainer.appendChild(weekWrapper);
+          self.weekNumbers = weekNumbers;
+          self.weekWrapper = weekWrapper;
+        }
+
+        self.rContainer = createElement("div", "flatpickr-rContainer");
+        self.rContainer.appendChild(buildWeekdays());
+
+        if (!self.daysContainer) {
+          self.daysContainer = createElement("div", "flatpickr-days");
+          self.daysContainer.tabIndex = -1;
+        }
+
+        buildDays();
+        self.rContainer.appendChild(self.daysContainer);
+        self.innerContainer.appendChild(self.rContainer);
+        fragment.appendChild(self.innerContainer);
+      }
+
+      if (self.config.enableTime) {
+        fragment.appendChild(buildTime());
+      }
+
+      toggleClass(self.calendarContainer, "rangeMode", self.config.mode === "range");
+      toggleClass(self.calendarContainer, "animate", self.config.animate === true);
+      toggleClass(self.calendarContainer, "multiMonth", self.config.showMonths > 1);
+      self.calendarContainer.appendChild(fragment);
+      var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType !== undefined;
+
+      if (self.config.inline || self.config.static) {
+        self.calendarContainer.classList.add(self.config.inline ? "inline" : "static");
+
+        if (self.config.inline) {
+          if (!customAppend && self.element.parentNode) self.element.parentNode.insertBefore(self.calendarContainer, self._input.nextSibling);else if (self.config.appendTo !== undefined) self.config.appendTo.appendChild(self.calendarContainer);
+        }
+
+        if (self.config.static) {
+          var wrapper = createElement("div", "flatpickr-wrapper");
+          if (self.element.parentNode) self.element.parentNode.insertBefore(wrapper, self.element);
+          wrapper.appendChild(self.element);
+          if (self.altInput) wrapper.appendChild(self.altInput);
+          wrapper.appendChild(self.calendarContainer);
+        }
+      }
+
+      if (!self.config.static && !self.config.inline) (self.config.appendTo !== undefined ? self.config.appendTo : window.document.body).appendChild(self.calendarContainer);
+    }
+
+    function createDay(className, date, dayNumber, i) {
+      var dateIsEnabled = isEnabled(date, true),
+          dayElement = createElement("span", "flatpickr-day " + className, date.getDate().toString());
+      dayElement.dateObj = date;
+      dayElement.$i = i;
+      dayElement.setAttribute("aria-label", self.formatDate(date, self.config.ariaDateFormat));
+
+      if (className.indexOf("hidden") === -1 && compareDates(date, self.now) === 0) {
+        self.todayDateElem = dayElement;
+        dayElement.classList.add("today");
+        dayElement.setAttribute("aria-current", "date");
+      }
+
+      if (dateIsEnabled) {
+        dayElement.tabIndex = -1;
+
+        if (isDateSelected(date)) {
+          dayElement.classList.add("selected");
+          self.selectedDateElem = dayElement;
+
+          if (self.config.mode === "range") {
+            toggleClass(dayElement, "startRange", self.selectedDates[0] && compareDates(date, self.selectedDates[0], true) === 0);
+            toggleClass(dayElement, "endRange", self.selectedDates[1] && compareDates(date, self.selectedDates[1], true) === 0);
+            if (className === "nextMonthDay") dayElement.classList.add("inRange");
+          }
+        }
+      } else {
+        dayElement.classList.add("disabled");
+      }
+
+      if (self.config.mode === "range") {
+        if (isDateInRange(date) && !isDateSelected(date)) dayElement.classList.add("inRange");
+      }
+
+      if (self.weekNumbers && self.config.showMonths === 1 && className !== "prevMonthDay" && dayNumber % 7 === 1) {
+        self.weekNumbers.insertAdjacentHTML("beforeend", "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>");
+      }
+
+      triggerEvent("onDayCreate", dayElement);
+      return dayElement;
+    }
+
+    function focusOnDayElem(targetNode) {
+      targetNode.focus();
+      if (self.config.mode === "range") onMouseOver(targetNode);
+    }
+
+    function getFirstAvailableDay(delta) {
+      var startMonth = delta > 0 ? 0 : self.config.showMonths - 1;
+      var endMonth = delta > 0 ? self.config.showMonths : -1;
+
+      for (var m = startMonth; m != endMonth; m += delta) {
+        var month = self.daysContainer.children[m];
+        var startIndex = delta > 0 ? 0 : month.children.length - 1;
+        var endIndex = delta > 0 ? month.children.length : -1;
+
+        for (var i = startIndex; i != endIndex; i += delta) {
+          var c = month.children[i];
+          if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj)) return c;
+        }
+      }
+
+      return undefined;
+    }
+
+    function getNextAvailableDay(current, delta) {
+      var givenMonth = current.className.indexOf("Month") === -1 ? current.dateObj.getMonth() : self.currentMonth;
+      var endMonth = delta > 0 ? self.config.showMonths : -1;
+      var loopDelta = delta > 0 ? 1 : -1;
+
+      for (var m = givenMonth - self.currentMonth; m != endMonth; m += loopDelta) {
+        var month = self.daysContainer.children[m];
+        var startIndex = givenMonth - self.currentMonth === m ? current.$i + delta : delta < 0 ? month.children.length - 1 : 0;
+        var numMonthDays = month.children.length;
+
+        for (var i = startIndex; i >= 0 && i < numMonthDays && i != (delta > 0 ? numMonthDays : -1); i += loopDelta) {
+          var c = month.children[i];
+          if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj) && Math.abs(current.$i - i) >= Math.abs(delta)) return focusOnDayElem(c);
+        }
+      }
+
+      self.changeMonth(loopDelta);
+      focusOnDay(getFirstAvailableDay(loopDelta), 0);
+      return undefined;
+    }
+
+    function focusOnDay(current, offset) {
+      var dayFocused = isInView(document.activeElement || document.body);
+      var startElem = current !== undefined ? current : dayFocused ? document.activeElement : self.selectedDateElem !== undefined && isInView(self.selectedDateElem) ? self.selectedDateElem : self.todayDateElem !== undefined && isInView(self.todayDateElem) ? self.todayDateElem : getFirstAvailableDay(offset > 0 ? 1 : -1);
+      if (startElem === undefined) return self._input.focus();
+      if (!dayFocused) return focusOnDayElem(startElem);
+      getNextAvailableDay(startElem, offset);
+    }
+
+    function buildMonthDays(year, month) {
+      var firstOfMonth = (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
+      var prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12);
+      var daysInMonth = self.utils.getDaysInMonth(month),
+          days = window.document.createDocumentFragment(),
+          isMultiMonth = self.config.showMonths > 1,
+          prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
+          nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
+      var dayNumber = prevMonthDays + 1 - firstOfMonth,
+          dayIndex = 0;
+
+      for (; dayNumber <= prevMonthDays; dayNumber++, dayIndex++) {
+        days.appendChild(createDay(prevMonthDayClass, new Date(year, month - 1, dayNumber), dayNumber, dayIndex));
+      }
+
+      for (dayNumber = 1; dayNumber <= daysInMonth; dayNumber++, dayIndex++) {
+        days.appendChild(createDay("", new Date(year, month, dayNumber), dayNumber, dayIndex));
+      }
+
+      for (var dayNum = daysInMonth + 1; dayNum <= 42 - firstOfMonth && (self.config.showMonths === 1 || dayIndex % 7 !== 0); dayNum++, dayIndex++) {
+        days.appendChild(createDay(nextMonthDayClass, new Date(year, month + 1, dayNum % daysInMonth), dayNum, dayIndex));
+      }
+
+      var dayContainer = createElement("div", "dayContainer");
+      dayContainer.appendChild(days);
+      return dayContainer;
+    }
+
+    function buildDays() {
+      if (self.daysContainer === undefined) {
+        return;
+      }
+
+      clearNode(self.daysContainer);
+      if (self.weekNumbers) clearNode(self.weekNumbers);
+      var frag = document.createDocumentFragment();
+
+      for (var i = 0; i < self.config.showMonths; i++) {
+        var d = new Date(self.currentYear, self.currentMonth, 1);
+        d.setMonth(self.currentMonth + i);
+        frag.appendChild(buildMonthDays(d.getFullYear(), d.getMonth()));
+      }
+
+      self.daysContainer.appendChild(frag);
+      self.days = self.daysContainer.firstChild;
+
+      if (self.config.mode === "range" && self.selectedDates.length === 1) {
+        onMouseOver();
+      }
+    }
+
+    function buildMonth() {
+      var container = createElement("div", "flatpickr-month");
+      var monthNavFragment = window.document.createDocumentFragment();
+      var monthElement = createElement("span", "cur-month");
+      var yearInput = createNumberInput("cur-year", {
+        tabindex: "-1"
+      });
+      var yearElement = yearInput.getElementsByTagName("input")[0];
+      yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
+      if (self.config.minDate) yearElement.setAttribute("data-min", self.config.minDate.getFullYear().toString());
+
+      if (self.config.maxDate) {
+        yearElement.setAttribute("data-max", self.config.maxDate.getFullYear().toString());
+        yearElement.disabled = !!self.config.minDate && self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
+      }
+
+      var currentMonth = createElement("div", "flatpickr-current-month");
+      currentMonth.appendChild(monthElement);
+      currentMonth.appendChild(yearInput);
+      monthNavFragment.appendChild(currentMonth);
+      container.appendChild(monthNavFragment);
+      return {
+        container: container,
+        yearElement: yearElement,
+        monthElement: monthElement
+      };
+    }
+
+    function buildMonths() {
+      clearNode(self.monthNav);
+      self.monthNav.appendChild(self.prevMonthNav);
+
+      for (var m = self.config.showMonths; m--;) {
+        var month = buildMonth();
+        self.yearElements.push(month.yearElement);
+        self.monthElements.push(month.monthElement);
+        self.monthNav.appendChild(month.container);
+      }
+
+      self.monthNav.appendChild(self.nextMonthNav);
+    }
+
+    function buildMonthNav() {
+      self.monthNav = createElement("div", "flatpickr-months");
+      self.yearElements = [];
+      self.monthElements = [];
+      self.prevMonthNav = createElement("span", "flatpickr-prev-month");
+      self.prevMonthNav.innerHTML = self.config.prevArrow;
+      self.nextMonthNav = createElement("span", "flatpickr-next-month");
+      self.nextMonthNav.innerHTML = self.config.nextArrow;
+      buildMonths();
+      Object.defineProperty(self, "_hidePrevMonthArrow", {
+        get: function get() {
+          return self.__hidePrevMonthArrow;
+        },
+        set: function set(bool) {
+          if (self.__hidePrevMonthArrow !== bool) {
+            toggleClass(self.prevMonthNav, "disabled", bool);
+            self.__hidePrevMonthArrow = bool;
+          }
+        }
+      });
+      Object.defineProperty(self, "_hideNextMonthArrow", {
+        get: function get() {
+          return self.__hideNextMonthArrow;
+        },
+        set: function set(bool) {
+          if (self.__hideNextMonthArrow !== bool) {
+            toggleClass(self.nextMonthNav, "disabled", bool);
+            self.__hideNextMonthArrow = bool;
+          }
+        }
+      });
+      self.currentYearElement = self.yearElements[0];
+      updateNavigationCurrentMonth();
+      return self.monthNav;
+    }
+
+    function buildTime() {
+      self.calendarContainer.classList.add("hasTime");
+      if (self.config.noCalendar) self.calendarContainer.classList.add("noCalendar");
+      self.timeContainer = createElement("div", "flatpickr-time");
+      self.timeContainer.tabIndex = -1;
+      var separator = createElement("span", "flatpickr-time-separator", ":");
+      var hourInput = createNumberInput("flatpickr-hour");
+      self.hourElement = hourInput.getElementsByTagName("input")[0];
+      var minuteInput = createNumberInput("flatpickr-minute");
+      self.minuteElement = minuteInput.getElementsByTagName("input")[0];
+      self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
+      self.hourElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getHours() : self.config.time_24hr ? self.config.defaultHour : military2ampm(self.config.defaultHour));
+      self.minuteElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getMinutes() : self.config.defaultMinute);
+      self.hourElement.setAttribute("data-step", self.config.hourIncrement.toString());
+      self.minuteElement.setAttribute("data-step", self.config.minuteIncrement.toString());
+      self.hourElement.setAttribute("data-min", self.config.time_24hr ? "0" : "1");
+      self.hourElement.setAttribute("data-max", self.config.time_24hr ? "23" : "12");
+      self.minuteElement.setAttribute("data-min", "0");
+      self.minuteElement.setAttribute("data-max", "59");
+      self.timeContainer.appendChild(hourInput);
+      self.timeContainer.appendChild(separator);
+      self.timeContainer.appendChild(minuteInput);
+      if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
+
+      if (self.config.enableSeconds) {
+        self.timeContainer.classList.add("hasSeconds");
+        var secondInput = createNumberInput("flatpickr-second");
+        self.secondElement = secondInput.getElementsByTagName("input")[0];
+        self.secondElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getSeconds() : self.config.defaultSeconds);
+        self.secondElement.setAttribute("data-step", self.minuteElement.getAttribute("data-step"));
+        self.secondElement.setAttribute("data-min", self.minuteElement.getAttribute("data-min"));
+        self.secondElement.setAttribute("data-max", self.minuteElement.getAttribute("data-max"));
+        self.timeContainer.appendChild(createElement("span", "flatpickr-time-separator", ":"));
+        self.timeContainer.appendChild(secondInput);
+      }
+
+      if (!self.config.time_24hr) {
+        self.amPM = createElement("span", "flatpickr-am-pm", self.l10n.amPM[int((self.latestSelectedDateObj ? self.hourElement.value : self.config.defaultHour) > 11)]);
+        self.amPM.title = self.l10n.toggleTitle;
+        self.amPM.tabIndex = -1;
+        self.timeContainer.appendChild(self.amPM);
+      }
+
+      return self.timeContainer;
+    }
+
+    function buildWeekdays() {
+      if (!self.weekdayContainer) self.weekdayContainer = createElement("div", "flatpickr-weekdays");else clearNode(self.weekdayContainer);
+
+      for (var i = self.config.showMonths; i--;) {
+        var container = createElement("div", "flatpickr-weekdaycontainer");
+        self.weekdayContainer.appendChild(container);
+      }
+
+      updateWeekdays();
+      return self.weekdayContainer;
+    }
+
+    function updateWeekdays() {
+      var firstDayOfWeek = self.l10n.firstDayOfWeek;
+      var weekdays = self.l10n.weekdays.shorthand.concat();
+
+      if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {
+        weekdays = weekdays.splice(firstDayOfWeek, weekdays.length).concat(weekdays.splice(0, firstDayOfWeek));
+      }
+
+      for (var i = self.config.showMonths; i--;) {
+        self.weekdayContainer.children[i].innerHTML = "\n      <span class=flatpickr-weekday>\n        " + weekdays.join("</span><span class=flatpickr-weekday>") + "\n      </span>\n      ";
+      }
+    }
+
+    function buildWeeks() {
+      self.calendarContainer.classList.add("hasWeeks");
+      var weekWrapper = createElement("div", "flatpickr-weekwrapper");
+      weekWrapper.appendChild(createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation));
+      var weekNumbers = createElement("div", "flatpickr-weeks");
+      weekWrapper.appendChild(weekNumbers);
+      return {
+        weekWrapper: weekWrapper,
+        weekNumbers: weekNumbers
+      };
+    }
+
+    function changeMonth(value, is_offset) {
+      if (is_offset === void 0) {
+        is_offset = true;
+      }
+
+      var delta = is_offset ? value : value - self.currentMonth;
+      if (delta < 0 && self._hidePrevMonthArrow === true || delta > 0 && self._hideNextMonthArrow === true) return;
+      self.currentMonth += delta;
+
+      if (self.currentMonth < 0 || self.currentMonth > 11) {
+        self.currentYear += self.currentMonth > 11 ? 1 : -1;
+        self.currentMonth = (self.currentMonth + 12) % 12;
+        triggerEvent("onYearChange");
+      }
+
+      buildDays();
+      triggerEvent("onMonthChange");
+      updateNavigationCurrentMonth();
+    }
+
+    function clear(triggerChangeEvent) {
+      if (triggerChangeEvent === void 0) {
+        triggerChangeEvent = true;
+      }
+
+      self.input.value = "";
+      if (self.altInput !== undefined) self.altInput.value = "";
+      if (self.mobileInput !== undefined) self.mobileInput.value = "";
+      self.selectedDates = [];
+      self.latestSelectedDateObj = undefined;
+      self.showTimeInput = false;
+
+      if (self.config.enableTime === true) {
+        setDefaultHours();
+      }
+
+      self.redraw();
+      if (triggerChangeEvent) triggerEvent("onChange");
+    }
+
+    function close() {
+      self.isOpen = false;
+
+      if (!self.isMobile) {
+        self.calendarContainer.classList.remove("open");
+
+        self._input.classList.remove("active");
+      }
+
+      triggerEvent("onClose");
+    }
+
+    function destroy() {
+      if (self.config !== undefined) triggerEvent("onDestroy");
+
+      for (var i = self._handlers.length; i--;) {
+        var h = self._handlers[i];
+        h.element.removeEventListener(h.event, h.handler, h.options);
+      }
+
+      self._handlers = [];
+
+      if (self.mobileInput) {
+        if (self.mobileInput.parentNode) self.mobileInput.parentNode.removeChild(self.mobileInput);
+        self.mobileInput = undefined;
+      } else if (self.calendarContainer && self.calendarContainer.parentNode) {
+        if (self.config.static && self.calendarContainer.parentNode) {
+          var wrapper = self.calendarContainer.parentNode;
+          wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
+
+          if (wrapper.parentNode) {
+            while (wrapper.firstChild) {
+              wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
+            }
+
+            wrapper.parentNode.removeChild(wrapper);
+          }
+        } else self.calendarContainer.parentNode.removeChild(self.calendarContainer);
+      }
+
+      if (self.altInput) {
+        self.input.type = "text";
+        if (self.altInput.parentNode) self.altInput.parentNode.removeChild(self.altInput);
+        delete self.altInput;
+      }
+
+      if (self.input) {
+        self.input.type = self.input._type;
+        self.input.classList.remove("flatpickr-input");
+        self.input.removeAttribute("readonly");
+        self.input.value = "";
+      }
+
+      ["_showTimeInput", "latestSelectedDateObj", "_hideNextMonthArrow", "_hidePrevMonthArrow", "__hideNextMonthArrow", "__hidePrevMonthArrow", "isMobile", "isOpen", "selectedDateElem", "minDateHasTime", "maxDateHasTime", "days", "daysContainer", "_input", "_positionElement", "innerContainer", "rContainer", "monthNav", "todayDateElem", "calendarContainer", "weekdayContainer", "prevMonthNav", "nextMonthNav", "currentMonthElement", "currentYearElement", "navigationCurrentMonth", "selectedDateElem", "config"].forEach(function (k) {
+        try {
+          delete self[k];
+        } catch (_) {}
+      });
+    }
+
+    function isCalendarElem(elem) {
+      if (self.config.appendTo && self.config.appendTo.contains(elem)) return true;
+      return self.calendarContainer.contains(elem);
+    }
+
+    function documentClick(e) {
+      if (self.isOpen && !self.config.inline) {
+        var isCalendarElement = isCalendarElem(e.target);
+        var isInput = e.target === self.input || e.target === self.altInput || self.element.contains(e.target) || e.path && e.path.indexOf && (~e.path.indexOf(self.input) || ~e.path.indexOf(self.altInput));
+        var lostFocus = e.type === "blur" ? isInput && e.relatedTarget && !isCalendarElem(e.relatedTarget) : !isInput && !isCalendarElement;
+        var isIgnored = !self.config.ignoredFocusElements.some(function (elem) {
+          return elem.contains(e.target);
+        });
+
+        if (lostFocus && isIgnored) {
+          self.close();
+
+          if (self.config.mode === "range" && self.selectedDates.length === 1) {
+            self.clear(false);
+            self.redraw();
+          }
+        }
+      }
+    }
+
+    function changeYear(newYear) {
+      if (!newYear || self.config.minDate && newYear < self.config.minDate.getFullYear() || self.config.maxDate && newYear > self.config.maxDate.getFullYear()) return;
+      var newYearNum = newYear,
+          isNewYear = self.currentYear !== newYearNum;
+      self.currentYear = newYearNum || self.currentYear;
+
+      if (self.config.maxDate && self.currentYear === self.config.maxDate.getFullYear()) {
+        self.currentMonth = Math.min(self.config.maxDate.getMonth(), self.currentMonth);
+      } else if (self.config.minDate && self.currentYear === self.config.minDate.getFullYear()) {
+        self.currentMonth = Math.max(self.config.minDate.getMonth(), self.currentMonth);
+      }
+
+      if (isNewYear) {
+        self.redraw();
+        triggerEvent("onYearChange");
+      }
+    }
+
+    function isEnabled(date, timeless) {
+      if (timeless === void 0) {
+        timeless = true;
+      }
+
+      var dateToCheck = self.parseDate(date, undefined, timeless);
+      if (self.config.minDate && dateToCheck && compareDates(dateToCheck, self.config.minDate, timeless !== undefined ? timeless : !self.minDateHasTime) < 0 || self.config.maxDate && dateToCheck && compareDates(dateToCheck, self.config.maxDate, timeless !== undefined ? timeless : !self.maxDateHasTime) > 0) return false;
+      if (self.config.enable.length === 0 && self.config.disable.length === 0) return true;
+      if (dateToCheck === undefined) return false;
+      var bool = self.config.enable.length > 0,
+          array = bool ? self.config.enable : self.config.disable;
+
+      for (var i = 0, d; i < array.length; i++) {
+        d = array[i];
+        if (typeof d === "function" && d(dateToCheck)) return bool;else if (d instanceof Date && dateToCheck !== undefined && d.getTime() === dateToCheck.getTime()) return bool;else if (typeof d === "string" && dateToCheck !== undefined) {
+          var parsed = self.parseDate(d, undefined, true);
+          return parsed && parsed.getTime() === dateToCheck.getTime() ? bool : !bool;
+        } else if ((typeof d === 'undefined' ? 'undefined' : _typeof(d)) === "object" && dateToCheck !== undefined && d.from && d.to && dateToCheck.getTime() >= d.from.getTime() && dateToCheck.getTime() <= d.to.getTime()) return bool;
+      }
+
+      return !bool;
+    }
+
+    function isInView(elem) {
+      if (self.daysContainer !== undefined) return elem.className.indexOf("hidden") === -1 && self.daysContainer.contains(elem);
+      return false;
+    }
+
+    function onKeyDown(e) {
+      var isInput = e.target === self._input;
+      var allowInput = self.config.allowInput;
+      var allowKeydown = self.isOpen && (!allowInput || !isInput);
+      var allowInlineKeydown = self.config.inline && isInput && !allowInput;
+
+      if (e.keyCode === 13 && isInput) {
+        if (allowInput) {
+          self.setDate(self._input.value, true, e.target === self.altInput ? self.config.altFormat : self.config.dateFormat);
+          return e.target.blur();
+        } else self.open();
+      } else if (isCalendarElem(e.target) || allowKeydown || allowInlineKeydown) {
+        var isTimeObj = !!self.timeContainer && self.timeContainer.contains(e.target);
+
+        switch (e.keyCode) {
+          case 13:
+            if (isTimeObj) updateTime();else selectDate(e);
+            break;
+
+          case 27:
+            e.preventDefault();
+            focusAndClose();
+            break;
+
+          case 8:
+          case 46:
+            if (isInput && !self.config.allowInput) {
+              e.preventDefault();
+              self.clear();
+            }
+
+            break;
+
+          case 37:
+          case 39:
+            if (!isTimeObj) {
+              e.preventDefault();
+
+              if (self.daysContainer !== undefined && (allowInput === false || isInView(document.activeElement))) {
+                var _delta = e.keyCode === 39 ? 1 : -1;
+
+                if (!e.ctrlKey) focusOnDay(undefined, _delta);else {
+                  changeMonth(_delta);
+                  focusOnDay(getFirstAvailableDay(1), 0);
+                }
+              }
+            } else if (self.hourElement) self.hourElement.focus();
+
+            break;
+
+          case 38:
+          case 40:
+            e.preventDefault();
+            var delta = e.keyCode === 40 ? 1 : -1;
+
+            if (self.daysContainer && e.target.$i !== undefined) {
+              if (e.ctrlKey) {
+                changeYear(self.currentYear - delta);
+                focusOnDay(getFirstAvailableDay(1), 0);
+              } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
+            } else if (self.config.enableTime) {
+              if (!isTimeObj && self.hourElement) self.hourElement.focus();
+              updateTime(e);
+
+              self._debouncedChange();
+            }
+
+            break;
+
+          case 9:
+            if (!isTimeObj) {
+              self.element.focus();
+              break;
+            }
+
+            var elems = [self.hourElement, self.minuteElement, self.secondElement, self.amPM].filter(function (x) {
+              return x;
+            });
+            var i = elems.indexOf(e.target);
+
+            if (i !== -1) {
+              var target = elems[i + (e.shiftKey ? -1 : 1)];
+
+              if (target !== undefined) {
+                e.preventDefault();
+                target.focus();
+              } else {
+                self.element.focus();
+              }
+            }
+
+            break;
+
+          default:
+            break;
+        }
+      }
+
+      if (self.amPM !== undefined && e.target === self.amPM) {
+        switch (e.key) {
+          case self.l10n.amPM[0].charAt(0):
+          case self.l10n.amPM[0].charAt(0).toLowerCase():
+            self.amPM.textContent = self.l10n.amPM[0];
+            setHoursFromInputs();
+            updateValue();
+            break;
+
+          case self.l10n.amPM[1].charAt(0):
+          case self.l10n.amPM[1].charAt(0).toLowerCase():
+            self.amPM.textContent = self.l10n.amPM[1];
+            setHoursFromInputs();
+            updateValue();
+            break;
+        }
+      }
+
+      triggerEvent("onKeyDown", e);
+    }
+
+    function onMouseOver(elem) {
+      if (self.selectedDates.length !== 1 || elem && (!elem.classList.contains("flatpickr-day") || elem.classList.contains("disabled"))) return;
+      var hoverDate = elem ? elem.dateObj.getTime() : self.days.firstElementChild.dateObj.getTime(),
+          initialDate = self.parseDate(self.selectedDates[0], undefined, true).getTime(),
+          rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
+          rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime()),
+          lastDate = self.daysContainer.lastChild.lastChild.dateObj.getTime();
+      var containsDisabled = false;
+      var minRange = 0,
+          maxRange = 0;
+
+      for (var t = rangeStartDate; t < lastDate; t += duration.DAY) {
+        if (!isEnabled(new Date(t), true)) {
+          containsDisabled = containsDisabled || t > rangeStartDate && t < rangeEndDate;
+          if (t < initialDate && (!minRange || t > minRange)) minRange = t;else if (t > initialDate && (!maxRange || t < maxRange)) maxRange = t;
+        }
+      }
+
+      for (var m = 0; m < self.config.showMonths; m++) {
+        var month = self.daysContainer.children[m];
+        var prevMonth = self.daysContainer.children[m - 1];
+
+        var _loop = function _loop(i, l) {
+          var dayElem = month.children[i],
+              date = dayElem.dateObj;
+          var timestamp = date.getTime();
+          var outOfRange = minRange > 0 && timestamp < minRange || maxRange > 0 && timestamp > maxRange;
+
+          if (outOfRange) {
+            dayElem.classList.add("notAllowed");
+            ["inRange", "startRange", "endRange"].forEach(function (c) {
+              dayElem.classList.remove(c);
+            });
+            return "continue";
+          } else if (containsDisabled && !outOfRange) return "continue";
+
+          ["startRange", "inRange", "endRange", "notAllowed"].forEach(function (c) {
+            dayElem.classList.remove(c);
+          });
+
+          if (elem !== undefined) {
+            elem.classList.add(hoverDate < self.selectedDates[0].getTime() ? "startRange" : "endRange");
+
+            if (month.contains(elem) || !(m > 0 && prevMonth && prevMonth.lastChild.dateObj.getTime() >= timestamp)) {
+              if (initialDate < hoverDate && timestamp === initialDate) dayElem.classList.add("startRange");else if (initialDate > hoverDate && timestamp === initialDate) dayElem.classList.add("endRange");
+              if (timestamp >= minRange && (maxRange === 0 || timestamp <= maxRange) && isBetween(timestamp, initialDate, hoverDate)) dayElem.classList.add("inRange");
+            }
+          }
+        };
+
+        for (var i = 0, l = month.children.length; i < l; i++) {
+          var _ret = _loop(i, l);
+
+          if (_ret === "continue") continue;
+        }
+      }
+    }
+
+    function onResize() {
+      if (self.isOpen && !self.config.static && !self.config.inline) positionCalendar();
+    }
+
+    function open(e, positionElement) {
+      if (positionElement === void 0) {
+        positionElement = self._positionElement;
+      }
+
+      if (self.isMobile === true) {
+        if (e) {
+          e.preventDefault();
+          e.target && e.target.blur();
+        }
+
+        if (self.mobileInput !== undefined) {
+          self.mobileInput.focus();
+          self.mobileInput.click();
+        }
+
+        triggerEvent("onOpen");
+        return;
+      }
+
+      if (self._input.disabled || self.config.inline) return;
+      var wasOpen = self.isOpen;
+      self.isOpen = true;
+
+      if (!wasOpen) {
+        self.calendarContainer.classList.add("open");
+
+        self._input.classList.add("active");
+
+        triggerEvent("onOpen");
+        positionCalendar(positionElement);
+      }
+
+      if (self.config.enableTime === true && self.config.noCalendar === true) {
+        if (self.selectedDates.length === 0) {
+          self.setDate(self.config.minDate !== undefined ? new Date(self.config.minDate.getTime()) : new Date(), false);
+          setDefaultHours();
+          updateValue();
+        }
+
+        if (self.config.allowInput === false && (e === undefined || !self.timeContainer.contains(e.relatedTarget))) {
+          setTimeout(function () {
+            return self.hourElement.select();
+          }, 50);
+        }
+      }
+    }
+
+    function minMaxDateSetter(type) {
+      return function (date) {
+        var dateObj = self.config["_" + type + "Date"] = self.parseDate(date, self.config.dateFormat);
+        var inverseDateObj = self.config["_" + (type === "min" ? "max" : "min") + "Date"];
+
+        if (dateObj !== undefined) {
+          self[type === "min" ? "minDateHasTime" : "maxDateHasTime"] = dateObj.getHours() > 0 || dateObj.getMinutes() > 0 || dateObj.getSeconds() > 0;
+        }
+
+        if (self.selectedDates) {
+          self.selectedDates = self.selectedDates.filter(function (d) {
+            return isEnabled(d);
+          });
+          if (!self.selectedDates.length && type === "min") setHoursFromDate(dateObj);
+          updateValue();
+        }
+
+        if (self.daysContainer) {
+          redraw();
+          if (dateObj !== undefined) self.currentYearElement[type] = dateObj.getFullYear().toString();else self.currentYearElement.removeAttribute(type);
+          self.currentYearElement.disabled = !!inverseDateObj && dateObj !== undefined && inverseDateObj.getFullYear() === dateObj.getFullYear();
+        }
+      };
+    }
+
+    function parseConfig() {
+      var boolOpts = ["wrap", "weekNumbers", "allowInput", "clickOpens", "time_24hr", "enableTime", "noCalendar", "altInput", "shorthandCurrentMonth", "inline", "static", "enableSeconds", "disableMobile"];
+      var userConfig = Object.assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
+      var formats$$1 = {};
+      self.config.parseDate = userConfig.parseDate;
+      self.config.formatDate = userConfig.formatDate;
+      Object.defineProperty(self.config, "enable", {
+        get: function get() {
+          return self.config._enable;
+        },
+        set: function set(dates) {
+          self.config._enable = parseDateRules(dates);
+        }
+      });
+      Object.defineProperty(self.config, "disable", {
+        get: function get() {
+          return self.config._disable;
+        },
+        set: function set(dates) {
+          self.config._disable = parseDateRules(dates);
+        }
+      });
+      var timeMode = userConfig.mode === "time";
+
+      if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
+        formats$$1.dateFormat = userConfig.noCalendar || timeMode ? "H:i" + (userConfig.enableSeconds ? ":S" : "") : flatpickr.defaultConfig.dateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
+      }
+
+      if (userConfig.altInput && (userConfig.enableTime || timeMode) && !userConfig.altFormat) {
+        formats$$1.altFormat = userConfig.noCalendar || timeMode ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K") : flatpickr.defaultConfig.altFormat + (" h:i" + (userConfig.enableSeconds ? ":S" : "") + " K");
+      }
+
+      Object.defineProperty(self.config, "minDate", {
+        get: function get() {
+          return self.config._minDate;
+        },
+        set: minMaxDateSetter("min")
+      });
+      Object.defineProperty(self.config, "maxDate", {
+        get: function get() {
+          return self.config._maxDate;
+        },
+        set: minMaxDateSetter("max")
+      });
+
+      var minMaxTimeSetter = function minMaxTimeSetter(type) {
+        return function (val) {
+          self.config[type === "min" ? "_minTime" : "_maxTime"] = self.parseDate(val, "H:i");
+        };
+      };
+
+      Object.defineProperty(self.config, "minTime", {
+        get: function get() {
+          return self.config._minTime;
+        },
+        set: minMaxTimeSetter("min")
+      });
+      Object.defineProperty(self.config, "maxTime", {
+        get: function get() {
+          return self.config._maxTime;
+        },
+        set: minMaxTimeSetter("max")
+      });
+
+      if (userConfig.mode === "time") {
+        self.config.noCalendar = true;
+        self.config.enableTime = true;
+      }
+
+      Object.assign(self.config, formats$$1, userConfig);
+
+      for (var i = 0; i < boolOpts.length; i++) {
+        self.config[boolOpts[i]] = self.config[boolOpts[i]] === true || self.config[boolOpts[i]] === "true";
+      }
+
+      HOOKS.filter(function (hook) {
+        return self.config[hook] !== undefined;
+      }).forEach(function (hook) {
+        self.config[hook] = arrayify(self.config[hook] || []).map(bindToInstance);
+      });
+      self.isMobile = !self.config.disableMobile && !self.config.inline && self.config.mode === "single" && !self.config.disable.length && !self.config.enable.length && !self.config.weekNumbers && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+
+      for (var _i = 0; _i < self.config.plugins.length; _i++) {
+        var pluginConf = self.config.plugins[_i](self) || {};
+
+        for (var key in pluginConf) {
+          if (HOOKS.indexOf(key) > -1) {
+            self.config[key] = arrayify(pluginConf[key]).map(bindToInstance).concat(self.config[key]);
+          } else if (typeof userConfig[key] === "undefined") self.config[key] = pluginConf[key];
+        }
+      }
+
+      triggerEvent("onParseConfig");
+    }
+
+    function setupLocale() {
+      if (_typeof(self.config.locale) !== "object" && typeof flatpickr.l10ns[self.config.locale] === "undefined") self.config.errorHandler(new Error("flatpickr: invalid locale " + self.config.locale));
+      self.l10n = Object.assign({}, flatpickr.l10ns.default, _typeof(self.config.locale) === "object" ? self.config.locale : self.config.locale !== "default" ? flatpickr.l10ns[self.config.locale] : undefined);
+      tokenRegex.K = "(" + self.l10n.amPM[0] + "|" + self.l10n.amPM[1] + "|" + self.l10n.amPM[0].toLowerCase() + "|" + self.l10n.amPM[1].toLowerCase() + ")";
+      self.formatDate = createDateFormatter(self);
+      self.parseDate = createDateParser({
+        config: self.config,
+        l10n: self.l10n
+      });
+    }
+
+    function positionCalendar(customPositionElement) {
+      if (self.calendarContainer === undefined) return;
+      triggerEvent("onPreCalendarPosition");
+      var positionElement = customPositionElement || self._positionElement;
+      var calendarHeight = Array.prototype.reduce.call(self.calendarContainer.children, function (acc, child) {
+        return acc + child.offsetHeight;
+      }, 0),
+          calendarWidth = self.calendarContainer.offsetWidth,
+          configPos = self.config.position.split(" "),
+          configPosVertical = configPos[0],
+          configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
+          inputBounds = positionElement.getBoundingClientRect(),
+          distanceFromBottom = window.innerHeight - inputBounds.bottom,
+          showOnTop = configPosVertical === "above" || configPosVertical !== "below" && distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
+      var top = window.pageYOffset + inputBounds.top + (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
+      toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
+      toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
+      if (self.config.inline) return;
+      var left = window.pageXOffset + inputBounds.left - (configPosHorizontal != null && configPosHorizontal === "center" ? (calendarWidth - inputBounds.width) / 2 : 0);
+      var right = window.document.body.offsetWidth - inputBounds.right;
+      var rightMost = left + calendarWidth > window.document.body.offsetWidth;
+      toggleClass(self.calendarContainer, "rightMost", rightMost);
+      if (self.config.static) return;
+      self.calendarContainer.style.top = top + "px";
+
+      if (!rightMost) {
+        self.calendarContainer.style.left = left + "px";
+        self.calendarContainer.style.right = "auto";
+      } else {
+        self.calendarContainer.style.left = "auto";
+        self.calendarContainer.style.right = right + "px";
+      }
+    }
+
+    function redraw() {
+      if (self.config.noCalendar || self.isMobile) return;
+      updateNavigationCurrentMonth();
+      buildDays();
+    }
+
+    function focusAndClose() {
+      self._input.focus();
+
+      if (window.navigator.userAgent.indexOf("MSIE") !== -1 || navigator.msMaxTouchPoints !== undefined) {
+        setTimeout(self.close, 0);
+      } else {
+        self.close();
+      }
+    }
+
+    function selectDate(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      var isSelectable = function isSelectable(day) {
+        return day.classList && day.classList.contains("flatpickr-day") && !day.classList.contains("disabled") && !day.classList.contains("notAllowed");
+      };
+
+      var t = findParent(e.target, isSelectable);
+      if (t === undefined) return;
+      var target = t;
+      var selectedDate = self.latestSelectedDateObj = new Date(target.dateObj.getTime());
+      var shouldChangeMonth = (selectedDate.getMonth() < self.currentMonth || selectedDate.getMonth() > self.currentMonth + self.config.showMonths - 1) && self.config.mode !== "range";
+      self.selectedDateElem = target;
+      if (self.config.mode === "single") self.selectedDates = [selectedDate];else if (self.config.mode === "multiple") {
+        var selectedIndex = isDateSelected(selectedDate);
+        if (selectedIndex) self.selectedDates.splice(parseInt(selectedIndex), 1);else self.selectedDates.push(selectedDate);
+      } else if (self.config.mode === "range") {
+        if (self.selectedDates.length === 2) self.clear(false);
+        self.selectedDates.push(selectedDate);
+        if (compareDates(selectedDate, self.selectedDates[0], true) !== 0) self.selectedDates.sort(function (a, b) {
+          return a.getTime() - b.getTime();
+        });
+      }
+      setHoursFromInputs();
+
+      if (shouldChangeMonth) {
+        var isNewYear = self.currentYear !== selectedDate.getFullYear();
+        self.currentYear = selectedDate.getFullYear();
+        self.currentMonth = selectedDate.getMonth();
+        if (isNewYear) triggerEvent("onYearChange");
+        triggerEvent("onMonthChange");
+      }
+
+      updateNavigationCurrentMonth();
+      buildDays();
+      updateValue();
+      if (self.config.enableTime) setTimeout(function () {
+        return self.showTimeInput = true;
+      }, 50);
+      if (!shouldChangeMonth && self.config.mode !== "range" && self.config.showMonths === 1) focusOnDayElem(target);else self.selectedDateElem && self.selectedDateElem.focus();
+      if (self.hourElement !== undefined) setTimeout(function () {
+        return self.hourElement !== undefined && self.hourElement.select();
+      }, 451);
+
+      if (self.config.closeOnSelect) {
+        var single = self.config.mode === "single" && !self.config.enableTime;
+        var range = self.config.mode === "range" && self.selectedDates.length === 2 && !self.config.enableTime;
+
+        if (single || range) {
+          focusAndClose();
+        }
+      }
+
+      triggerChange();
+    }
+
+    var CALLBACKS = {
+      locale: [setupLocale, updateWeekdays],
+      showMonths: [buildMonths, setCalendarWidth, buildWeekdays]
+    };
+
+    function set(option, value) {
+      if (option !== null && (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === "object") Object.assign(self.config, option);else {
+        self.config[option] = value;
+        if (CALLBACKS[option] !== undefined) CALLBACKS[option].forEach(function (x) {
+          return x();
+        });else if (HOOKS.indexOf(option) > -1) self.config[option] = arrayify(value);
+      }
+      self.redraw();
+      jumpToDate();
+      updateValue(false);
+    }
+
+    function setSelectedDate(inputDate, format) {
+      var dates = [];
+      if (inputDate instanceof Array) dates = inputDate.map(function (d) {
+        return self.parseDate(d, format);
+      });else if (inputDate instanceof Date || typeof inputDate === "number") dates = [self.parseDate(inputDate, format)];else if (typeof inputDate === "string") {
+        switch (self.config.mode) {
+          case "single":
+          case "time":
+            dates = [self.parseDate(inputDate, format)];
+            break;
+
+          case "multiple":
+            dates = inputDate.split(self.config.conjunction).map(function (date) {
+              return self.parseDate(date, format);
+            });
+            break;
+
+          case "range":
+            dates = inputDate.split(self.l10n.rangeSeparator).map(function (date) {
+              return self.parseDate(date, format);
+            });
+            break;
+
+          default:
+            break;
+        }
+      } else self.config.errorHandler(new Error("Invalid date supplied: " + JSON.stringify(inputDate)));
+      self.selectedDates = dates.filter(function (d) {
+        return d instanceof Date && isEnabled(d, false);
+      });
+      if (self.config.mode === "range") self.selectedDates.sort(function (a, b) {
+        return a.getTime() - b.getTime();
+      });
+    }
+
+    function setDate(date, triggerChange, format) {
+      if (triggerChange === void 0) {
+        triggerChange = false;
+      }
+
+      if (format === void 0) {
+        format = self.config.dateFormat;
+      }
+
+      if (date !== 0 && !date || date instanceof Array && date.length === 0) return self.clear(triggerChange);
+      setSelectedDate(date, format);
+      self.showTimeInput = self.selectedDates.length > 0;
+      self.latestSelectedDateObj = self.selectedDates[0];
+      self.redraw();
+      jumpToDate();
+      setHoursFromDate();
+      updateValue(triggerChange);
+      if (triggerChange) triggerEvent("onChange");
+    }
+
+    function parseDateRules(arr) {
+      return arr.slice().map(function (rule) {
+        if (typeof rule === "string" || typeof rule === "number" || rule instanceof Date) {
+          return self.parseDate(rule, undefined, true);
+        } else if (rule && (typeof rule === 'undefined' ? 'undefined' : _typeof(rule)) === "object" && rule.from && rule.to) return {
+          from: self.parseDate(rule.from, undefined),
+          to: self.parseDate(rule.to, undefined)
+        };
+
+        return rule;
+      }).filter(function (x) {
+        return x;
+      });
+    }
+
+    function setupDates() {
+      self.selectedDates = [];
+      self.now = self.parseDate(self.config.now) || new Date();
+      var preloadedDate = self.config.defaultDate || ((self.input.nodeName === "INPUT" || self.input.nodeName === "TEXTAREA") && self.input.placeholder && self.input.value === self.input.placeholder ? null : self.input.value);
+      if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
+      var initialDate = self.selectedDates.length > 0 ? self.selectedDates[0] : self.config.minDate && self.config.minDate.getTime() > self.now.getTime() ? self.config.minDate : self.config.maxDate && self.config.maxDate.getTime() < self.now.getTime() ? self.config.maxDate : self.now;
+      self.currentYear = initialDate.getFullYear();
+      self.currentMonth = initialDate.getMonth();
+      if (self.selectedDates.length > 0) self.latestSelectedDateObj = self.selectedDates[0];
+      if (self.config.minTime !== undefined) self.config.minTime = self.parseDate(self.config.minTime, "H:i");
+      if (self.config.maxTime !== undefined) self.config.maxTime = self.parseDate(self.config.maxTime, "H:i");
+      self.minDateHasTime = !!self.config.minDate && (self.config.minDate.getHours() > 0 || self.config.minDate.getMinutes() > 0 || self.config.minDate.getSeconds() > 0);
+      self.maxDateHasTime = !!self.config.maxDate && (self.config.maxDate.getHours() > 0 || self.config.maxDate.getMinutes() > 0 || self.config.maxDate.getSeconds() > 0);
+      Object.defineProperty(self, "showTimeInput", {
+        get: function get() {
+          return self._showTimeInput;
+        },
+        set: function set(bool) {
+          self._showTimeInput = bool;
+          if (self.calendarContainer) toggleClass(self.calendarContainer, "showTimeInput", bool);
+          self.isOpen && positionCalendar();
+        }
+      });
+    }
+
+    function setupInputs() {
+      self.input = self.config.wrap ? element.querySelector("[data-input]") : element;
+
+      if (!self.input) {
+        self.config.errorHandler(new Error("Invalid input element specified"));
+        return;
+      }
+
+      self.input._type = self.input.type;
+      self.input.type = "text";
+      self.input.classList.add("flatpickr-input");
+      self._input = self.input;
+
+      if (self.config.altInput) {
+        self.altInput = createElement(self.input.nodeName, self.input.className + " " + self.config.altInputClass);
+        self._input = self.altInput;
+        self.altInput.placeholder = self.input.placeholder;
+        self.altInput.disabled = self.input.disabled;
+        self.altInput.required = self.input.required;
+        self.altInput.tabIndex = self.input.tabIndex;
+        self.altInput.type = "text";
+        self.input.setAttribute("type", "hidden");
+        if (!self.config.static && self.input.parentNode) self.input.parentNode.insertBefore(self.altInput, self.input.nextSibling);
+      }
+
+      if (!self.config.allowInput) self._input.setAttribute("readonly", "readonly");
+      self._positionElement = self.config.positionElement || self._input;
+    }
+
+    function setupMobile() {
+      var inputType = self.config.enableTime ? self.config.noCalendar ? "time" : "datetime-local" : "date";
+      self.mobileInput = createElement("input", self.input.className + " flatpickr-mobile");
+      self.mobileInput.step = self.input.getAttribute("step") || "any";
+      self.mobileInput.tabIndex = 1;
+      self.mobileInput.type = inputType;
+      self.mobileInput.disabled = self.input.disabled;
+      self.mobileInput.required = self.input.required;
+      self.mobileInput.placeholder = self.input.placeholder;
+      self.mobileFormatStr = inputType === "datetime-local" ? "Y-m-d\\TH:i:S" : inputType === "date" ? "Y-m-d" : "H:i:S";
+
+      if (self.selectedDates.length > 0) {
+        self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(self.selectedDates[0], self.mobileFormatStr);
+      }
+
+      if (self.config.minDate) self.mobileInput.min = self.formatDate(self.config.minDate, "Y-m-d");
+      if (self.config.maxDate) self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
+      self.input.type = "hidden";
+      if (self.altInput !== undefined) self.altInput.type = "hidden";
+
+      try {
+        if (self.input.parentNode) self.input.parentNode.insertBefore(self.mobileInput, self.input.nextSibling);
+      } catch (_a) {}
+
+      bind(self.mobileInput, "change", function (e) {
+        self.setDate(e.target.value, false, self.mobileFormatStr);
+        triggerEvent("onChange");
+        triggerEvent("onClose");
+      });
+    }
+
+    function toggle(e) {
+      if (self.isOpen === true) return self.close();
+      self.open(e);
+    }
+
+    function triggerEvent(event, data) {
+      if (self.config === undefined) return;
+      var hooks = self.config[event];
+
+      if (hooks !== undefined && hooks.length > 0) {
+        for (var i = 0; hooks[i] && i < hooks.length; i++) {
+          hooks[i](self.selectedDates, self.input.value, self, data);
+        }
+      }
+
+      if (event === "onChange") {
+        self.input.dispatchEvent(createEvent("change"));
+        self.input.dispatchEvent(createEvent("input"));
+      }
+    }
+
+    function createEvent(name) {
+      var e = document.createEvent("Event");
+      e.initEvent(name, true, true);
+      return e;
+    }
+
+    function isDateSelected(date) {
+      for (var i = 0; i < self.selectedDates.length; i++) {
+        if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
+      }
+
+      return false;
+    }
+
+    function isDateInRange(date) {
+      if (self.config.mode !== "range" || self.selectedDates.length < 2) return false;
+      return compareDates(date, self.selectedDates[0]) >= 0 && compareDates(date, self.selectedDates[1]) <= 0;
+    }
+
+    function updateNavigationCurrentMonth() {
+      if (self.config.noCalendar || self.isMobile || !self.monthNav) return;
+      self.yearElements.forEach(function (yearElement, i) {
+        var d = new Date(self.currentYear, self.currentMonth, 1);
+        d.setMonth(self.currentMonth + i);
+        self.monthElements[i].textContent = monthToStr(d.getMonth(), self.config.shorthandCurrentMonth, self.l10n) + " ";
+        yearElement.value = d.getFullYear().toString();
+      });
+      self._hidePrevMonthArrow = self.config.minDate !== undefined && (self.currentYear === self.config.minDate.getFullYear() ? self.currentMonth <= self.config.minDate.getMonth() : self.currentYear < self.config.minDate.getFullYear());
+      self._hideNextMonthArrow = self.config.maxDate !== undefined && (self.currentYear === self.config.maxDate.getFullYear() ? self.currentMonth + 1 > self.config.maxDate.getMonth() : self.currentYear > self.config.maxDate.getFullYear());
+    }
+
+    function getDateStr(format) {
+      return self.selectedDates.map(function (dObj) {
+        return self.formatDate(dObj, format);
+      }).filter(function (d, i, arr) {
+        return self.config.mode !== "range" || self.config.enableTime || arr.indexOf(d) === i;
+      }).join(self.config.mode !== "range" ? self.config.conjunction : self.l10n.rangeSeparator);
+    }
+
+    function updateValue(triggerChange) {
+      if (triggerChange === void 0) {
+        triggerChange = true;
+      }
+
+      if (self.selectedDates.length === 0) return self.clear(triggerChange);
+
+      if (self.mobileInput !== undefined && self.mobileFormatStr) {
+        self.mobileInput.value = self.latestSelectedDateObj !== undefined ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr) : "";
+      }
+
+      self.input.value = getDateStr(self.config.dateFormat);
+
+      if (self.altInput !== undefined) {
+        self.altInput.value = getDateStr(self.config.altFormat);
+      }
+
+      if (triggerChange !== false) triggerEvent("onValueUpdate");
+    }
+
+    function onMonthNavClick(e) {
+      e.preventDefault();
+      var isPrevMonth = self.prevMonthNav.contains(e.target);
+      var isNextMonth = self.nextMonthNav.contains(e.target);
+
+      if (isPrevMonth || isNextMonth) {
+        changeMonth(isPrevMonth ? -1 : 1);
+      } else if (self.yearElements.indexOf(e.target) >= 0) {
+        e.target.select();
+      } else if (e.target.classList.contains("arrowUp")) {
+        self.changeYear(self.currentYear + 1);
+      } else if (e.target.classList.contains("arrowDown")) {
+        self.changeYear(self.currentYear - 1);
+      }
+    }
+
+    function timeWrapper(e) {
+      e.preventDefault();
+      var isKeyDown = e.type === "keydown",
+          input = e.target;
+
+      if (self.amPM !== undefined && e.target === self.amPM) {
+        self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
+      }
+
+      var min = parseFloat(input.getAttribute("data-min")),
+          max = parseFloat(input.getAttribute("data-max")),
+          step = parseFloat(input.getAttribute("data-step")),
+          curValue = parseInt(input.value, 10),
+          delta = e.delta || (isKeyDown ? e.which === 38 ? 1 : -1 : 0);
+      var newValue = curValue + step * delta;
+
+      if (typeof input.value !== "undefined" && input.value.length === 2) {
+        var isHourElem = input === self.hourElement,
+            isMinuteElem = input === self.minuteElement;
+
+        if (newValue < min) {
+          newValue = max + newValue + int(!isHourElem) + (int(isHourElem) && int(!self.amPM));
+          if (isMinuteElem) incrementNumInput(undefined, -1, self.hourElement);
+        } else if (newValue > max) {
+          newValue = input === self.hourElement ? newValue - max - int(!self.amPM) : min;
+          if (isMinuteElem) incrementNumInput(undefined, 1, self.hourElement);
+        }
+
+        if (self.amPM && isHourElem && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) {
+          self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
+        }
+
+        input.value = pad(newValue);
+      }
+    }
+
+    init();
+    return self;
+  }
+
+  function _flatpickr(nodeList, config) {
+    var nodes = Array.prototype.slice.call(nodeList);
+    var instances = [];
+
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+
+      try {
+        if (node.getAttribute("data-fp-omit") !== null) continue;
+
+        if (node._flatpickr !== undefined) {
+          node._flatpickr.destroy();
+
+          node._flatpickr = undefined;
+        }
+
+        node._flatpickr = FlatpickrInstance(node, config || {});
+        instances.push(node._flatpickr);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    return instances.length === 1 ? instances[0] : instances;
+  }
+
+  if (typeof HTMLElement !== "undefined") {
+    HTMLCollection.prototype.flatpickr = NodeList.prototype.flatpickr = function (config) {
+      return _flatpickr(this, config);
+    };
+
+    HTMLElement.prototype.flatpickr = function (config) {
+      return _flatpickr([this], config);
+    };
+  }
+
+  var flatpickr = function flatpickr(selector, config) {
+    if (selector instanceof NodeList) return _flatpickr(selector, config);else if (typeof selector === "string") return _flatpickr(window.document.querySelectorAll(selector), config);
+    return _flatpickr([selector], config);
+  };
+
+  flatpickr.defaultConfig = defaults;
+  flatpickr.l10ns = {
+    en: Object.assign({}, english),
+    default: Object.assign({}, english)
+  };
+
+  flatpickr.localize = function (l10n) {
+    flatpickr.l10ns.default = Object.assign({}, flatpickr.l10ns.default, l10n);
+  };
+
+  flatpickr.setDefaults = function (config) {
+    flatpickr.defaultConfig = Object.assign({}, flatpickr.defaultConfig, config);
+  };
+
+  flatpickr.parseDate = createDateParser({});
+  flatpickr.formatDate = createDateFormatter({});
+  flatpickr.compareDates = compareDates;
+
+  if (typeof jQuery !== "undefined") {
+    jQuery.fn.flatpickr = function (config) {
+      return _flatpickr(this, config);
+    };
+  }
+
+  Date.prototype.fp_incr = function (days) {
+    return new Date(this.getFullYear(), this.getMonth(), this.getDate() + (typeof days === "string" ? parseInt(days, 10) : days));
+  };
+
+  if (typeof window !== "undefined") {
+    window.flatpickr = flatpickr;
+  }
+
+  return flatpickr;
 });
 
 /***/ }),
@@ -25462,10 +25533,6 @@ var VPosts = function (_VBase) {
 
             if (paramCount < 1) {
                 console.warn('Creating request with no data!' + ' Are you sure you\'ve hooked everything up correctly?');
-            } else {
-                // log dupes:
-                // TODO: remove me (debug)
-                console.table(Array.from(formData));
             }
 
             var httpRequest = new XMLHttpRequest();

--- a/public/wc.js
+++ b/public/wc.js
@@ -25420,9 +25420,6 @@ var VPosts = function (_VBase) {
 
                     formData.append(_name, Object(__WEBPACK_IMPORTED_MODULE_3__encode__["a" /* encode */])(_value));
                 }
-
-                // log dupes:
-                // TODO: remove me (debug)
             } catch (err) {
                 _didIteratorError2 = true;
                 _iteratorError2 = err;
@@ -25438,40 +25435,14 @@ var VPosts = function (_VBase) {
                 }
             }
 
-            var _iteratorNormalCompletion3 = true;
-            var _didIteratorError3 = false;
-            var _iteratorError3 = undefined;
-
-            try {
-                for (var _iterator3 = formData[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-                    var _ref5 = _step3.value;
-
-                    var _ref6 = _slicedToArray(_ref5, 2);
-
-                    var k = _ref6[0];
-                    var v = _ref6[1];
-
-                    console.log(k + ': ' + v);
-                }
-            } catch (err) {
-                _didIteratorError3 = true;
-                _iteratorError3 = err;
-            } finally {
-                try {
-                    if (!_iteratorNormalCompletion3 && _iterator3.return) {
-                        _iterator3.return();
-                    }
-                } finally {
-                    if (_didIteratorError3) {
-                        throw _iteratorError3;
-                    }
-                }
-            }
-
             var paramCount = Array.from(formData).length;
 
             if (paramCount < 1) {
                 console.warn('Creating request with no data!' + ' Are you sure you\'ve hooked everything up correctly?');
+            } else {
+                // log dupes:
+                // TODO: remove me (debug)
+                console.table(Array.from(formData));
             }
 
             var httpRequest = new XMLHttpRequest();
@@ -25483,11 +25454,20 @@ var VPosts = function (_VBase) {
             }
 
             var snackbarCallback = function snackbarCallback(contentType, response) {
-                var snackbar = root.querySelector('.mdc-snackbar').vComponent;
-                if (contentType && contentType.indexOf('application/json') !== -1) {
+                var element = root.querySelector('.mdc-snackbar');
+
+                if (!(element && element.vComponent)) {
+                    return;
+                }
+
+                var snackbar = element.vComponent;
+
+                if (contentType && contentType.includes('application/json')) {
                     var messages = JSON.parse(response).messages;
-                    if (snackbar && messages && messages.snackbar) {
+
+                    if (messages && messages.snackbar) {
                         var message = messages.snackbar.join('<br/>');
+
                         if (message !== '') {
                             snackbar.display(message);
                         }
@@ -25542,63 +25522,63 @@ var VPosts = function (_VBase) {
 
                 var configHeaders = __WEBPACK_IMPORTED_MODULE_1__config__["a" /* default */].get('request.headers.POST', {});
 
-                var _iteratorNormalCompletion4 = true;
-                var _didIteratorError4 = false;
-                var _iteratorError4 = undefined;
+                var _iteratorNormalCompletion3 = true;
+                var _didIteratorError3 = false;
+                var _iteratorError3 = undefined;
 
                 try {
-                    for (var _iterator4 = Object.entries(configHeaders)[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
-                        var _ref7 = _step4.value;
+                    for (var _iterator3 = Object.entries(configHeaders)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                        var _ref5 = _step3.value;
 
-                        var _ref8 = _slicedToArray(_ref7, 2);
+                        var _ref6 = _slicedToArray(_ref5, 2);
 
-                        var key = _ref8[0];
-                        var _value2 = _ref8[1];
+                        var key = _ref6[0];
+                        var _value2 = _ref6[1];
 
                         httpRequest.setRequestHeader(key, _value2);
                     }
                 } catch (err) {
-                    _didIteratorError4 = true;
-                    _iteratorError4 = err;
+                    _didIteratorError3 = true;
+                    _iteratorError3 = err;
                 } finally {
                     try {
-                        if (!_iteratorNormalCompletion4 && _iterator4.return) {
-                            _iterator4.return();
+                        if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                            _iterator3.return();
                         }
                     } finally {
-                        if (_didIteratorError4) {
-                            throw _iteratorError4;
+                        if (_didIteratorError3) {
+                            throw _iteratorError3;
                         }
                     }
                 }
 
                 if (callHeaders) {
-                    var _iteratorNormalCompletion5 = true;
-                    var _didIteratorError5 = false;
-                    var _iteratorError5 = undefined;
+                    var _iteratorNormalCompletion4 = true;
+                    var _didIteratorError4 = false;
+                    var _iteratorError4 = undefined;
 
                     try {
-                        for (var _iterator5 = Object.entries(callHeaders)[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
-                            var _ref9 = _step5.value;
+                        for (var _iterator4 = Object.entries(callHeaders)[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                            var _ref7 = _step4.value;
 
-                            var _ref10 = _slicedToArray(_ref9, 2);
+                            var _ref8 = _slicedToArray(_ref7, 2);
 
-                            var _key = _ref10[0];
-                            var _value3 = _ref10[1];
+                            var _key = _ref8[0];
+                            var _value3 = _ref8[1];
 
                             httpRequest.setRequestHeader(_key, _value3);
                         }
                     } catch (err) {
-                        _didIteratorError5 = true;
-                        _iteratorError5 = err;
+                        _didIteratorError4 = true;
+                        _iteratorError4 = err;
                     } finally {
                         try {
-                            if (!_iteratorNormalCompletion5 && _iterator5.return) {
-                                _iterator5.return();
+                            if (!_iteratorNormalCompletion4 && _iterator4.return) {
+                                _iterator4.return();
                             }
                         } finally {
-                            if (_didIteratorError5) {
-                                throw _iteratorError5;
+                            if (_didIteratorError4) {
+                                throw _iteratorError4;
                             }
                         }
                     }

--- a/views/mdc/assets/js/components/base-container.js
+++ b/views/mdc/assets/js/components/base-container.js
@@ -3,7 +3,6 @@ import {VBaseComponent} from './base-component';
 export class VBaseContainer extends VBaseComponent {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
-        element.dataset.isContainer = true;
     }
 
     inputs() {

--- a/views/mdc/assets/js/components/content.js
+++ b/views/mdc/assets/js/components/content.js
@@ -10,5 +10,6 @@ export function initContent(e) {
 export class VContent extends eventHandlerMixin(VBaseContainer) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
+        element.setAttribute('data-is-container', '');
     }
 }

--- a/views/mdc/assets/js/components/events/base.js
+++ b/views/mdc/assets/js/components/events/base.js
@@ -70,7 +70,7 @@ export class VBase extends VUrls {
             else if (!comp.respondTo('inputs')) {
                 // Defer to the component's closest content container if the
                 // component itself does not respond to `inputs`:
-                comp = this.closestContent();
+                comp = this.closestContainer();
             }
         }
 
@@ -127,8 +127,8 @@ export class VBase extends VUrls {
         return [];
     }
 
-    closestContent() {
-        const element = this.closestContentElement();
+    closestContainer() {
+        const element = this.closestContainerElement();
 
         if (!element) {
             return null;
@@ -137,13 +137,13 @@ export class VBase extends VUrls {
         return element.vComponent;
     }
 
-    closestContentElement() {
+    closestContainerElement() {
         const comp = this.component();
 
         if (!(comp && comp.element)) {
             return null;
         }
 
-        return comp.element.closest('.v-content');
+        return comp.element.closest('[data-is-container]');
     }
 }

--- a/views/mdc/assets/js/components/events/posts.js
+++ b/views/mdc/assets/js/components/events/posts.js
@@ -58,11 +58,6 @@ export class VPosts extends VBase {
                 + ' Are you sure you\'ve hooked everything up correctly?'
             );
         }
-        else {
-            // log dupes:
-            // TODO: remove me (debug)
-            console.table(Array.from(formData));
-        }
 
         const httpRequest = new XMLHttpRequest();
         const url = this.url;

--- a/views/mdc/assets/js/components/events/posts.js
+++ b/views/mdc/assets/js/components/events/posts.js
@@ -50,12 +50,6 @@ export class VPosts extends VBase {
             formData.append(name, encode(value));
         }
 
-        // log dupes:
-        // TODO: remove me (debug)
-        for (const [k, v] of formData) {
-            console.log(`${k}: ${v}`);
-        }
-
         const paramCount = Array.from(formData).length;
 
         if (paramCount < 1) {
@@ -63,6 +57,11 @@ export class VPosts extends VBase {
                 'Creating request with no data!'
                 + ' Are you sure you\'ve hooked everything up correctly?'
             );
+        }
+        else {
+            // log dupes:
+            // TODO: remove me (debug)
+            console.table(Array.from(formData));
         }
 
         const httpRequest = new XMLHttpRequest();

--- a/views/mdc/assets/js/components/events/posts.js
+++ b/views/mdc/assets/js/components/events/posts.js
@@ -74,12 +74,21 @@ export class VPosts extends VBase {
                 'Cannot talk to server! Please upgrade your browser to one that supports XMLHttpRequest.');
         }
 
-        let snackbarCallback = function(contentType, response) {
-            const snackbar = root.querySelector('.mdc-snackbar').vComponent;
-            if (contentType && contentType.indexOf('application/json') !== -1) {
+        const snackbarCallback = function(contentType, response) {
+            const element = root.querySelector('.mdc-snackbar');
+
+            if (!(element && element.vComponent)) {
+                return;
+            }
+
+            const snackbar = element.vComponent;
+
+            if (contentType && contentType.includes('application/json')) {
                 const messages = JSON.parse(response).messages;
-                if (snackbar && messages && messages.snackbar) {
+
+                if (messages && messages.snackbar) {
                     const message = messages.snackbar.join('<br/>');
+
                     if (message !== '') {
                         snackbar.display(message);
                     }

--- a/views/mdc/components/card.erb
+++ b/views/mdc/components/card.erb
@@ -8,7 +8,7 @@
          <%= "height: #{comp.height};" if comp.height%>
        <%= "outline: medium solid rgb(63,81,181);" if comp.selected %>"
      <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} %>
->
+     data-is-conatiner>
   <% if comp.media %>
     <div class="v-errors">
       <div id="<%=comp.media.id%>"

--- a/views/mdc/components/dialog.erb
+++ b/views/mdc/components/dialog.erb
@@ -18,14 +18,14 @@
          <% if comp.width || comp.height %>
               style="<%= "width: #{comp.width.to_i.to_s == comp.width ? comp.width + 'px' : comp.width}; " if comp.width %>
                 <%= "height: #{comp.height.to_i.to_s == comp.height ? comp.height + 'px' : comp.height}; " if comp.height %>"
-        <% end %>
+        <% end %>>
 
       <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
       <% if comp.title %>
-        <h2 class="mdc-dialog__title" id="my-dialog-title"><%= expand_text(comp.title.text) %></h2>
+        <h2 class="mdc-dialog__title"><%= expand_text(comp.title.text) %></h2>
       <% end %>
 
-      <div class="mdc-dialog__content" id="my-dialog-content">
+      <div class="mdc-dialog__content">
         <div class="v-errors">
           <% if forms.size == 1 %>
             <form role="form"

--- a/views/mdc/components/dialog.erb
+++ b/views/mdc/components/dialog.erb
@@ -12,7 +12,8 @@
      role="alertdialog"
      aria-modal="true"
      aria-labelledby="my-dialog-title"
-     aria-describedby="my-dialog-content">
+     aria-describedby="my-dialog-content"
+     data-is-container>
   <div class="mdc-dialog__container">
     <div class="mdc-dialog__surface"
          <% if comp.width || comp.height %>

--- a/views/mdc/components/dialog.erb
+++ b/views/mdc/components/dialog.erb
@@ -11,8 +11,8 @@
      class="v-dialog mdc-dialog"
      role="alertdialog"
      aria-modal="true"
-     aria-labelledby="my-dialog-title"
-     aria-describedby="my-dialog-content"
+     aria-labelledby="<%= comp.id %>-title"
+     aria-describedby="<%= comp.id %>-content"
      data-is-container>
   <div class="mdc-dialog__container">
     <div class="mdc-dialog__surface"
@@ -23,10 +23,10 @@
 
       <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
       <% if comp.title %>
-        <h2 class="mdc-dialog__title"><%= expand_text(comp.title.text) %></h2>
+        <h2 class="mdc-dialog__title" id="<%= comp.id %>-title"><%= expand_text(comp.title.text) %></h2>
       <% end %>
 
-      <div class="mdc-dialog__content">
+      <div class="mdc-dialog__content" id="<%= comp.id %>-content">
         <div class="v-errors">
           <% if forms.size == 1 %>
             <form role="form"

--- a/views/mdc/components/form.erb
+++ b/views/mdc/components/form.erb
@@ -15,7 +15,8 @@
       class="v-form"
       style='width: 100%'
       onsubmit="javascript:void(0);return false;"
-      <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} %>>
+      <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} %>
+      data-is-container>
   <div class="v-errors">
     <%= erb :"components/render", :locals => {:components => comp.components.select {|c| !eq(c.type, :button)}, :scope => nil} %>
     <% if buttons?(comp.components) %>


### PR DESCRIPTION
* Refactor base event input value collection
  * Collected components are now more eagerly resolved to elements, and the resulting array of elements is deduplicated.
* Stop flagging grid and column as containers
* Flag cards and forms as containers
* Add missing `null` check for snackbar component usage
* Small dialog fixes

As of this PR, only the following components are considered containers:
* content
* form
* dialog
* card