### PR TITLE
Fix dirty state of the rich text area component

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -67296,6 +67296,8 @@ var VRichTextArea = function (_eventHandlerMixin) {
             placeholder: _this.quillEditorElement.dataset.placeholder
 
         });
+
+        _this.element.dataset.originalValue = _this.value();
         return _this;
     }
 

--- a/public/wc.js
+++ b/public/wc.js
@@ -53205,6 +53205,8 @@ var VRichTextArea = function (_eventHandlerMixin) {
             placeholder: _this.quillEditorElement.dataset.placeholder
 
         });
+
+        _this.element.dataset.originalValue = _this.value();
         return _this;
     }
 

--- a/views/mdc/assets/js/components/rich-text-area.js
+++ b/views/mdc/assets/js/components/rich-text-area.js
@@ -40,6 +40,8 @@ export class VRichTextArea extends eventHandlerMixin(VBaseComponent) {
             placeholder: this.quillEditorElement.dataset.placeholder
 
         });
+
+        this.element.dataset.originalValue = this.value();
     }
 
     prepareSubmit(params) {


### PR DESCRIPTION
Upon initialization, the value of the rich text area's `data-original-value` attribute will now be set to the component's value, which is the same value used for comparison by `VRichTextArea .isDirty()`.

This change should mitigate invisible HTML differences between the initial value and what the Quill editor renders into the component's DOM.