### PR TITLE
Non-dirtyable list header checkbox

### DIFF
--- a/lib/voom/presenters/dsl/components/input.rb
+++ b/lib/voom/presenters/dsl/components/input.rb
@@ -7,11 +7,14 @@ module Voom
       module Components
         class Input < EventBase
           include Mixins::Tooltips
-          attr_reader :name
+
+          attr_reader :name,
+                      :dirtyable
 
           def initialize(**attribs_, &block)
             super(**attribs_, &block)
             @name = attribs.delete(:name)
+            @dirtyable = attribs.delete(:dirtyable) { true }
           end
         end
       end

--- a/lib/voom/presenters/dsl/components/list.rb
+++ b/lib/voom/presenters/dsl/components/list.rb
@@ -38,7 +38,7 @@ module Voom
             return unless @selectable && !@lines_only
             @lines << Lists::Header.new(parent: self,
                                         total_lines: @total_lines,
-                                        checkbox: {text: text})
+                                        checkbox: {text: text, dirtyable: false})
           end
 
           def line(text=nil, **attribs, &block)

--- a/lib/voom/presenters/dsl/components/lists/line.rb
+++ b/lib/voom/presenters/dsl/components/lists/line.rb
@@ -27,7 +27,7 @@ module Voom
               self.avatar(attribs.delete(:avatar)) if attribs.key?(:avatar)
               self.icon(attribs.delete(:icon)) if attribs.key?(:icon)
               self.checkbox(attribs.delete(:checkbox)) if attribs.key?(:checkbox) && !@selectable
-              self.checkbox(attribs.slice(:name, :value, :checked)) if @selectable
+              self.checkbox(attribs.slice(:name, :value, :checked, :dirtyable)) if @selectable
 
               @actions = []
               expand!

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -63537,6 +63537,11 @@ var VCheckbox = function (_VBaseToggle) {
     _createClass(VCheckbox, [{
         key: 'isDirty',
         value: function isDirty() {
+            // If the checkbox is cannot be dirtied, it is never dirty.
+            if (!this.element.hasAttribute('data-original-value')) {
+                return false;
+            }
+
             return String(this.input.checked) != this.element.dataset.originalValue;
         }
     }]);

--- a/public/wc.js
+++ b/public/wc.js
@@ -48980,6 +48980,11 @@ var VCheckbox = function (_VBaseToggle) {
     _createClass(VCheckbox, [{
         key: 'isDirty',
         value: function isDirty() {
+            // If the checkbox is cannot be dirtied, it is never dirty.
+            if (!this.element.hasAttribute('data-original-value')) {
+                return false;
+            }
+
             return String(this.input.checked) != this.element.dataset.originalValue;
         }
     }]);

--- a/views/mdc/assets/js/components/checkboxes.js
+++ b/views/mdc/assets/js/components/checkboxes.js
@@ -14,6 +14,11 @@ export class VCheckbox extends VBaseToggle {
     }
 
     isDirty() {
+        // If the checkbox is cannot be dirtied, it is never dirty.
+        if (!this.element.hasAttribute('data-original-value')) {
+            return false;
+        }
+
         return String(this.input.checked) != this.element.dataset.originalValue;
     }
 }

--- a/views/mdc/components/checkbox.erb
+++ b/views/mdc/components/checkbox.erb
@@ -1,16 +1,13 @@
 <% class_name = '' unless local_variables.include? :class_name %>
-
 <div class="v-form-field mdc-form-field">
   <div id="<%= comp.id %>"
-       <% if comp.tag %>
-       data-input-tag="<%= comp.tag %>"
-       <% end %>
-       data-original-value="<%=comp.checked%>"
+       <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+       <% if comp.dirtyable %>data-original-value="<%=comp.checked%>"<% end %>
        class="v-checkbox mdc-checkbox v-input">
     <input type="checkbox"
            id="<%= comp.id %>-input"
            name="<%= comp.name %>"
-           data-indeterminate=<%=comp.indeterminate%>
+           data-indeterminate="<%=comp.indeterminate%>"
            <% if comp.value %>value="<%= comp.value %>"<% end %>
            class="mdc-checkbox__native-control
                  <%= class_name %>"

--- a/views/mdc/components/datetime.erb
+++ b/views/mdc/components/datetime.erb
@@ -2,10 +2,8 @@
   time_val = comp.value ? Array([comp.value]).join(', ') : nil
 %>
 <div id="<%= comp.id %>"
-     <% if comp.tag %>
-     data-input-tag="<%= comp.tag %>"
-     <% end %>
-     data-original-value="<%=comp.value%>"
+     <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+     <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
      class="v-input v-datetime mdc-text-field mdc-text-field--outlined
             <%= 'mdc-text-field--with-trailing-icon' if comp.clear_icon %>
             <%= 'mdc-text-field--disabled' if comp.disabled %>

--- a/views/mdc/components/file_input.erb
+++ b/views/mdc/components/file_input.erb
@@ -2,7 +2,7 @@
   <div id="<%= comp.id %>" class="v-input v-file-input"
        data-preview=<%= JSON.generate(Array(comp.preview)) %>
            data-accept="<%= comp.accept %>"
-       data-original-value="<%= comp.value %>"
+       <% if comp.dirtyable %>data-original-value="<%= comp.value %>"<% end %>
 
 
        <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} %>>

