### PR TITLE
Revert container classification behavior

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -1633,7 +1633,6 @@ var VBaseContainer = function (_VBaseComponent) {
 
         var _this = _possibleConstructorReturn(this, (VBaseContainer.__proto__ || Object.getPrototypeOf(VBaseContainer)).call(this, element, mdcComponent));
 
-        element.dataset.isContainer = true;
         _this.element.classList.add('v-container');
         return _this;
     }
@@ -89246,10 +89245,7 @@ var VContent = function (_eventHandlerMixin) {
     function VContent(element, mdcComponent) {
         _classCallCheck(this, VContent);
 
-        var _this = _possibleConstructorReturn(this, (VContent.__proto__ || Object.getPrototypeOf(VContent)).call(this, element, mdcComponent));
-
-        element.setAttribute('data-is-container', '');
-        return _this;
+        return _possibleConstructorReturn(this, (VContent.__proto__ || Object.getPrototypeOf(VContent)).call(this, element, mdcComponent));
     }
 
     return VContent;

--- a/public/wc.js
+++ b/public/wc.js
@@ -346,7 +346,6 @@ var VBaseContainer = function (_VBaseComponent) {
 
         var _this = _possibleConstructorReturn(this, (VBaseContainer.__proto__ || Object.getPrototypeOf(VBaseContainer)).call(this, element, mdcComponent));
 
-        element.dataset.isContainer = true;
         _this.element.classList.add('v-container');
         return _this;
     }
@@ -74689,10 +74688,7 @@ var VContent = function (_eventHandlerMixin) {
     function VContent(element, mdcComponent) {
         _classCallCheck(this, VContent);
 
-        var _this = _possibleConstructorReturn(this, (VContent.__proto__ || Object.getPrototypeOf(VContent)).call(this, element, mdcComponent));
-
-        element.setAttribute('data-is-container', '');
-        return _this;
+        return _possibleConstructorReturn(this, (VContent.__proto__ || Object.getPrototypeOf(VContent)).call(this, element, mdcComponent));
     }
 
     return VContent;

--- a/views/mdc/assets/js/components/base-container.js
+++ b/views/mdc/assets/js/components/base-container.js
@@ -3,7 +3,6 @@ import {VBaseComponent} from './base-component';
 export class VBaseContainer extends VBaseComponent {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
-        element.dataset.isContainer = true;
         this.element.classList.add('v-container');
     }
 

--- a/views/mdc/assets/js/components/content.js
+++ b/views/mdc/assets/js/components/content.js
@@ -10,6 +10,5 @@ export function initContent(e) {
 export class VContent extends eventHandlerMixin(VBaseContainer) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
-        element.setAttribute('data-is-container', '');
     }
 }

--- a/views/mdc/components/content.erb
+++ b/views/mdc/components/content.erb
@@ -14,7 +14,8 @@
        style="text-align: <%= comp.text_align %>;
              <%= "display: inline;" if comp.inline %>
              <%= "width: #{comp.width};" if comp.width %>
-             <%= "height : #{comp.height };" if comp.height  %>">
+             <%= "height : #{comp.height };" if comp.height  %>"
+       data-is-container>
     <%= erb(:"components/progress", :locals => {:comp => comp.progress}) if comp.progress && includes_one?(Array(comp.progress.position), %i(top both)) %>
     <% if comp.shows_errors %>
       <div class="v-errors">


### PR DESCRIPTION
This reverts the behavior of container classification to the state in f5d7c42.

At some point, the change in [f5d7c42](https://github.com/rx/presenters/commit/f5d7c429d787dfad110bfaf9903c0ab1fa7dddad#diff-18b58a6e1672a9752936c059ab3013c9L6) was reverted and the removed line was added back in, causing columns and grid to incorrectly be classified as containers for request payload collection purposes. This results in events which collect input values collecting far too many input values.