### PR TITLE
Actually disable switches when set as such so they can't be toggled

### DIFF
--- a/views/mdc/components/switch.erb
+++ b/views/mdc/components/switch.erb
@@ -21,6 +21,7 @@
                <% if comp.value %>value="<%= comp.value %>"<% end %>
                data-off="<%= comp.off_value %>"
                <%= ' checked ' if comp.checked %>
+               <%= ' disabled ' if comp.disabled %>
                <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} %>/>
       </div>
     </div>


### PR DESCRIPTION
Clicking on the label of a disabled switch was toggling it because it
was only styled as disabled