--- a/views/mdc/components/hidden_field.erb
+++ b/views/mdc/components/hidden_field.erb
@@ -1,7 +1,5 @@
 <input class="v-input v-hidden-field"
        type="hidden"
-       <% if comp.tag %>
-       data-input-tag="<%= comp.tag %>"
-       <% end %>
-       data-original-value="<%=comp.value%>"
+       <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+       <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
        id="<%= comp.id %>" name="<%= comp.name %>" value="<%= comp.value %>"/>

--- a/views/mdc/components/icon_toggle.erb
+++ b/views/mdc/components/icon_toggle.erb
@@ -11,7 +11,6 @@
    data-toggle-off='{"label": "", "content": "<%= comp.icon  %>", "cssClass": "v-toggle-icon--off"}'
    data-off="<%= comp.off_value %>"
    <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} %>>
-   <input type="checkbox" checked="<%= comp.checked %>" name="<%= comp.name %>" hidden>
   <%= comp.icon  %>
 </i>
 <%= erb :"components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} %>

--- a/views/mdc/components/icon_toggle.erb
+++ b/views/mdc/components/icon_toggle.erb
@@ -11,6 +11,7 @@
    data-toggle-off='{"label": "", "content": "<%= comp.icon  %>", "cssClass": "v-toggle-icon--off"}'
    data-off="<%= comp.off_value %>"
    <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} %>>
+   <input type="checkbox" checked="<%= comp.checked %>" name="<%= comp.name %>" hidden>
   <%= comp.icon  %>
 </i>
 <%= erb :"components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} %>

--- a/views/mdc/components/list/header.erb
+++ b/views/mdc/components/list/header.erb
@@ -5,7 +5,7 @@
   <div class="v-input v-checkbox v-hidden">
     <input class="mdc-checkbox__native-control" type="checkbox" id="select-total" name="all" value="true" data-indeterminate="false"/>
   </div>
-  <%= erb :"components/checkbox", :locals => {:comp => line.checkbox, :class_name => 'v-checkbox--select-control'} if line.checkbox %>
+  <%= erb :"components/checkbox", :locals => {:comp => line.checkbox, :class_name => 'v-checkbox--select-control', :dirtyable => false} if line.checkbox %>
   <span class="mdc-list-item__text">
     <%= expand_text(line.text&.text) %>
 

--- a/views/mdc/components/radio_button.erb
+++ b/views/mdc/components/radio_button.erb
@@ -1,9 +1,7 @@
 <div class="v-form-field mdc-form-field">
   <div id="<%= comp.id %>"
-       <% if comp.tag %>
-       data-input-tag="<%= comp.tag %>"
-       <% end %>
-       data-original-value="<%=comp.checked%>"
+       <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+       <% if comp.dirtyable %>data-original-value="<%=comp.checked%>"<% end %>
        class="v-radio mdc-radio v-input">
     <input class="mdc-radio__native-control"
            type="radio"

