### PR TITLE
Make stepper button events manual to avoid parallel actions

### DIFF
--- a/lib/voom/presenters/dsl/components/stepper.rb
+++ b/lib/voom/presenters/dsl/components/stepper.rb
@@ -77,12 +77,6 @@ module Voom
               def button(text = nil, stepper_type, **options, &block)
                 btn = StepperButton.new(stepper_type, parent: self, text: text,
                                                    **options, &block)
-
-                btn.instance_eval do
-                  event :click do
-                    stepper stepper_type
-                  end
-                end
                 @buttons << btn
               end
 


### PR DESCRIPTION
When steppers were used and gave their buttons an event block to perform
actions such as post then we didn't have a promise chain that would
cancel, each event block was run.  This caused the stepper to move to
the next step when a post returned a 422.