### PR TITLE
Toggle buttons for the duration of issued requests

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -33391,7 +33391,15 @@ var VButton = function (_eventHandlerMixin) {
     function VButton(element, mdcComponent) {
         _classCallCheck(this, VButton);
 
-        return _possibleConstructorReturn(this, (VButton.__proto__ || Object.getPrototypeOf(VButton)).call(this, element, mdcComponent));
+        var _this = _possibleConstructorReturn(this, (VButton.__proto__ || Object.getPrototypeOf(VButton)).call(this, element, mdcComponent));
+
+        _this.element.addEventListener('V:postStarted', function (e) {
+            return _this.disable();
+        });
+        _this.element.addEventListener('V:postFinished', function (e) {
+            return _this.enable();
+        });
+        return _this;
     }
 
     _createClass(VButton, [{
@@ -33402,6 +33410,16 @@ var VButton = function (_eventHandlerMixin) {
             } else {
                 console.warn('WARNING: Attempted to preview an image on a Button (id: ' + this.element.id + ') that is NOT an image button.\nMake sure you set the type: :image on the button.');
             }
+        }
+    }, {
+        key: 'disable',
+        value: function disable() {
+            this.element.setAttribute('disabled', 'disabled');
+        }
+    }, {
+        key: 'enable',
+        value: function enable() {
+            this.element.removeAttribute('disabled');
         }
     }, {
         key: 'actionsHalted',

--- a/public/wc.js
+++ b/public/wc.js
@@ -18732,7 +18732,15 @@ var VButton = function (_eventHandlerMixin) {
     function VButton(element, mdcComponent) {
         _classCallCheck(this, VButton);
 
-        return _possibleConstructorReturn(this, (VButton.__proto__ || Object.getPrototypeOf(VButton)).call(this, element, mdcComponent));
+        var _this = _possibleConstructorReturn(this, (VButton.__proto__ || Object.getPrototypeOf(VButton)).call(this, element, mdcComponent));
+
+        _this.element.addEventListener('V:postStarted', function (e) {
+            return _this.disable();
+        });
+        _this.element.addEventListener('V:postFinished', function (e) {
+            return _this.enable();
+        });
+        return _this;
     }
 
     _createClass(VButton, [{
@@ -18743,6 +18751,16 @@ var VButton = function (_eventHandlerMixin) {
             } else {
                 console.warn('WARNING: Attempted to preview an image on a Button (id: ' + this.element.id + ') that is NOT an image button.\nMake sure you set the type: :image on the button.');
             }
+        }
+    }, {
+        key: 'disable',
+        value: function disable() {
+            this.element.setAttribute('disabled', 'disabled');
+        }
+    }, {
+        key: 'enable',
+        value: function enable() {
+            this.element.removeAttribute('disabled');
         }
     }, {
         key: 'actionsHalted',

--- a/views/mdc/assets/js/components/button.js
+++ b/views/mdc/assets/js/components/button.js
@@ -12,6 +12,9 @@ export function initButtons(e) {
 export class VButton extends eventHandlerMixin(VBaseComponent) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
+
+        this.element.addEventListener('V:postStarted', (e) => this.disable());
+        this.element.addEventListener('V:postFinished', (e) => this.enable());
     }
 
     preview(result, acceptsMimeTypes, file) {
@@ -23,6 +26,14 @@ export class VButton extends eventHandlerMixin(VBaseComponent) {
                 `WARNING: Attempted to preview an image on a Button (id: ${this.element.id}) that is NOT an image button.
 Make sure you set the type: :image on the button.`);
         }
+    }
+
+    disable() {
+        this.element.setAttribute('disabled', 'disabled');
+    }
+
+    enable() {
+        this.element.removeAttribute('disabled');
     }
 
     actionsHalted(vEvent) {


### PR DESCRIPTION
Buttons will be unconditionally disabled when a `VPosts`-based request is issued and unconditionally enabled when the issued request has finished.