### PR TITLE
Change autocomplete to off by default

### DIFF
--- a/lib/voom/presenters/dsl/components/text_field.rb
+++ b/lib/voom/presenters/dsl/components/text_field.rb
@@ -14,7 +14,7 @@ module Voom
             @full_width = attribs.delete(:full_width){ true }
             @password = attribs.delete(:password){ false }
             @disabled = attribs.delete(:disabled){ false }
-            @auto_complete = attribs.delete(:auto_complete){ true }
+            @auto_complete = validate_auto_complete(attribs.delete(:auto_complete) { :off })
             label(attribs.delete(:label))if attribs.key?(:label)
             value(attribs.delete(:value))if attribs.key?(:value)
             expand!
@@ -63,6 +63,17 @@ module Voom
                 gsub(/\(\?-\w+:/, '(').
                 gsub(/\s/, '')
             Regexp.new(str).source
+          end
+
+          def validate_auto_complete(value)
+            case value
+            when false, :disabled, 'disabled', 'off', nil
+              :off
+            when true, :enabled, 'enabled', 'on'
+              :on
+            else # :on, :off, client-specific values
+              value
+            end
           end
         end
       end

--- a/views/mdc/components/text_field.erb
+++ b/views/mdc/components/text_field.erb
@@ -1,6 +1,7 @@
 <% if comp
      leading_icon = comp.icon && comp.icon.position.select {|p| eq(p, :left)}.any?
      trailing_icon = comp.icon && comp.icon.position.select {|p| eq(p, :right)}.any?
+     auto_complete = comp.auto_complete&.to_sym == :off ? 'extra-off' : comp.auto_complete
 %>
   <div id="<%= comp.id %>"
        <% if comp.tag %>
@@ -23,7 +24,7 @@
            <%= 'required' if comp.required %>
            <%= 'invalid' if comp.error %>
            <%= "pattern='#{comp.pattern}'" if comp.pattern %>
-           autocomplete="<%= comp.auto_complete ? 'on' : 'off' %>"
+           autocomplete="<%= auto_complete %>"
            list="<%= comp.id %>-list"
            <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id:  "#{comp.id}-input"} %>>
 


### PR DESCRIPTION
* Allow `false`, `:disabled`, and `:off` to specify off
* Allow `true`, `:enabled`, and `:on` to specify on
* Pass through other values to the web client
* Map `auto_complete: :off` to `autocomplete="extra-off"` in the web client to make `:off` behave as expected