### PR TITLE
Use MDC class instead of sibling selector

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -10082,13 +10082,6 @@ a.mdc-list-item {
   flex-wrap: nowrap;
   box-sizing: border-box; }
 
-.v-header.v-header--fixed + .drawer-main-content {
-  margin-top: 64px; }
-
-@media (max-width: 599px) {
-  .v-header.v-header--fixed + .drawer-main-content {
-    margin-top: 56px; } }
-
 .mdc-drawer {
   border-color: rgba(0, 0, 0, 0.12);
   background-color: #fff;

--- a/views/mdc/assets/scss/components/header.scss
+++ b/views/mdc/assets/scss/components/header.scss
@@ -19,15 +19,3 @@
   flex-wrap: nowrap;
   box-sizing: border-box;
 }
-
-// Since fixed elements reserve no space for themselves in the document, the
-// content area must have additional margin.
-.v-header.v-header--fixed + .drawer-main-content {
-  margin-top: $mdc-top-app-bar-row-height;
-}
-
-@media (max-width: $mdc-top-app-bar-mobile-breakpoint) {
-  .v-header.v-header--fixed + .drawer-main-content {
-    margin-top: $mdc-top-app-bar-mobile-row-height;
-  }
-}

--- a/views/mdc/body/header.erb
+++ b/views/mdc/body/header.erb
@@ -36,3 +36,4 @@
     </section>
   </div>
 </header>
+<% if header.placement == :fixed %><div class="mdc-top-app-bar--fixed-adjust"></div><% end %>

--- a/views/mdc/layout.erb
+++ b/views/mdc/layout.erb
@@ -27,10 +27,7 @@
   root_classes << 'v-root--header-present' if header
   root_classes << 'v-root--drawer-present' if drawer
   root_classes << 'v-root--footer-present' if footer
-
-  drawer_wrapper_class = drawer ? 'drawer-main-content' : 'mdc-top-app-bar--fixed-adjust'
 %>
-
 <div class="v-root compatibility-wrapper <%= root_classes.join(' ') %>">
 
 <% if drawer %>
@@ -41,8 +38,8 @@
 <% if header %>
   <%= erb :"body/header", :locals => {header:header, drawer: drawer} %>
 <% end %>
-  <div class="<%= drawer_wrapper_class %>">
   <% if drawer %>
+    <div class="drawer-main-content">
       <%= erb :"body/modal-drawer", :locals => {drawer: drawer} %>
   <% end %>
 <div class="v-page-content page-content">
@@ -50,8 +47,8 @@
     <%= yield %>
   </div>
 </div>
-    </div>
 <% if drawer %>
+    </div>
   </div>
 </div>
 <% end %>


### PR DESCRIPTION
This fixes and issue which incorrectly padded the top of the main content area in the absence of both a drawer and a header.