### PR TITLE
Fix icon buttons

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -6986,7 +6986,7 @@ svg.mdc-button__icon {
   height: 32px;
   font-size: .8125rem; }
 
-.v-button-image {
+.v-button.v-button--image {
   width: 150px;
   height: 45px;
   background-color: #fff !important;
@@ -6995,7 +6995,7 @@ svg.mdc-button__icon {
   background-position-x: 18%;
   background-position-y: center;
   border-radius: 10px; }
-  .v-button-image > i {
+  .v-button.v-button--image > i {
     position: absolute;
     margin-right: 0 !important;
     color: #263138; }
@@ -13707,6 +13707,9 @@ select {
 .mdc-linear-progress--indeterminate.mdc-linear-progress--reversed .mdc-linear-progress__secondary-bar {
   right: -54.888891%;
   left: auto; }
+
+.v-tooltip {
+  text-transform: initial; }
 
 .v-expansion {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12); }

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -13335,6 +13335,8 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 
 
+var EVENTS_SELECTOR = '[data-events]';
+
 var VEvents = function () {
     // [[type, url, target, params]]
     function VEvents(actions, event, root, vComponent) {
@@ -13464,59 +13466,109 @@ function createEventHandler(actionsData, root, vComponent) {
     };
 }
 
+function getEventElements(root) {
+    var elements = Array.from(root.querySelectorAll(EVENTS_SELECTOR));
+
+    // Include `root` if it has events:
+    if (typeof root.matches === 'function' && root.matches(EVENTS_SELECTOR)) {
+        elements.unshift(root);
+    }
+
+    return elements;
+}
+
 function initEvents(e) {
     console.debug('\tEvents');
 
-    var events = e.querySelectorAll('[data-events]');
-    for (var i = 0; i < events.length; i++) {
-        var eventElem = events[i];
-        var eventsData = JSON.parse(eventElem.dataset.events);
-        for (var j = 0; j < eventsData.length; j++) {
-            var eventData = eventsData[j];
-            var eventName = eventData[0];
-            var eventOptions = eventData[2];
-            eventOptions.passive = true;
-            var actionsData = eventData[1];
-            var vComponent = eventElem.vComponent;
-            var eventHandler = createEventHandler(actionsData, Object(__WEBPACK_IMPORTED_MODULE_13__root_document__["a" /* default */])(e), vComponent);
-            // allow override of event handler by component
-            if (vComponent && vComponent.createEventHandler) {
-                eventHandler = vComponent.createEventHandler(actionsData, Object(__WEBPACK_IMPORTED_MODULE_13__root_document__["a" /* default */])(e), vComponent);
-            }
-            // Delegate to the component if possible
-            if (vComponent && vComponent.initEventListener) {
-                vComponent.initEventListener(eventName, eventHandler, eventOptions);
-            } else {
-                if (typeof eventElem.eventsHandler === 'undefined') {
-                    eventElem.eventsHandler = {};
-                }
-                if (typeof eventElem.eventsHandler[eventName] === 'undefined') {
-                    eventElem.eventsHandler[eventName] = [];
-                }
-                eventElem.eventsHandler[eventName].push(eventHandler);
-                eventElem.addEventListener(eventName, eventHandler, eventOptions);
-            }
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
 
-            if (vComponent) {
-                vComponent.afterInit();
+    try {
+        for (var _iterator = getEventElements(e)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var eventElem = _step.value;
+
+            var eventsData = JSON.parse(eventElem.dataset.events);
+            for (var j = 0; j < eventsData.length; j++) {
+                var eventData = eventsData[j];
+                var eventName = eventData[0];
+                var eventOptions = eventData[2];
+                eventOptions.passive = true;
+                var actionsData = eventData[1];
+                var vComponent = eventElem.vComponent;
+                var eventHandler = createEventHandler(actionsData, Object(__WEBPACK_IMPORTED_MODULE_13__root_document__["a" /* default */])(e), vComponent);
+                // allow override of event handler by component
+                if (vComponent && vComponent.createEventHandler) {
+                    eventHandler = vComponent.createEventHandler(actionsData, Object(__WEBPACK_IMPORTED_MODULE_13__root_document__["a" /* default */])(e), vComponent);
+                }
+                // Delegate to the component if possible
+                if (vComponent && vComponent.initEventListener) {
+                    vComponent.initEventListener(eventName, eventHandler, eventOptions);
+                } else {
+                    if (typeof eventElem.eventsHandler === 'undefined') {
+                        eventElem.eventsHandler = {};
+                    }
+                    if (typeof eventElem.eventsHandler[eventName] === 'undefined') {
+                        eventElem.eventsHandler[eventName] = [];
+                    }
+                    eventElem.eventsHandler[eventName].push(eventHandler);
+                    eventElem.addEventListener(eventName, eventHandler, eventOptions);
+                }
+
+                if (vComponent) {
+                    vComponent.afterInit();
+                }
+            }
+        }
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator.return) {
+                _iterator.return();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
             }
         }
     }
+
     fireAfterLoad(e);
 }
 
 function fireAfterLoad(e) {
-    var events = e.querySelectorAll('[data-events]');
-    for (var i = 0; i < events.length; i++) {
-        var eventElem = events[i];
-        var eventsData = JSON.parse(eventElem.dataset.events);
-        for (var j = 0; j < eventsData.length; j++) {
-            var eventData = eventsData[j];
-            var eventName = eventData[0];
-            if (eventName === 'after_init') {
-                var event = new Event('after_init');
-                // Dispatch the event.
-                eventElem.dispatchEvent(event);
+    var _iteratorNormalCompletion2 = true;
+    var _didIteratorError2 = false;
+    var _iteratorError2 = undefined;
+
+    try {
+        for (var _iterator2 = getEventElements(e)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+            var eventElem = _step2.value;
+
+            var eventsData = JSON.parse(eventElem.dataset.events);
+            for (var j = 0; j < eventsData.length; j++) {
+                var eventData = eventsData[j];
+                var eventName = eventData[0];
+                if (eventName === 'after_init') {
+                    var event = new Event('after_init');
+                    // Dispatch the event.
+                    eventElem.dispatchEvent(event);
+                }
+            }
+        }
+    } catch (err) {
+        _didIteratorError2 = true;
+        _iteratorError2 = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                _iterator2.return();
+            }
+        } finally {
+            if (_didIteratorError2) {
+                throw _iteratorError2;
             }
         }
     }
@@ -33382,7 +33434,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initButtons(e) {
     console.debug('\tButtons');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-js-ripple-button', VButton, __WEBPACK_IMPORTED_MODULE_0__material_ripple__["MDCRipple"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-button', VButton, __WEBPACK_IMPORTED_MODULE_0__material_ripple__["MDCRipple"]);
 }
 
 var VButton = function (_eventHandlerMixin) {
@@ -33405,7 +33457,7 @@ var VButton = function (_eventHandlerMixin) {
     _createClass(VButton, [{
         key: 'preview',
         value: function preview(result, acceptsMimeTypes, file) {
-            if (this.element.classList.contains('v-button-image')) {
+            if (this.element.classList.contains('v-button--image')) {
                 this.element.style.backgroundImage = 'url(\'' + result + '\')';
             } else {
                 console.warn('WARNING: Attempted to preview an image on a Button (id: ' + this.element.id + ') that is NOT an image button.\nMake sure you set the type: :image on the button.');

--- a/public/wc.js
+++ b/public/wc.js
@@ -9529,6 +9529,8 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 
 
+var EVENTS_SELECTOR = '[data-events]';
+
 var VEvents = function () {
     // [[type, url, target, params]]
     function VEvents(actions, event, root, vComponent) {
@@ -9658,59 +9660,109 @@ function createEventHandler(actionsData, root, vComponent) {
     };
 }
 
+function getEventElements(root) {
+    var elements = Array.from(root.querySelectorAll(EVENTS_SELECTOR));
+
+    // Include `root` if it has events:
+    if (typeof root.matches === 'function' && root.matches(EVENTS_SELECTOR)) {
+        elements.unshift(root);
+    }
+
+    return elements;
+}
+
 function initEvents(e) {
     console.debug('\tEvents');
 
-    var events = e.querySelectorAll('[data-events]');
-    for (var i = 0; i < events.length; i++) {
-        var eventElem = events[i];
-        var eventsData = JSON.parse(eventElem.dataset.events);
-        for (var j = 0; j < eventsData.length; j++) {
-            var eventData = eventsData[j];
-            var eventName = eventData[0];
-            var eventOptions = eventData[2];
-            eventOptions.passive = true;
-            var actionsData = eventData[1];
-            var vComponent = eventElem.vComponent;
-            var eventHandler = createEventHandler(actionsData, Object(__WEBPACK_IMPORTED_MODULE_13__root_document__["a" /* default */])(e), vComponent);
-            // allow override of event handler by component
-            if (vComponent && vComponent.createEventHandler) {
-                eventHandler = vComponent.createEventHandler(actionsData, Object(__WEBPACK_IMPORTED_MODULE_13__root_document__["a" /* default */])(e), vComponent);
-            }
-            // Delegate to the component if possible
-            if (vComponent && vComponent.initEventListener) {
-                vComponent.initEventListener(eventName, eventHandler, eventOptions);
-            } else {
-                if (typeof eventElem.eventsHandler === 'undefined') {
-                    eventElem.eventsHandler = {};
-                }
-                if (typeof eventElem.eventsHandler[eventName] === 'undefined') {
-                    eventElem.eventsHandler[eventName] = [];
-                }
-                eventElem.eventsHandler[eventName].push(eventHandler);
-                eventElem.addEventListener(eventName, eventHandler, eventOptions);
-            }
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
 
-            if (vComponent) {
-                vComponent.afterInit();
+    try {
+        for (var _iterator = getEventElements(e)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var eventElem = _step.value;
+
+            var eventsData = JSON.parse(eventElem.dataset.events);
+            for (var j = 0; j < eventsData.length; j++) {
+                var eventData = eventsData[j];
+                var eventName = eventData[0];
+                var eventOptions = eventData[2];
+                eventOptions.passive = true;
+                var actionsData = eventData[1];
+                var vComponent = eventElem.vComponent;
+                var eventHandler = createEventHandler(actionsData, Object(__WEBPACK_IMPORTED_MODULE_13__root_document__["a" /* default */])(e), vComponent);
+                // allow override of event handler by component
+                if (vComponent && vComponent.createEventHandler) {
+                    eventHandler = vComponent.createEventHandler(actionsData, Object(__WEBPACK_IMPORTED_MODULE_13__root_document__["a" /* default */])(e), vComponent);
+                }
+                // Delegate to the component if possible
+                if (vComponent && vComponent.initEventListener) {
+                    vComponent.initEventListener(eventName, eventHandler, eventOptions);
+                } else {
+                    if (typeof eventElem.eventsHandler === 'undefined') {
+                        eventElem.eventsHandler = {};
+                    }
+                    if (typeof eventElem.eventsHandler[eventName] === 'undefined') {
+                        eventElem.eventsHandler[eventName] = [];
+                    }
+                    eventElem.eventsHandler[eventName].push(eventHandler);
+                    eventElem.addEventListener(eventName, eventHandler, eventOptions);
+                }
+
+                if (vComponent) {
+                    vComponent.afterInit();
+                }
+            }
+        }
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator.return) {
+                _iterator.return();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
             }
         }
     }
+
     fireAfterLoad(e);
 }
 
 function fireAfterLoad(e) {
-    var events = e.querySelectorAll('[data-events]');
-    for (var i = 0; i < events.length; i++) {
-        var eventElem = events[i];
-        var eventsData = JSON.parse(eventElem.dataset.events);
-        for (var j = 0; j < eventsData.length; j++) {
-            var eventData = eventsData[j];
-            var eventName = eventData[0];
-            if (eventName === 'after_init') {
-                var event = new Event('after_init');
-                // Dispatch the event.
-                eventElem.dispatchEvent(event);
+    var _iteratorNormalCompletion2 = true;
+    var _didIteratorError2 = false;
+    var _iteratorError2 = undefined;
+
+    try {
+        for (var _iterator2 = getEventElements(e)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+            var eventElem = _step2.value;
+
+            var eventsData = JSON.parse(eventElem.dataset.events);
+            for (var j = 0; j < eventsData.length; j++) {
+                var eventData = eventsData[j];
+                var eventName = eventData[0];
+                if (eventName === 'after_init') {
+                    var event = new Event('after_init');
+                    // Dispatch the event.
+                    eventElem.dispatchEvent(event);
+                }
+            }
+        }
+    } catch (err) {
+        _didIteratorError2 = true;
+        _iteratorError2 = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                _iterator2.return();
+            }
+        } finally {
+            if (_didIteratorError2) {
+                throw _iteratorError2;
             }
         }
     }
@@ -18723,7 +18775,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initButtons(e) {
     console.debug('\tButtons');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-js-ripple-button', VButton, __WEBPACK_IMPORTED_MODULE_0__material_ripple__["MDCRipple"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-button', VButton, __WEBPACK_IMPORTED_MODULE_0__material_ripple__["MDCRipple"]);
 }
 
 var VButton = function (_eventHandlerMixin) {
@@ -18746,7 +18798,7 @@ var VButton = function (_eventHandlerMixin) {
     _createClass(VButton, [{
         key: 'preview',
         value: function preview(result, acceptsMimeTypes, file) {
-            if (this.element.classList.contains('v-button-image')) {
+            if (this.element.classList.contains('v-button--image')) {
                 this.element.style.backgroundImage = 'url(\'' + result + '\')';
             } else {
                 console.warn('WARNING: Attempted to preview an image on a Button (id: ' + this.element.id + ') that is NOT an image button.\nMake sure you set the type: :image on the button.');

--- a/views/mdc/assets/js/components/button.js
+++ b/views/mdc/assets/js/components/button.js
@@ -5,7 +5,7 @@ import {eventHandlerMixin} from './mixins/event-handler';
 
 export function initButtons(e) {
     console.debug('\tButtons');
-    hookupComponents(e, '.v-js-ripple-button', VButton, MDCRipple);
+    hookupComponents(e, '.v-button', VButton, MDCRipple);
 }
 
 
@@ -18,7 +18,7 @@ export class VButton extends eventHandlerMixin(VBaseComponent) {
     }
 
     preview(result, acceptsMimeTypes, file) {
-        if (this.element.classList.contains('v-button-image')) {
+        if (this.element.classList.contains('v-button--image')) {
             this.element.style.backgroundImage = `url('${result}')`;
         }
         else {

--- a/views/mdc/assets/js/components/events.js
+++ b/views/mdc/assets/js/components/events.js
@@ -13,6 +13,8 @@ import {VNavigates} from './events/navigates';
 import {VPluginEventAction} from './events/plugin';
 import getRoot from './root_document';
 
+const EVENTS_SELECTOR = '[data-events]';
+
 export class VEvents {
     // [[type, url, target, params]]
     constructor(actions, event, root, vComponent) {
@@ -133,12 +135,21 @@ function createEventHandler(actionsData, root, vComponent) {
     };
 }
 
+function getEventElements(root) {
+    const elements = Array.from(root.querySelectorAll(EVENTS_SELECTOR));
+
+    // Include `root` if it has events:
+    if (typeof root.matches === 'function' && root.matches(EVENTS_SELECTOR)) {
+        elements.unshift(root);
+    }
+
+    return elements;
+}
+
 export function initEvents(e) {
     console.debug('\tEvents');
 
-    var events = e.querySelectorAll('[data-events]');
-    for (var i = 0; i < events.length; i++) {
-        var eventElem = events[i];
+    for (const eventElem of getEventElements(e)) {
         var eventsData = JSON.parse(eventElem.dataset.events);
         for (var j = 0; j < eventsData.length; j++) {
             var eventData = eventsData[j];
@@ -179,9 +190,7 @@ export function initEvents(e) {
 }
 
 function fireAfterLoad(e) {
-    var events = e.querySelectorAll('[data-events]');
-    for (var i = 0; i < events.length; i++) {
-        var eventElem = events[i];
+    for (const eventElem of getEventElements(e)) {
         var eventsData = JSON.parse(eventElem.dataset.events);
         for (var j = 0; j < eventsData.length; j++) {
             var eventData = eventsData[j];

--- a/views/mdc/assets/scss/app.scss
+++ b/views/mdc/assets/scss/app.scss
@@ -23,6 +23,7 @@
 @import "components/slider";
 @import "components/tab-bars";
 @import "components/progress";
+@import "components/tooltip";
 
 // Custom
 @import "components/expansion-panel"; // MDL derivative

--- a/views/mdc/assets/scss/components/button.scss
+++ b/views/mdc/assets/scss/components/button.scss
@@ -1,6 +1,6 @@
 @import "@material/button/mdc-button";
 
-.v-button-image {
+.v-button.v-button--image {
   width: 150px;
   height: 45px;
   background-color: $mdc-theme-background !important;

--- a/views/mdc/assets/scss/components/tooltip.scss
+++ b/views/mdc/assets/scss/components/tooltip.scss
@@ -1,0 +1,3 @@
+.v-tooltip {
+    text-transform: initial;
+}

--- a/views/mdc/components/buttons/button.erb
+++ b/views/mdc/components/buttons/button.erb
@@ -7,7 +7,7 @@
 
 
 <button id="<%= comp.id %>"
-         class="mdc-button v-js-ripple-button <%=class_name%>
+         class="v-button v-button--button mdc-button v-js-ripple-button <%=class_name%>
          <%= 'v-hidden' if comp.hidden %>
          <%= 'mdc-button--raised' if eq(comp.button_type, :raised) %>
          <%= 'v-secondary-filled-button' if eq(comp.button_type, :raised) && eq(comp.color, :secondary) %>

--- a/views/mdc/components/buttons/fab.erb
+++ b/views/mdc/components/buttons/fab.erb
@@ -6,7 +6,7 @@
 
 <button id="<%= comp.id %>"
         <%= data_attributes %>
-        class="mdc-fab material-icons v-fab--absolute v-js-ripple-button
+        class="v-button v-button--fab mdc-fab material-icons v-fab--absolute v-js-ripple-button
           <%= 'v-hidden' if comp.hidden %>
           <%= class_name %>
           <%= position_classes %>

--- a/views/mdc/components/buttons/icon.erb
+++ b/views/mdc/components/buttons/icon.erb
@@ -6,7 +6,7 @@
 
 <button id="<%= comp.id %>"
         <%= data_attributes %>
-        class="mdl-button mdl-js-button mdl-button--icon
+        class="v-button v-button--icon mdl-button v-js-ripple-button mdl-js-button mdl-button--icon
          <%= 'v-hidden' if comp.hidden %>
          <%=class_name%>
          <%= position_classes %>

--- a/views/mdc/components/buttons/icon.erb
+++ b/views/mdc/components/buttons/icon.erb
@@ -17,6 +17,6 @@
         <%= erb :'components/event', :locals => {comp: comp, events: comp.events, parent_id: event_parent_id || comp.event_parent_id} unless comp.disabled %>>
   <%= erb :'components/icon', :locals => {comp: comp.icon} %>
   <%= comp.text %>
+  <%= erb :"components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} %>
 </button>
-<%= erb :"components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} %>
 <%= erb :"components/menu", :locals => {comp: comp.menu, parent_id: comp.id} %>

--- a/views/mdc/components/buttons/image.erb
+++ b/views/mdc/components/buttons/image.erb
@@ -6,7 +6,7 @@
 
 <button
   id="<%= comp.id %>"
-  class="mdc-button v-js-ripple-button v-button-image <%=class_name%>
+  class="v-button v-button--image mdc-button v-js-ripple-button <%=class_name%>
           <%= data_attributes %>
           <%= 'v-hidden' if comp.hidden %>
           <%= 'mdc-button--raised' if eq(comp.button_type, :raised) %>

--- a/views/mdc/components/table/pagination.erb
+++ b/views/mdc/components/table/pagination.erb
@@ -6,10 +6,10 @@
   <span class="v-paging__count">
     <%= comp.range&.join(' - ') %> of <%= comp.total %>
   </span>
-  <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon v-paging__prev">
+  <button class="v-button v-button--icon v-button--pagination v-button--pagination--previous mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon v-paging__prev">
     <%= erb :"components/icon", :locals => {:comp=>comp.previous_button} %>
   </button>
-  <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon v-paging__next">
+  <button class="v-button v-button--icon v-button--pagination v-button--pagination--next mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon v-paging__next">
     <%= erb :"components/icon", :locals => {:comp=>comp.next_button} %>
   </button>
 </div>


### PR DESCRIPTION
* Implement `.v-button` CSS classes
* Ensure events are reinitialized correctly
  * When replacing an element, the new root passed to component and event initialization is the replaced element itself (rather than the document or web component root).
  * The component initializers were patched to include the replaced element if it matches the given selector, but this patch was not applied to the event initialization logic.
  * This change remedies this, bringing event initialization up to par with component initialization.
* Bring icon button tooltip into its button element
  * This fixes an issue which prevents tooltips from being properly reinitialized after a non-nested button is replaced.
  * This is a stop-gap fix and does not work for other button types.