### PR TITLE
Allow non markdown typography

### DIFF
--- a/lib/voom/presenters/dsl/components/event_base.rb
+++ b/lib/voom/presenters/dsl/components/event_base.rb
@@ -9,7 +9,7 @@ module Voom
           attr_reader :event_parent_id
 
           def initialize(**attribs_, &block)
-            super(type: :icon, 
+            super(type: :icon,
                   **attribs_, &block)
             @event_parent_id = @id
           end

--- a/lib/voom/presenters/dsl/components/header.rb
+++ b/lib/voom/presenters/dsl/components/header.rb
@@ -46,7 +46,7 @@ module Voom
             placement = value.to_sym
 
             unless VALID_PLACEMENTS.include?(placement)
-              raise Errors::ParameterValidation, "Invalid placement specified: #{placement}" 
+              raise Errors::ParameterValidation, "Invalid placement specified: #{placement}"
             end
 
             placement

--- a/lib/voom/presenters/dsl/components/list.rb
+++ b/lib/voom/presenters/dsl/components/list.rb
@@ -15,10 +15,10 @@ module Voom
           include Mixins::Append
           include Mixins::Attaches
           include Mixins::Event
-          
+
           attr_reader :lines, :lines_only, :color, :border, :selectable, :total_lines, :dense
           attr_accessor :components
-          
+
           def initialize(**attribs_, &block)
             super(type: :list, **attribs_, &block)
             @color  = attribs.delete(:color) { nil }
@@ -53,5 +53,3 @@ module Voom
     end
   end
 end
-
-

--- a/lib/voom/presenters/dsl/components/lists/line.rb
+++ b/lib/voom/presenters/dsl/components/lists/line.rb
@@ -20,10 +20,10 @@ module Voom
               super(type: :line, **attribs_, &block)
               @selected = attribs.delete(:selected) {false}
               @selectable = attribs.delete(:selectable) {false}
-              self.text(attribs.delete(:text)) unless attribs.fetch(:text){nil}.nil?
-              self.subtitle(attribs.delete(:subtitle)) unless attribs.fetch(:subtitle){nil}.nil?
-              self.info(attribs.delete(:info)) unless attribs.fetch(:info){nil}.nil?
-              self.body(attribs.delete(:body)) unless attribs.fetch(:body){nil}.nil?
+              self.text(attribs.delete(:text), attribs) if attribs[:text]
+              self.subtitle(attribs.delete(:subtitle)) if attribs[:subtitle]
+              self.info(attribs.delete(:info)) if attribs[:info]
+              self.body(attribs.delete(:body)) if attribs[:body]
               self.avatar(attribs.delete(:avatar)) if attribs.key?(:avatar)
               self.icon(attribs.delete(:icon)) if attribs.key?(:icon)
               self.checkbox(attribs.delete(:checkbox)) if attribs.key?(:checkbox) && !@selectable
@@ -35,7 +35,7 @@ module Voom
 
             def text(*text, **attribs, &block)
               return @text if locked?
-              @text = Components::Typography.new(parent: self,type: :text, text: text, **attribs, &block)
+              @text = Components::Typography.new(parent: self, type: :text, text: text, **attribs, &block)
             end
             alias title text
 

--- a/lib/voom/presenters/dsl/components/typography.rb
+++ b/lib/voom/presenters/dsl/components/typography.rb
@@ -8,15 +8,16 @@ module Voom
         class Typography < EventBase
           include Mixins::Tooltips
 
-          attr_accessor :text, :level, :color, :position, :inline
+          attr_accessor :text, :level, :color, :position, :inline, :markdown
 
           def initialize(parent:, level: nil, **attribs_, &block)
             super(type: :text, parent: parent, **attribs_, &block)
             @text = Array(attribs.delete(:text)||'').flatten.join("\n\n").split("\n\n")
             @level = level
             @color = attribs.delete(:color)
-            @inline = attribs.delete(:inline){false}
+            @inline = attribs.delete(:inline) { false }
             @position = Array(attribs.delete(:position)).compact
+            @markdown = attribs.delete(:markdown) { true }
             expand!
           end
         end

--- a/lib/voom/presenters/web_client/app.rb
+++ b/lib/voom/presenters/web_client/app.rb
@@ -75,8 +75,12 @@ module Voom
             "#{comp.id}-#{SecureRandom.hex(4)}"
           end
 
-          def expand_text(text)
-            self.markdown(Array(text).join("\n\n")) #.gsub("\n\n", "<br/>")
+          def expand_text(text, markdown: true)
+            if markdown
+              self.markdown(Array(text).join("\n\n")) #.gsub("\n\n", "<br/>")
+            else
+              Array(text).join('<br/>')
+            end
           end
 
           def color_classname(comp)

--- a/views/mdc/body/header.erb
+++ b/views/mdc/body/header.erb
@@ -11,7 +11,7 @@
       <% end %>
       <span class="mdc-top-app-bar__title <%= 'v-actionable' if header.title&.events %>"
             <%= erb :"components/event", :locals => {comp: header, events: header.title&.events, parent_id: header.title&.event_parent_id} %>>
-        <%= expand_text(header.title&.text) %>
+        <%= expand_text(header.title&.text, markdown: header.title&.markdown) %>
       </span>
     </section>
     <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">

--- a/views/mdc/components/list/line.erb
+++ b/views/mdc/components/list/line.erb
@@ -21,15 +21,15 @@
                <%= 'v-menu-click' if line.menu && line.actions.any? %>">
 
     <% if line.text %>
-      <span class="<%= primary_text_class %>"><%= expand_text(line.text&.text) %></span>
+      <span class="<%= primary_text_class %>"><%= expand_text(line.text&.text, markdown: line.text&.markdown) %></span>
     <% end %>
 
     <% if line.subtitle %>
-      <span class="mdc-list-item__secondary-text"><%= expand_text(line.subtitle&.text) %></span>
+      <span class="mdc-list-item__secondary-text"><%= expand_text(line.subtitle&.text, markdown: line.subtitle&.markdown) %></span>
     <% end %>
 
     <% if line.body %>
-      <span class="mdc-list-item__secondary-text"><%= expand_text(line.body&.text) %></span>
+      <span class="mdc-list-item__secondary-text"><%= expand_text(line.body&.text, markdown: line.body&.markdown) %></span>
     <% end %>
   </span>
   <%= erb :"components/list/actions", :locals => {:line => line} %>

--- a/views/mdc/components/typography.erb
+++ b/views/mdc/components/typography.erb
@@ -9,6 +9,6 @@
      style = "<%= "color: #{comp.color};" if comp.color %>
               <%= "display: inline;" if comp.inline %>"
      <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} %>>
-  <%= expand_text(comp.text) %>
+  <%= expand_text(comp.text, markdown: comp.markdown) %>
 </div>
 <%= erb :"components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} %>


### PR DESCRIPTION
This provides a way to have raw text so user values can be straight
rendered and #foo won't result in a heading.  Any typography type can
take `markdown: false` to allow raw text.