### PR TITLE
Clear errors before action chain

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -13379,6 +13379,8 @@ var VEvents = function () {
                 this.vComponent.actionsStarted(this);
             }
 
+            new __WEBPACK_IMPORTED_MODULE_4__events_errors__["a" /* VErrors */](root).clearErrors();
+
             pseries(fnlist).then(function (results) {
                 var result = results.pop();
                 var contentType = result.contentType;

--- a/public/wc.js
+++ b/public/wc.js
@@ -9573,6 +9573,8 @@ var VEvents = function () {
                 this.vComponent.actionsStarted(this);
             }
 
+            new __WEBPACK_IMPORTED_MODULE_4__events_errors__["a" /* VErrors */](root).clearErrors();
+
             pseries(fnlist).then(function (results) {
                 var result = results.pop();
                 var contentType = result.contentType;

--- a/views/mdc/assets/js/components/events.js
+++ b/views/mdc/assets/js/components/events.js
@@ -49,6 +49,8 @@ export class VEvents {
             this.vComponent.actionsStarted(this);
         }
 
+        new VErrors(root).clearErrors();
+
         pseries(fnlist).then((results) => {
             const result = results.pop();
             const contentType = result.contentType;


### PR DESCRIPTION
An action from a plugin is resulting in an error that never gets
cleared.  Plugins only provide a function so don't have access to the
clearErrors() function and it makes sense to clear them when a new chain
begins as it will result in new errors or a clean run.