### PR TITLE
Selectable list line ergonomics

### DIFF
--- a/lib/voom/presenters/dsl/components/lists/line.rb
+++ b/lib/voom/presenters/dsl/components/lists/line.rb
@@ -68,7 +68,12 @@ module Voom
 
             def checkbox(**attributes, &block)
               return @checkbox if locked?
-              field_name = @selectable ? "#{attributes.delete(:name)}[]" : attributes.delete(:name)
+
+              # Append [] if the list is selectable and the checkbox's name
+              # doesn't already include brackets:
+              field_name = attributes.delete(:name).to_s
+              field_name << '[]' if @selectable && !field_name.include?('[')
+
               @checkbox = Components::Checkbox.new(parent: self,
                                                    name: field_name,
                                                    **attributes,

--- a/lib/voom/presenters/dsl/components/lists/line.rb
+++ b/lib/voom/presenters/dsl/components/lists/line.rb
@@ -14,6 +14,8 @@ module Voom
             extend Gem::Deprecate
             include Mixins::Tooltips
 
+            CHECKBOX_ATTRIBUTES = %i[name value checked dirtyable value off_value].freeze
+
             attr_accessor :selected, :selectable
 
             def initialize(**attribs_, &block)
@@ -26,8 +28,12 @@ module Voom
               self.body(attribs.delete(:body)) if attribs[:body]
               self.avatar(attribs.delete(:avatar)) if attribs.key?(:avatar)
               self.icon(attribs.delete(:icon)) if attribs.key?(:icon)
-              self.checkbox(attribs.delete(:checkbox)) if attribs.key?(:checkbox) && !@selectable
-              self.checkbox(attribs.slice(:name, :value, :checked, :dirtyable)) if @selectable
+
+              if @selectable
+                self.checkbox(attribs.slice(*CHECKBOX_ATTRIBUTES))
+              elsif attribs.key?(:checkbox)
+                self.checkbox(attribs.delete(:checkbox))
+              end
 
               @actions = []
               expand!

--- a/lib/voom/presenters/dsl/components/lists/line.rb
+++ b/lib/voom/presenters/dsl/components/lists/line.rb
@@ -80,6 +80,12 @@ module Voom
                                                    &block)
             end
 
+            def hidden_field(**attributes, &block)
+              return @hidden_field if locked?
+
+              @hidden_field = Components::HiddenField.new(parent: self, **attributes, &block)
+            end
+
             def menu(**attributes, &block)
               return @menu if locked?
               @menu = Components::Menu.new(parent: self, **attributes, &block)

--- a/views/mdc/components/list/hidden_field.erb
+++ b/views/mdc/components/list/hidden_field.erb
@@ -1,0 +1,3 @@
+<% if line.hidden_field %>
+  <%= erb :"components/hidden_field", :locals => {comp: line.hidden_field} %>
+<% end %>

--- a/views/mdc/components/list/line.erb
+++ b/views/mdc/components/list/line.erb
@@ -15,6 +15,7 @@
     <%= draggable_attributes(line) %>
     <%= drop_zone_attributes(line) %>
     <%= erb :"components/event", :locals => {comp: line, events: line.events, parent_id: line.event_parent_id} %>>
+  <%= erb :"components/list/hidden_field", :locals => {:line => line} %>
   <%= erb :"components/list/checkbox", :locals => {:line => line} %>
   <%= erb :"components/list/icon", :locals => {:line => line} %>
   <%= erb :"components/list/avatar", :locals => {:line => line} %>


### PR DESCRIPTION
* Avoid mutating selectable list line checkbox names
  * If a selectable list line specifies checkbox attributes or provides a checkbox component, mutate the name to append `[]` iff the provided name does not contain `[`.
  * This ensures names like `hash[key]` are not mutated to `hash[key][]` and preserves existing behavior for names comprised of only word characters.
* Allow `hidden_field` within a list line
* Include `value` and `off_value` in allowed list line checkbox attributes