### PR TITLE
Conditionally include root when hooking up components

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -162,17 +162,42 @@ var VBaseComponent = function () {
 }();
 
 function hookupComponents(root, selector, VoomClass, MdcClass) {
-    var components = root.querySelectorAll(selector);
-    for (var i = 0; i < components.length; i++) {
-        var component = components[i];
-        if (!component.mdcComponent) {
-            var mdcInstance = null;
-            if (MdcClass != null) {
-                mdcInstance = new MdcClass(component);
+    var components = Array.from(root.querySelectorAll(selector));
+
+    if (root && typeof root.matches === 'function' && root.matches(selector)) {
+        components.unshift(root);
+    }
+
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+        for (var _iterator = components[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var component = _step.value;
+
+            if (component.mdcComponent) {
+                continue;
             }
+
+            var mdcInstance = typeof MdcClass === 'function' ? new MdcClass(component) : null;
+
             if (!component.vComponent) {
                 component.vComponent = new VoomClass(component, mdcInstance, root);
                 component.vComponent.root = root;
+            }
+        }
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator.return) {
+                _iterator.return();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
             }
         }
     }

--- a/public/wc.js
+++ b/public/wc.js
@@ -114,17 +114,42 @@ var VBaseComponent = function () {
 }();
 
 function hookupComponents(root, selector, VoomClass, MdcClass) {
-    var components = root.querySelectorAll(selector);
-    for (var i = 0; i < components.length; i++) {
-        var component = components[i];
-        if (!component.mdcComponent) {
-            var mdcInstance = null;
-            if (MdcClass != null) {
-                mdcInstance = new MdcClass(component);
+    var components = Array.from(root.querySelectorAll(selector));
+
+    if (root && typeof root.matches === 'function' && root.matches(selector)) {
+        components.unshift(root);
+    }
+
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+        for (var _iterator = components[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var component = _step.value;
+
+            if (component.mdcComponent) {
+                continue;
             }
+
+            var mdcInstance = typeof MdcClass === 'function' ? new MdcClass(component) : null;
+
             if (!component.vComponent) {
                 component.vComponent = new VoomClass(component, mdcInstance, root);
                 component.vComponent.root = root;
+            }
+        }
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator.return) {
+                _iterator.return();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
             }
         }
     }

--- a/views/mdc/assets/js/components/base-component.js
+++ b/views/mdc/assets/js/components/base-component.js
@@ -28,19 +28,24 @@ export class VBaseComponent {
 }
 
 export function hookupComponents(root, selector, VoomClass, MdcClass) {
-    const components = root.querySelectorAll(selector);
-    for (let i = 0; i < components.length; i++) {
-        const component = components[i];
-        if (!component.mdcComponent) {
-            let mdcInstance = null;
-            if (MdcClass != null) {
-                mdcInstance = new MdcClass(component);
-            }
-            if (!component.vComponent) {
-                component.vComponent = new VoomClass(component, mdcInstance,
-                    root);
-                component.vComponent.root = root;
-            }
+    const components = Array.from(root.querySelectorAll(selector));
+
+    if (root && typeof root.matches === 'function' && root.matches(selector)) {
+        components.unshift(root);
+    }
+
+    for (const component of components) {
+        if (component.mdcComponent) {
+            continue;
+        }
+
+        const mdcInstance = typeof MdcClass === 'function'
+            ? new MdcClass(component)
+            : null;
+
+        if (!component.vComponent) {
+            component.vComponent = new VoomClass(component, mdcInstance, root);
+            component.vComponent.root = root;
         }
     }
 }

--- a/views/mdc/assets/js/components/events/replaces.js
+++ b/views/mdc/assets/js/components/events/replaces.js
@@ -73,7 +73,7 @@ export class VReplaces extends VBase {
                                     root
                                 ));
 
-                                nodeToReplace.replaceWith(...newNodes)
+                                nodeToReplace.replaceWith(...newNodes);
 
                                 for (const node of newNodes) {
                                     initialize(node);


### PR DESCRIPTION
The removal of the <span> wrapper around a replaced element prevents the
hookupComponents logic from finding the element. If the provided root
matches the provided selector, include the root in the hookup logic.
This ensures the replaced element is properly initialized.