### PR TITLE
Add link component

### DIFF
--- a/app/demo/styles.pom
+++ b/app/demo/styles.pom
@@ -34,6 +34,8 @@ Voom::Presenters.define(:styles) do
     separator
     body 'Line above me is a separator'
     link 'You can have a link', 'https://www.google.com/search?q=link&source=lnms&tbm=isch&sa=X&ved=0ahUKEwipr4zY_JXdAhVNXK0KHWFNCdYQ_AUICigB&biw=1651&bih=932'
+    blank
+    link 'I open in a new tab or window', 'https://example.com', target: :blank
 
   end
   attach :code, file: __FILE__

--- a/lib/voom/presenters/dsl/components/link.rb
+++ b/lib/voom/presenters/dsl/components/link.rb
@@ -1,0 +1,35 @@
+require 'voom/presenters/dsl/components/typography'
+
+module Voom::Presenters::DSL::Components
+  class Link < Typography
+
+    VALID_TARGETS = %i[self blank].freeze
+
+    attr_accessor :url,
+                  :text,
+                  :target
+
+    def initialize(parent:, **attribs_, &block)
+      super(type: :link, parent: parent, **attribs_, &block)
+
+      @url = attribs_.delete(:url)
+      @text = attribs_.delete(:text) { url }
+      @target = validate_target(attribs_.delete(:target) { :self })
+
+      expand!
+    end
+
+    private
+
+    def validate_target(value)
+      target = value&.to_sym
+
+      unless VALID_TARGETS.include?(target)
+        raise Errors::ParameterValidation,
+              "target must be one of #{VALID_TARGETS.join(', ')}"
+      end
+
+      target
+    end
+  end
+end

--- a/lib/voom/presenters/dsl/components/mixins/typography.rb
+++ b/lib/voom/presenters/dsl/components/mixins/typography.rb
@@ -98,8 +98,7 @@ module Voom
             end
 
             def link(text, url, **attributes, &block)
-              self << Components::Typography.new(parent: self, type: :body, text: ["[#{text}](#{url})"],
-                                                 **attributes, &block)
+              self << Components::Link.new(parent: self, text: text, url: url, **attributes, &block)
             end
           end
         end

--- a/views/mdc/components/link.erb
+++ b/views/mdc/components/link.erb
@@ -1,14 +1,4 @@
-<% if link %>
-  <% if preamble %>
-    <a style="color: unset; text-decoration: none;"
-       <% unless link&.replaces %>
-         href ="<%=link.url%>"
-       <% else %>
-         onclick="new VReplaceElement('<%=link&.replaces%>','<%= link.url %>', '<%="grid_nesting=#{@grid_nesting-1}"%>').call()"
-       <% end %>
-    >
-  <% else %>
-    </a>
-  <% end %>
+<% target = "_#{comp.target}" %>
+<% if comp %>
+    <a href="<%= comp.url %>" target="<%= target %>"><%= comp.text %></a>
 <% end %>
-


### PR DESCRIPTION
The link component functions the same as a Markdown hyperlink and additionally allows a value for the `target` attribute to be specified.

Targets `blank` and `self` are supported, which expand to the equivalent HTML attribute value in the web client. The default target is `self`.