### PR TITLE
Update color classes that are added on an icon based on `color` attribute,

### DIFF
--- a/app/demo/components/icons.pom
+++ b/app/demo/components/icons.pom
@@ -45,6 +45,8 @@ Voom::Presenters.define(:icons) do
           icon :thumb_up, color: :primary
           body '**secondary**'
           icon :thumb_up, color: :secondary
+          body '**custom from palette**'
+          icon :thumb_up, color: :red
           body '**custom**'
           icon :thumb_up, color: :hotpink
         end

--- a/lib/voom/presenters/web_client/app.rb
+++ b/lib/voom/presenters/web_client/app.rb
@@ -81,7 +81,8 @@ module Voom
 
           def color_classname(comp)
             return "v-#{comp.type}__primary" if eq(comp.color, :primary)
-            "v-#{comp.type}__secondary" if eq(comp.color, :secondary)
+            return "v-#{comp.type}__secondary" if eq(comp.color, :secondary)
+            "v-color__#{comp.color}"
           end
 
           def color_style(comp, affects = nil)

--- a/public/bundle.css
+++ b/public/bundle.css
@@ -5966,6 +5966,16 @@ h1.v-page-title {
       background-color: #37424a;
       color: #a9b3ba; }
 
+/* Sample palette */
+.v-color__red {
+  color: #FFEBEE !important; }
+
+.v-color__yellow {
+  color: #FFFDE7 !important; }
+
+.v-color__green {
+  color: #E8F5E9 !important; }
+
 @keyframes mdc-ripple-fg-radius-in {
   from {
     animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);

--- a/views/mdc/assets/scss/app.scss
+++ b/views/mdc/assets/scss/app.scss
@@ -1,5 +1,6 @@
 @import 'material.blue_grey-orange.min';
 @import "theme";
+@import "palette";
 
 // MDC
 @import "components/fab";

--- a/views/mdc/assets/scss/palette.scss
+++ b/views/mdc/assets/scss/palette.scss
@@ -1,0 +1,16 @@
+/* Sample palette */
+$palette-colors: (
+  red: #FFEBEE,
+  yellow: #FFFDE7,
+  green: #E8F5E9
+);
+
+@function palette($color) {
+  @return map-get($palette-colors, $color);
+}
+
+@each $name, $color in $palette-colors {
+  .v-color__#{$name} {
+    color: $color !important;
+  }
+}


### PR DESCRIPTION
add sample palette style sheet.

Allows use of `icon :thumbs-up color: [palette-color-name]` or `icon :thumbs-up color: [html-color-name]` and a palette color style will be applied if present.