--- a/views/mdc/components/rich_text_area.erb
+++ b/views/mdc/components/rich_text_area.erb
@@ -1,9 +1,7 @@
 <div class="v-rich-text-area-container v-input"
      id="<%= comp.id %>"
-     <% if comp.tag %>
-     data-input-tag="<%= comp.tag %>"
-     <% end %>
-     data-original-value="<%=h comp.value%>">
+     <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+     <% if comp.dirtyable %>data-original-value="<%= h(comp.value) %>"><% end %>
   <label for="<%= comp.id %>-rta"><%= expand_text(comp.label) %></label>
   <div class="v-rich-text-area"
        id="<%= comp.id %>-rta"

--- a/views/mdc/components/select.erb
+++ b/views/mdc/components/select.erb
@@ -2,10 +2,8 @@
   float_label = comp.options.select{|o| o.selected }.any?
 %>
   <div class="mdc-select <%= 'mdc-select--outlined' if comp.outlined %> v-select v-input"
-       <% if comp.tag %>
-       data-input-tag="<%= comp.tag %>"
-       <% end %>
-       data-original-value="<%=comp.value%>"
+       <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+       <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
        <%= 'style="width: 100%;"' if comp.full_width %>>
     <i class="mdc-select__dropdown-icon"></i>
     <select id="<%= comp.id %>"

--- a/views/mdc/components/slider.erb
+++ b/views/mdc/components/slider.erb
@@ -11,7 +11,7 @@
      <% if comp.step %>
      data-step="<%= comp.step %>"
      <% end %>
-     data-original-value="<%=comp.value%>"
+     <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
      aria-valuemin="<%= comp.value_min %>"
      aria-valuemax="<%= comp.value_max %>"
      aria-valuenow="<%= comp.value unless comp.value.nil? %>"

--- a/views/mdc/components/switch.erb
+++ b/views/mdc/components/switch.erb
@@ -3,10 +3,8 @@
 
 <div class="v-form-field mdc-form-field">
   <div id="<%= comp.id %>"
-       <% if comp.tag %>
-       data-input-tag="<%= comp.tag %>"
-       <% end %>
-       data-original-value="<%=comp.checked%>"
+       <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+       <% if comp.dirtyable %>data-original-value="<%=comp.checked%>"<% end %>
        class="v-switch v-input mdc-switch
       <%= 'mdc-switch--disabled' if comp.disabled %>
       <%= class_name %>">

--- a/views/mdc/components/text_area.erb
+++ b/views/mdc/components/text_area.erb
@@ -1,9 +1,7 @@
 <div id="<%= comp.id %>" class="v-input v-text-field mdc-text-field mdc-text-field--textarea
             <%= ' is-invalid is-dirty' if comp.error %>"
-     <% if comp.tag %>
-     data-input-tag="<%= comp.tag %>"
-     <% end %>
-     data-original-value="<%=comp.value%>"
+     <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+     <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
      style="<%= 'width:100%' if comp.full_width %>">
   <textarea id="<%= comp.id %>-input"
             name="<%= comp.name %>"

--- a/views/mdc/components/text_field.erb
+++ b/views/mdc/components/text_field.erb
@@ -4,10 +4,8 @@
      auto_complete = comp.auto_complete&.to_sym == :off ? 'extra-off' : comp.auto_complete
 %>
   <div id="<%= comp.id %>"
-       <% if comp.tag %>
-       data-input-tag="<%= comp.tag %>"
-       <% end %>
-       data-original-value="<%=comp.value%>"
+       <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
+       <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
        class="v-input v-text-field v-focusable mdc-text-field mdc-text-field--outlined
             <%= 'mdc-text-field--with-leading-icon' if leading_icon %>
             <%= 'mdc-text-field--with-trailing-icon' if trailing_icon %>


### PR DESCRIPTION
The list header checkbox is rendered as a standard checkbox component, but it should not be considered when checking for dirtied input elements.

Also make all input components optionally dirtyable.