### PR TITLE
Add `error_logger` setting

### DIFF
--- a/lib/voom/presenters/api/app.rb
+++ b/lib/voom/presenters/api/app.rb
@@ -40,7 +40,7 @@ module Voom
             content_type :json
             JSON.dump(pom.to_hash)
           rescue StandardError => e
-            Presenters::Settings.config.presenters.api_client.error_logger.call(
+            Presenters::Settings.config.presenters.error_logger.call(
               @env['rack.errors'],
               e,
               params,

--- a/lib/voom/presenters/api/app.rb
+++ b/lib/voom/presenters/api/app.rb
@@ -32,13 +32,22 @@ module Voom
 
         private
 
+        # analogous to Voom::Presenters::WebClient::App#render_presenter
         def render_presenter(presenter)
-          # puts "/presenters/api/#{params[:version]}/#{params[:presenter]}/"
-          # puts "Parameters: #{params.inspect}"
-          presenter = Voom::Presenters::App[presenter].call
-          pom = presenter.expand(router: router, context: prepare_context)
-          content_type :json
-          JSON.dump(pom.to_hash)
+          begin
+            presenter = Voom::Presenters::App[presenter].call
+            pom = presenter.expand(router: router, context: prepare_context)
+            content_type :json
+            JSON.dump(pom.to_hash)
+          rescue StandardError => e
+            Presenters::Settings.config.presenters.api_client.error_logger.call(
+              @env['rack.errors'],
+              e,
+              params,
+              presenter.name
+            )
+            raise e
+          end
         end
 
         def router

--- a/lib/voom/presenters/settings.rb
+++ b/lib/voom/presenters/settings.rb
@@ -20,6 +20,12 @@ unless defined?(Voom::Presenters::Settings)
           setting :helpers, [Voom::Presenters::Helpers::Route]
           setting :deep_freeze, false
           setting :id_generator, ->(node) {"id-#{SecureRandom.hex}"}
+          setting :api_client do
+            setting :error_logger, ->(file, e, _params, _presenter_name) {
+              msg = ["#{Time.now.strftime("%Y-%m-%d %H:%M:%S")} - #{e.class} - #{e.message}:", *e.backtrace].join("\n\t")
+              file.puts(msg)
+            }
+          end
           setting :web_client do
             # Add lambda's to modify the context for the presenters
             # For example:
@@ -32,6 +38,10 @@ unless defined?(Voom::Presenters::Settings)
             setting :prepare_context, []
             # Relative to the root
             setting :custom_css, '../public/presenters'
+            setting :error_logger, ->(file, e, _params, _presenter_name) {
+              msg = ["#{Time.now.strftime("%Y-%m-%d %H:%M:%S")} - #{e.class} - #{e.message}:", *e.backtrace].join("\n\t")
+              file.puts(msg)
+            }
           end
           setting :plugins, [:google_maps]
           setting :components do

--- a/lib/voom/presenters/settings.rb
+++ b/lib/voom/presenters/settings.rb
@@ -20,12 +20,6 @@ unless defined?(Voom::Presenters::Settings)
           setting :helpers, [Voom::Presenters::Helpers::Route]
           setting :deep_freeze, false
           setting :id_generator, ->(node) {"id-#{SecureRandom.hex}"}
-          setting :api_client do
-            setting :error_logger, ->(file, e, _params, _presenter_name) {
-              msg = ["#{Time.now.strftime("%Y-%m-%d %H:%M:%S")} - #{e.class} - #{e.message}:", *e.backtrace].join("\n\t")
-              file.puts(msg)
-            }
-          end
           setting :web_client do
             # Add lambda's to modify the context for the presenters
             # For example:
@@ -38,10 +32,6 @@ unless defined?(Voom::Presenters::Settings)
             setting :prepare_context, []
             # Relative to the root
             setting :custom_css, '../public/presenters'
-            setting :error_logger, ->(file, e, _params, _presenter_name) {
-              msg = ["#{Time.now.strftime("%Y-%m-%d %H:%M:%S")} - #{e.class} - #{e.message}:", *e.backtrace].join("\n\t")
-              file.puts(msg)
-            }
           end
           setting :plugins, [:google_maps]
           setting :components do
@@ -73,6 +63,13 @@ unless defined?(Voom::Presenters::Settings)
               end
             end
           end
+          setting :error_logger, ->(file, e, _params, _presenter_name) {
+            msg = [
+              "#{Time.now.strftime("%Y-%m-%d %H:%M:%S")} - #{e.class} - #{e.message}:",
+              *e.backtrace
+            ].join("\n\t")
+            file.puts(msg)
+          }
         end
 
         def self.default(type, key)

--- a/lib/voom/presenters/web_client/app.rb
+++ b/lib/voom/presenters/web_client/app.rb
@@ -23,6 +23,7 @@ module Voom
         set :router_, WebClient::Router
         set :bind, '0.0.0.0'
         set :views, Proc.new {File.join(root, "views", ENV['VIEW_ENGINE'] || 'mdc')}
+        set :dump_errors, false
         configure do
           enable :logging
         end
@@ -167,6 +168,7 @@ module Voom
 
         private
 
+        # analogous to Voom::Presenters::Api::App#render_presenter
         def render_presenter(presenter)
           @grid_nesting = Integer(params[:grid_nesting] || 0)
 
@@ -175,6 +177,14 @@ module Voom
             layout = !(request.env['HTTP_X_NO_LAYOUT'] == 'true')
             response.headers['X-Frame-Options'] = 'ALLOWALL' if ENV['ALLOWALL_FRAME_OPTIONS']
             erb :web, layout: layout
+          rescue StandardError => e
+            Presenters::Settings.config.presenters.web_client.error_logger.call(
+              @env['rack.errors'],
+              e,
+              params,
+              presenter.name
+            )
+            raise e
           rescue Presenters::Errors::Unprocessable => e
             content_type :json
             status 422

--- a/lib/voom/presenters/web_client/app.rb
+++ b/lib/voom/presenters/web_client/app.rb
@@ -178,7 +178,7 @@ module Voom
             response.headers['X-Frame-Options'] = 'ALLOWALL' if ENV['ALLOWALL_FRAME_OPTIONS']
             erb :web, layout: layout
           rescue StandardError => e
-            Presenters::Settings.config.presenters.web_client.error_logger.call(
+            Presenters::Settings.config.presenters.error_logger.call(
               @env['rack.errors'],
               e,
               params,


### PR DESCRIPTION
The `error_logger` allows a proc to be invoked whenever a
`StandardError` is caught (for example, to log exceptions as JSON) when
the API or web client renders a Presenter.

The default `error_logger` proc mimics Sinatra's dump_errors behavior,
logging a timestamp, exception class, message, and backtrace to the rack
errors file.

Also Disable Sinatra's `dump_errors` for the web client.