### PR TITLE
Fix `data-original-value` values for text areas

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -14669,7 +14669,7 @@ select {
   background: transparent;
   color: rgba(0, 0, 0, 0.9);
   fill: rgba(0, 0, 0, 0.9);
-  height: 34px;
+  height: 28px;
   line-height: 1;
   text-align: center;
   position: relative;
@@ -14688,13 +14688,14 @@ select {
   cursor: pointer;
   position: absolute;
   top: 0;
-  height: 34px;
+  line-height: 16px;
+  height: 28px;
   padding: 10px;
   z-index: 3;
   color: rgba(0, 0, 0, 0.9);
   fill: rgba(0, 0, 0, 0.9); }
 
-.flatpickr-months .flatpickr-prev-month.flatpickr-disabled, .flatpickr-months .flatpickr-next-month.flatpickr-disabled {
+.flatpickr-months .flatpickr-prev-month.disabled, .flatpickr-months .flatpickr-next-month.disabled {
   display: none; }
 
 .flatpickr-months .flatpickr-prev-month i, .flatpickr-months .flatpickr-next-month i {
@@ -14749,10 +14750,6 @@ select {
 
 .numInputWrapper input::-ms-clear {
   display: none; }
-
-.numInputWrapper input::-webkit-outer-spin-button, .numInputWrapper input::-webkit-inner-spin-button {
-  margin: 0;
-  -webkit-appearance: none; }
 
 .numInputWrapper span {
   position: absolute;
@@ -14818,9 +14815,9 @@ select {
   position: absolute;
   width: 75%;
   left: 12.5%;
-  padding: 7.48px 0 0 0;
+  padding: 6.16px 0 0 0;
   line-height: 1;
-  height: 34px;
+  height: 28px;
   display: inline-block;
   text-align: center;
   -webkit-transform: translate3d(0, 0, 0);
@@ -14864,10 +14861,7 @@ select {
   height: auto;
   border: 0;
   border-radius: 0;
-  vertical-align: initial;
-  -webkit-appearance: textfield;
-  -moz-appearance: textfield;
-  appearance: textfield; }
+  vertical-align: initial; }
 
 .flatpickr-current-month input.cur-year:focus {
   outline: 0; }
@@ -14877,40 +14871,6 @@ select {
   color: rgba(0, 0, 0, 0.5);
   background: transparent;
   pointer-events: none; }
-
-.flatpickr-current-month .flatpickr-monthDropdown-months {
-  appearance: menulist;
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  box-sizing: border-box;
-  color: inherit;
-  cursor: pointer;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: 300;
-  height: auto;
-  line-height: inherit;
-  margin: -1px 0 0 0;
-  outline: none;
-  padding: 0 0 0 .5ch;
-  position: relative;
-  vertical-align: initial;
-  -webkit-box-sizing: border-box;
-  -webkit-appearance: menulist;
-  -moz-appearance: menulist;
-  width: auto; }
-
-.flatpickr-current-month .flatpickr-monthDropdown-months:focus, .flatpickr-current-month .flatpickr-monthDropdown-months:active {
-  outline: none; }
-
-.flatpickr-current-month .flatpickr-monthDropdown-months:hover {
-  background: rgba(0, 0, 0, 0.05); }
-
-.flatpickr-current-month .flatpickr-monthDropdown-months .flatpickr-monthDropdown-month {
-  background-color: transparent;
-  outline: none;
-  padding: 0; }
 
 .flatpickr-weekdays {
   background: transparent;
@@ -15063,13 +15023,13 @@ span.flatpickr-weekday {
   -webkit-box-shadow: -5px 0 0 #e6e6e6,5px 0 0 #e6e6e6;
   box-shadow: -5px 0 0 #e6e6e6,5px 0 0 #e6e6e6; }
 
-.flatpickr-day.flatpickr-disabled, .flatpickr-day.flatpickr-disabled:hover, .flatpickr-day.prevMonthDay, .flatpickr-day.nextMonthDay, .flatpickr-day.notAllowed, .flatpickr-day.notAllowed.prevMonthDay, .flatpickr-day.notAllowed.nextMonthDay {
+.flatpickr-day.disabled, .flatpickr-day.disabled:hover, .flatpickr-day.prevMonthDay, .flatpickr-day.nextMonthDay, .flatpickr-day.notAllowed, .flatpickr-day.notAllowed.prevMonthDay, .flatpickr-day.notAllowed.nextMonthDay {
   color: rgba(57, 57, 57, 0.3);
   background: transparent;
   border-color: transparent;
   cursor: default; }
 
-.flatpickr-day.flatpickr-disabled, .flatpickr-day.flatpickr-disabled:hover {
+.flatpickr-day.disabled, .flatpickr-day.disabled:hover {
   cursor: not-allowed;
   color: rgba(57, 57, 57, 0.1); }
 
@@ -15085,6 +15045,7 @@ span.flatpickr-weekday {
   margin-top: 1px; }
 
 .flatpickr-weekwrapper {
+  display: inline-block;
   float: left; }
 
 .flatpickr-weekwrapper .flatpickr-weeks {
@@ -15178,10 +15139,7 @@ span.flatpickr-weekday {
   font-size: 14px;
   position: relative;
   -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-  -webkit-appearance: textfield;
-  -moz-appearance: textfield;
-  appearance: textfield; }
+  box-sizing: border-box; }
 
 .flatpickr-time input.flatpickr-hour {
   font-weight: bold; }
@@ -15195,6 +15153,7 @@ span.flatpickr-weekday {
 
 .flatpickr-time .flatpickr-time-separator, .flatpickr-time .flatpickr-am-pm {
   height: inherit;
+  display: inline-block;
   float: left;
   line-height: inherit;
   color: #393939;
@@ -15216,7 +15175,7 @@ span.flatpickr-weekday {
   font-weight: 400; }
 
 .flatpickr-time input:hover, .flatpickr-time .flatpickr-am-pm:hover, .flatpickr-time input:focus, .flatpickr-time .flatpickr-am-pm:focus {
-  background: #eee; }
+  background: #f3f3f3; }
 
 .flatpickr-input[readonly] {
   cursor: pointer; }

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -129,7 +129,7 @@ module.exports = function (it) {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseComponent; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = hookupComponents;
 /* harmony export (immutable) */ __webpack_exports__["c"] = unhookupComponents;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_errors__ = __webpack_require__(114);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_errors__ = __webpack_require__(115);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -365,7 +365,7 @@ module.exports = function (it) {
 /* 6 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var store = __webpack_require__(52)('wks');
+var store = __webpack_require__(53)('wks');
 var uid = __webpack_require__(37);
 var _Symbol = __webpack_require__(3).Symbol;
 var USE_SYMBOL = typeof _Symbol == 'function';
@@ -403,7 +403,7 @@ module.exports = !__webpack_require__(4)(function () {
 /***/ (function(module, exports, __webpack_require__) {
 
 var anObject = __webpack_require__(1);
-var IE8_DOM_DEFINE = __webpack_require__(125);
+var IE8_DOM_DEFINE = __webpack_require__(126);
 var toPrimitive = __webpack_require__(27);
 var dP = Object.defineProperty;
 
@@ -596,7 +596,7 @@ module.exports = function (it, key) {
 /***/ (function(module, exports, __webpack_require__) {
 
 // to indexed object, toObject with fallback for non-array-like ES3 strings
-var IObject = __webpack_require__(53);
+var IObject = __webpack_require__(54);
 var defined = __webpack_require__(28);
 module.exports = function (it) {
   return IObject(defined(it));
@@ -606,12 +606,12 @@ module.exports = function (it) {
 /* 19 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var pIE = __webpack_require__(54);
+var pIE = __webpack_require__(55);
 var createDesc = __webpack_require__(36);
 var toIObject = __webpack_require__(18);
 var toPrimitive = __webpack_require__(27);
 var has = __webpack_require__(17);
-var IE8_DOM_DEFINE = __webpack_require__(125);
+var IE8_DOM_DEFINE = __webpack_require__(126);
 var gOPD = Object.getOwnPropertyDescriptor;
 
 exports.f = __webpack_require__(8) ? gOPD : function getOwnPropertyDescriptor(O, P) {
@@ -630,7 +630,7 @@ exports.f = __webpack_require__(8) ? gOPD : function getOwnPropertyDescriptor(O,
 // 19.1.2.9 / 15.2.3.2 Object.getPrototypeOf(O)
 var has = __webpack_require__(17);
 var toObject = __webpack_require__(10);
-var IE_PROTO = __webpack_require__(89)('IE_PROTO');
+var IE_PROTO = __webpack_require__(90)('IE_PROTO');
 var ObjectProto = Object.prototype;
 
 module.exports = Object.getPrototypeOf || function (O) {
@@ -730,7 +730,7 @@ module.exports =
 check((typeof globalThis === 'undefined' ? 'undefined' : _typeof(globalThis)) == O && globalThis) || check((typeof window === 'undefined' ? 'undefined' : _typeof(window)) == O && window) || check((typeof self === 'undefined' ? 'undefined' : _typeof(self)) == O && self) || check((typeof global === 'undefined' ? 'undefined' : _typeof(global)) == O && global) ||
 // eslint-disable-next-line no-new-func
 Function('return this')();
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(65)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(66)))
 
 /***/ }),
 /* 27 */
@@ -788,10 +788,10 @@ module.exports = function (KEY, exec) {
 // 5 -> Array#find
 // 6 -> Array#findIndex
 var ctx = __webpack_require__(22);
-var IObject = __webpack_require__(53);
+var IObject = __webpack_require__(54);
 var toObject = __webpack_require__(10);
 var toLength = __webpack_require__(7);
-var asc = __webpack_require__(105);
+var asc = __webpack_require__(106);
 module.exports = function (TYPE, $create) {
   var IS_MAP = TYPE == 1;
   var IS_FILTER = TYPE == 2;
@@ -844,8 +844,8 @@ if (__webpack_require__(8)) {
   var global = __webpack_require__(3);
   var fails = __webpack_require__(4);
   var $export = __webpack_require__(0);
-  var $typed = __webpack_require__(76);
-  var $buffer = __webpack_require__(113);
+  var $typed = __webpack_require__(77);
+  var $buffer = __webpack_require__(114);
   var ctx = __webpack_require__(22);
   var anInstance = __webpack_require__(43);
   var propertyDesc = __webpack_require__(36);
@@ -853,29 +853,29 @@ if (__webpack_require__(8)) {
   var redefineAll = __webpack_require__(45);
   var toInteger = __webpack_require__(24);
   var toLength = __webpack_require__(7);
-  var toIndex = __webpack_require__(153);
+  var toIndex = __webpack_require__(154);
   var toAbsoluteIndex = __webpack_require__(39);
   var toPrimitive = __webpack_require__(27);
   var has = __webpack_require__(17);
-  var classof = __webpack_require__(49);
+  var classof = __webpack_require__(50);
   var isObject = __webpack_require__(5);
   var toObject = __webpack_require__(10);
-  var isArrayIter = __webpack_require__(102);
+  var isArrayIter = __webpack_require__(103);
   var create = __webpack_require__(40);
   var getPrototypeOf = __webpack_require__(20);
   var gOPN = __webpack_require__(41).f;
-  var getIterFn = __webpack_require__(104);
+  var getIterFn = __webpack_require__(105);
   var uid = __webpack_require__(37);
   var wks = __webpack_require__(6);
   var createArrayMethod = __webpack_require__(30);
-  var createArrayIncludes = __webpack_require__(66);
-  var speciesConstructor = __webpack_require__(56);
-  var ArrayIterators = __webpack_require__(107);
-  var Iterators = __webpack_require__(51);
-  var $iterDetect = __webpack_require__(71);
+  var createArrayIncludes = __webpack_require__(67);
+  var speciesConstructor = __webpack_require__(57);
+  var ArrayIterators = __webpack_require__(108);
+  var Iterators = __webpack_require__(52);
+  var $iterDetect = __webpack_require__(72);
   var setSpecies = __webpack_require__(42);
-  var arrayFill = __webpack_require__(106);
-  var arrayCopyWithin = __webpack_require__(142);
+  var arrayFill = __webpack_require__(107);
+  var arrayCopyWithin = __webpack_require__(143);
   var $DP = __webpack_require__(9);
   var $GOPD = __webpack_require__(19);
   var dP = $DP.f;
@@ -1325,10 +1325,10 @@ if (__webpack_require__(8)) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var Map = __webpack_require__(148);
+var Map = __webpack_require__(149);
 var $export = __webpack_require__(0);
-var shared = __webpack_require__(52)('metadata');
-var store = shared.store || (shared.store = new (__webpack_require__(151))());
+var shared = __webpack_require__(53)('metadata');
+var store = shared.store || (shared.store = new (__webpack_require__(152))());
 
 var getOrCreateMetadataMap = function getOrCreateMetadataMap(target, targetKey, create) {
   var targetMetadata = store.get(target);
@@ -1485,8 +1485,8 @@ module.exports = function (key) {
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.14 / 15.2.3.14 Object.keys(O)
-var $keys = __webpack_require__(127);
-var enumBugKeys = __webpack_require__(90);
+var $keys = __webpack_require__(128);
+var enumBugKeys = __webpack_require__(91);
 
 module.exports = Object.keys || function keys(O) {
   return $keys(O, enumBugKeys);
@@ -1510,22 +1510,22 @@ module.exports = function (index, length) {
 
 // 19.1.2.2 / 15.2.3.5 Object.create(O [, Properties])
 var anObject = __webpack_require__(1);
-var dPs = __webpack_require__(128);
-var enumBugKeys = __webpack_require__(90);
-var IE_PROTO = __webpack_require__(89)('IE_PROTO');
+var dPs = __webpack_require__(129);
+var enumBugKeys = __webpack_require__(91);
+var IE_PROTO = __webpack_require__(90)('IE_PROTO');
 var Empty = function Empty() {/* empty */};
 var PROTOTYPE = 'prototype';
 
 // Create object with fake `null` prototype: use iframe Object with cleared prototype
 var _createDict = function createDict() {
   // Thrash, waste and sodomy: IE GC bug
-  var iframe = __webpack_require__(87)('iframe');
+  var iframe = __webpack_require__(88)('iframe');
   var i = enumBugKeys.length;
   var lt = '<';
   var gt = '>';
   var iframeDocument;
   iframe.style.display = 'none';
-  __webpack_require__(91).appendChild(iframe);
+  __webpack_require__(92).appendChild(iframe);
   iframe.src = 'javascript:'; // eslint-disable-line no-script-url
   // createDict = iframe.contentWindow.Object;
   // html.removeChild(iframe);
@@ -1556,8 +1556,8 @@ module.exports = Object.create || function create(O, Properties) {
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.7 / 15.2.3.4 Object.getOwnPropertyNames(O)
-var $keys = __webpack_require__(127);
-var hiddenKeys = __webpack_require__(90).concat('length', 'prototype');
+var $keys = __webpack_require__(128);
+var hiddenKeys = __webpack_require__(91).concat('length', 'prototype');
 
 exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
   return $keys(O, hiddenKeys);
@@ -1600,11 +1600,11 @@ module.exports = function (it, Constructor, name, forbiddenField) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var ctx = __webpack_require__(22);
-var call = __webpack_require__(140);
-var isArrayIter = __webpack_require__(102);
+var call = __webpack_require__(141);
+var isArrayIter = __webpack_require__(103);
 var anObject = __webpack_require__(1);
 var toLength = __webpack_require__(7);
-var getIterFn = __webpack_require__(104);
+var getIterFn = __webpack_require__(105);
 var BREAK = {};
 var RETURN = {};
 var exports = module.exports = function (iterable, entries, fn, that, ITERATOR) {
@@ -1887,6 +1887,59 @@ var VBaseContainer = function (_VBaseComponent) {
 
 /***/ }),
 /* 48 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return dirtyableMixin; });
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var dirtyableMixin = function dirtyableMixin(Base) {
+    return function (_Base) {
+        _inherits(_class, _Base);
+
+        function _class() {
+            _classCallCheck(this, _class);
+
+            return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
+        }
+
+        _createClass(_class, [{
+            key: 'isDirty',
+            value: function isDirty() {
+                // Implement in extending classes.
+                throw new Error('Implement isDirty()');
+            }
+        }, {
+            key: 'originalValue',
+            get: function get() {
+                return this._originalValue;
+            },
+            set: function set(value) {
+                this._originalValue = value;
+            }
+        }, {
+            key: 'dirtyable',
+            get: function get() {
+                if (!this.element) {
+                    return false;
+                }
+
+                return this.element.hasAttribute('data-dirtyable');
+            }
+        }]);
+
+        return _class;
+    }(Base);
+};
+
+/***/ }),
+/* 49 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var def = __webpack_require__(9).f;
@@ -1898,7 +1951,7 @@ module.exports = function (it, tag, stat) {
 };
 
 /***/ }),
-/* 49 */
+/* 50 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // getting tag from 19.1.3.6 Object.prototype.toString()
@@ -1928,13 +1981,13 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 50 */
+/* 51 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
 var defined = __webpack_require__(28);
 var fails = __webpack_require__(4);
-var spaces = __webpack_require__(93);
+var spaces = __webpack_require__(94);
 var space = '[' + spaces + ']';
 var non = '\u200B\x85';
 var ltrim = RegExp('^' + space + space + '*');
@@ -1963,13 +2016,13 @@ var trim = exporter.trim = function (string, TYPE) {
 module.exports = exporter;
 
 /***/ }),
-/* 51 */
+/* 52 */
 /***/ (function(module, exports) {
 
 module.exports = {};
 
 /***/ }),
-/* 52 */
+/* 53 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var core = __webpack_require__(21);
@@ -1986,7 +2039,7 @@ var store = global[SHARED] || (global[SHARED] = {});
 });
 
 /***/ }),
-/* 53 */
+/* 54 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // fallback for non-array-like ES3 and non-enumerable old V8 strings
@@ -1997,13 +2050,13 @@ module.exports = Object('z').propertyIsEnumerable(0) ? Object : function (it) {
 };
 
 /***/ }),
-/* 54 */
+/* 55 */
 /***/ (function(module, exports) {
 
 exports.f = {}.propertyIsEnumerable;
 
 /***/ }),
-/* 55 */
+/* 56 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2023,7 +2076,7 @@ module.exports = function () {
 };
 
 /***/ }),
-/* 56 */
+/* 57 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.3.20 SpeciesConstructor(O, defaultConstructor)
@@ -2037,10 +2090,10 @@ module.exports = function (O, D) {
 };
 
 /***/ }),
-/* 57 */
+/* 58 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var fails = __webpack_require__(58);
+var fails = __webpack_require__(59);
 
 // Thank's IE8 for his funny defineProperty
 module.exports = !fails(function () {
@@ -2050,7 +2103,7 @@ module.exports = !fails(function () {
 });
 
 /***/ }),
-/* 58 */
+/* 59 */
 /***/ (function(module, exports) {
 
 module.exports = function (exec) {
@@ -2062,7 +2115,7 @@ module.exports = function (exec) {
 };
 
 /***/ }),
-/* 59 */
+/* 60 */
 /***/ (function(module, exports) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -2072,7 +2125,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 60 */
+/* 61 */
 /***/ (function(module, exports) {
 
 var hasOwnProperty = {}.hasOwnProperty;
@@ -2082,12 +2135,12 @@ module.exports = function (it, key) {
 };
 
 /***/ }),
-/* 61 */
+/* 62 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(57);
-var definePropertyModule = __webpack_require__(116);
-var createPropertyDescriptor = __webpack_require__(165);
+var DESCRIPTORS = __webpack_require__(58);
+var definePropertyModule = __webpack_require__(117);
+var createPropertyDescriptor = __webpack_require__(166);
 
 module.exports = DESCRIPTORS ? function (object, key, value) {
   return definePropertyModule.f(object, key, createPropertyDescriptor(1, value));
@@ -2097,7 +2150,7 @@ module.exports = DESCRIPTORS ? function (object, key, value) {
 };
 
 /***/ }),
-/* 62 */
+/* 63 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -2263,7 +2316,7 @@ var MDCTopAppBarAdapter = function () {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCTopAppBarAdapter);
 
 /***/ }),
-/* 63 */
+/* 64 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -2320,7 +2373,7 @@ var strings = {
 
 
 /***/ }),
-/* 64 */
+/* 65 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -2352,7 +2405,7 @@ var strings = {
 }));
 
 /***/ }),
-/* 65 */
+/* 66 */
 /***/ (function(module, exports) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -2379,7 +2432,7 @@ try {
 module.exports = g;
 
 /***/ }),
-/* 66 */
+/* 67 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // false -> Array#indexOf
@@ -2409,13 +2462,13 @@ module.exports = function (IS_INCLUDES) {
 };
 
 /***/ }),
-/* 67 */
+/* 68 */
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 /***/ }),
-/* 68 */
+/* 69 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.2.2 IsArray(argument)
@@ -2425,7 +2478,7 @@ module.exports = Array.isArray || function isArray(arg) {
 };
 
 /***/ }),
-/* 69 */
+/* 70 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var toInteger = __webpack_require__(24);
@@ -2445,7 +2498,7 @@ module.exports = function (TO_STRING) {
 };
 
 /***/ }),
-/* 70 */
+/* 71 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.2.8 IsRegExp(argument)
@@ -2458,7 +2511,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 71 */
+/* 72 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var ITERATOR = __webpack_require__(6)('iterator');
@@ -2493,7 +2546,7 @@ module.exports = function (exec, skipClosing) {
 };
 
 /***/ }),
-/* 72 */
+/* 73 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2501,7 +2554,7 @@ module.exports = function (exec, skipClosing) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var classof = __webpack_require__(49);
+var classof = __webpack_require__(50);
 var builtinExec = RegExp.prototype.exec;
 
 // `RegExpExec` abstract operation
@@ -2522,19 +2575,19 @@ module.exports = function (R, S) {
 };
 
 /***/ }),
-/* 73 */
+/* 74 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-__webpack_require__(144);
+__webpack_require__(145);
 var redefine = __webpack_require__(15);
 var hide = __webpack_require__(14);
 var fails = __webpack_require__(4);
 var defined = __webpack_require__(28);
 var wks = __webpack_require__(6);
-var regexpExec = __webpack_require__(108);
+var regexpExec = __webpack_require__(109);
 
 var SPECIES = wks('species');
 
@@ -2626,7 +2679,7 @@ module.exports = function (KEY, length, exec) {
 };
 
 /***/ }),
-/* 74 */
+/* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
@@ -2635,7 +2688,7 @@ var navigator = global.navigator;
 module.exports = navigator && navigator.userAgent || '';
 
 /***/ }),
-/* 75 */
+/* 76 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2650,9 +2703,9 @@ var forOf = __webpack_require__(44);
 var anInstance = __webpack_require__(43);
 var isObject = __webpack_require__(5);
 var fails = __webpack_require__(4);
-var $iterDetect = __webpack_require__(71);
-var setToStringTag = __webpack_require__(48);
-var inheritIfRequired = __webpack_require__(94);
+var $iterDetect = __webpack_require__(72);
+var setToStringTag = __webpack_require__(49);
+var inheritIfRequired = __webpack_require__(95);
 
 module.exports = function (NAME, wrapper, methods, common, IS_MAP, IS_WEAK) {
   var Base = global[NAME];
@@ -2733,7 +2786,7 @@ module.exports = function (NAME, wrapper, methods, common, IS_MAP, IS_WEAK) {
 };
 
 /***/ }),
-/* 76 */
+/* 77 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
@@ -2764,7 +2817,7 @@ module.exports = {
 };
 
 /***/ }),
-/* 77 */
+/* 78 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2780,7 +2833,7 @@ module.exports = __webpack_require__(33) || !__webpack_require__(4)(function () 
 });
 
 /***/ }),
-/* 78 */
+/* 79 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2800,7 +2853,7 @@ module.exports = function (COLLECTION) {
 };
 
 /***/ }),
-/* 79 */
+/* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2835,10 +2888,10 @@ module.exports = function (COLLECTION) {
 };
 
 /***/ }),
-/* 80 */
+/* 81 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(59);
+var isObject = __webpack_require__(60);
 
 module.exports = function (it) {
   if (!isObject(it)) {
@@ -2847,11 +2900,11 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 81 */
+/* 82 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
-var setGlobal = __webpack_require__(117);
+var setGlobal = __webpack_require__(118);
 var IS_PURE = __webpack_require__(414);
 
 var SHARED = '__core-js_shared__';
@@ -2866,10 +2919,10 @@ var store = global[SHARED] || setGlobal(SHARED, {});
 });
 
 /***/ }),
-/* 82 */
+/* 83 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toInteger = __webpack_require__(119);
+var toInteger = __webpack_require__(120);
 
 var min = Math.min;
 
@@ -2880,7 +2933,7 @@ module.exports = function (argument) {
 };
 
 /***/ }),
-/* 83 */
+/* 84 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -2991,16 +3044,16 @@ function expandParams(results, params) {
 }
 
 /***/ }),
-/* 84 */
+/* 85 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(162);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(163);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(437);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(436);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(114);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(115);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(187);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -3207,13 +3260,13 @@ var VBase = function (_VUrls) {
 }(__WEBPACK_IMPORTED_MODULE_3__utils_urls__["a" /* VUrls */]);
 
 /***/ }),
-/* 85 */
+/* 86 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(63);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(62);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(124);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -3361,13 +3414,14 @@ var MDCTopAppBarBaseFoundation = function (_MDCFoundation) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCTopAppBarBaseFoundation);
 
 /***/ }),
-/* 86 */
+/* 87 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseToggle; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__ = __webpack_require__(48);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -3379,8 +3433,9 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
-var VBaseToggle = function (_eventHandlerMixin) {
-    _inherits(VBaseToggle, _eventHandlerMixin);
+
+var VBaseToggle = function (_dirtyableMixin) {
+    _inherits(VBaseToggle, _dirtyableMixin);
 
     function VBaseToggle(element, mdcComponent) {
         _classCallCheck(this, VBaseToggle);
@@ -3393,6 +3448,8 @@ var VBaseToggle = function (_eventHandlerMixin) {
             // Revert to previous checked state on failed post.
             _this.mdcComponent.checked = !_this.mdcComponent.checked;
         });
+
+        _this.originalValue = _this.input.checked;
         return _this;
     }
 
@@ -3431,20 +3488,25 @@ var VBaseToggle = function (_eventHandlerMixin) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.input.checked = this.element.dataset.originalValue;
+            this.input.checked = this.originalValue;
         }
     }, {
         key: 'setValue',
         value: function setValue(value) {
             this.input.value = value;
         }
+    }, {
+        key: 'isDirty',
+        value: function isDirty() {
+            return this.dirtyable && this.input.checked !== this.originalValue;
+        }
     }]);
 
     return VBaseToggle;
-}(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
+}(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 87 */
+/* 88 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(5);
@@ -3456,13 +3518,13 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 88 */
+/* 89 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
 var core = __webpack_require__(21);
 var LIBRARY = __webpack_require__(33);
-var wksExt = __webpack_require__(126);
+var wksExt = __webpack_require__(127);
 var defineProperty = __webpack_require__(9).f;
 module.exports = function (name) {
   var $Symbol = core.Symbol || (core.Symbol = LIBRARY ? {} : global.Symbol || {});
@@ -3470,31 +3532,31 @@ module.exports = function (name) {
 };
 
 /***/ }),
-/* 89 */
+/* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var shared = __webpack_require__(52)('keys');
+var shared = __webpack_require__(53)('keys');
 var uid = __webpack_require__(37);
 module.exports = function (key) {
   return shared[key] || (shared[key] = uid(key));
 };
 
 /***/ }),
-/* 90 */
+/* 91 */
 /***/ (function(module, exports) {
 
 // IE 8- don't enum bug keys
 module.exports = 'constructor,hasOwnProperty,isPrototypeOf,propertyIsEnumerable,toLocaleString,toString,valueOf'.split(',');
 
 /***/ }),
-/* 91 */
+/* 92 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var document = __webpack_require__(3).document;
 module.exports = document && document.documentElement;
 
 /***/ }),
-/* 92 */
+/* 93 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // Works with __proto__ only. Old v8 can't work with null proto objects.
@@ -3525,17 +3587,17 @@ module.exports = {
 };
 
 /***/ }),
-/* 93 */
+/* 94 */
 /***/ (function(module, exports) {
 
 module.exports = '\t\n\x0B\f\r \xA0\u1680\u180E\u2000\u2001\u2002\u2003' + '\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF';
 
 /***/ }),
-/* 94 */
+/* 95 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(5);
-var setPrototypeOf = __webpack_require__(92).set;
+var setPrototypeOf = __webpack_require__(93).set;
 module.exports = function (that, target, C) {
   var S = target.constructor;
   var P;
@@ -3545,7 +3607,7 @@ module.exports = function (that, target, C) {
 };
 
 /***/ }),
-/* 95 */
+/* 96 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -3565,7 +3627,7 @@ module.exports = function repeat(count) {
 };
 
 /***/ }),
-/* 96 */
+/* 97 */
 /***/ (function(module, exports) {
 
 // 20.2.2.28 Math.sign(x)
@@ -3575,7 +3637,7 @@ module.exports = Math.sign || function sign(x) {
 };
 
 /***/ }),
-/* 97 */
+/* 98 */
 /***/ (function(module, exports) {
 
 // 20.2.2.14 Math.expm1(x)
@@ -3589,7 +3651,7 @@ module.exports = !$expm1
 } : $expm1;
 
 /***/ }),
-/* 98 */
+/* 99 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -3599,9 +3661,9 @@ var LIBRARY = __webpack_require__(33);
 var $export = __webpack_require__(0);
 var redefine = __webpack_require__(15);
 var hide = __webpack_require__(14);
-var Iterators = __webpack_require__(51);
-var $iterCreate = __webpack_require__(99);
-var setToStringTag = __webpack_require__(48);
+var Iterators = __webpack_require__(52);
+var $iterCreate = __webpack_require__(100);
+var setToStringTag = __webpack_require__(49);
 var getPrototypeOf = __webpack_require__(20);
 var ITERATOR = __webpack_require__(6)('iterator');
 var BUGGY = !([].keys && 'next' in [].keys()); // Safari has buggy iterators w/o `next`
@@ -3677,7 +3739,7 @@ module.exports = function (Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCE
 };
 
 /***/ }),
-/* 99 */
+/* 100 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -3685,7 +3747,7 @@ module.exports = function (Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCE
 
 var create = __webpack_require__(40);
 var descriptor = __webpack_require__(36);
-var setToStringTag = __webpack_require__(48);
+var setToStringTag = __webpack_require__(49);
 var IteratorPrototype = {};
 
 // 25.1.2.1.1 %IteratorPrototype%[@@iterator]()
@@ -3699,11 +3761,11 @@ module.exports = function (Constructor, NAME, next) {
 };
 
 /***/ }),
-/* 100 */
+/* 101 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // helper for String#{startsWith, endsWith, includes}
-var isRegExp = __webpack_require__(70);
+var isRegExp = __webpack_require__(71);
 var defined = __webpack_require__(28);
 
 module.exports = function (that, searchString, NAME) {
@@ -3712,7 +3774,7 @@ module.exports = function (that, searchString, NAME) {
 };
 
 /***/ }),
-/* 101 */
+/* 102 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var MATCH = __webpack_require__(6)('match');
@@ -3729,11 +3791,11 @@ module.exports = function (KEY) {
 };
 
 /***/ }),
-/* 102 */
+/* 103 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // check on default Array iterator
-var Iterators = __webpack_require__(51);
+var Iterators = __webpack_require__(52);
 var ITERATOR = __webpack_require__(6)('iterator');
 var ArrayProto = Array.prototype;
 
@@ -3742,7 +3804,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 103 */
+/* 104 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -3756,18 +3818,18 @@ module.exports = function (object, index, value) {
 };
 
 /***/ }),
-/* 104 */
+/* 105 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var classof = __webpack_require__(49);
+var classof = __webpack_require__(50);
 var ITERATOR = __webpack_require__(6)('iterator');
-var Iterators = __webpack_require__(51);
+var Iterators = __webpack_require__(52);
 module.exports = __webpack_require__(21).getIteratorMethod = function (it) {
   if (it != undefined) return it[ITERATOR] || it['@@iterator'] || Iterators[classof(it)];
 };
 
 /***/ }),
-/* 105 */
+/* 106 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 9.4.2.3 ArraySpeciesCreate(originalArray, length)
@@ -3778,7 +3840,7 @@ module.exports = function (original, length) {
 };
 
 /***/ }),
-/* 106 */
+/* 107 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -3801,22 +3863,22 @@ module.exports = function fill(value /* , start = 0, end = @length */) {
 };
 
 /***/ }),
-/* 107 */
+/* 108 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
 var addToUnscopables = __webpack_require__(35);
-var step = __webpack_require__(143);
-var Iterators = __webpack_require__(51);
+var step = __webpack_require__(144);
+var Iterators = __webpack_require__(52);
 var toIObject = __webpack_require__(18);
 
 // 22.1.3.4 Array.prototype.entries()
 // 22.1.3.13 Array.prototype.keys()
 // 22.1.3.29 Array.prototype.values()
 // 22.1.3.30 Array.prototype[@@iterator]()
-module.exports = __webpack_require__(98)(Array, 'Array', function (iterated, kind) {
+module.exports = __webpack_require__(99)(Array, 'Array', function (iterated, kind) {
   this._t = toIObject(iterated); // target
   this._i = 0; // next index
   this._k = kind; // kind
@@ -3842,13 +3904,13 @@ addToUnscopables('values');
 addToUnscopables('entries');
 
 /***/ }),
-/* 108 */
+/* 109 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var regexpFlags = __webpack_require__(55);
+var regexpFlags = __webpack_require__(56);
 
 var nativeExec = RegExp.prototype.exec;
 // This always refers to the native implementation, because the
@@ -3906,13 +3968,13 @@ if (PATCH) {
 module.exports = patchedExec;
 
 /***/ }),
-/* 109 */
+/* 110 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var at = __webpack_require__(69)(true);
+var at = __webpack_require__(70)(true);
 
 // `AdvanceStringIndex` abstract operation
 // https://tc39.github.io/ecma262/#sec-advancestringindex
@@ -3921,13 +3983,13 @@ module.exports = function (S, index, unicode) {
 };
 
 /***/ }),
-/* 110 */
+/* 111 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var ctx = __webpack_require__(22);
-var invoke = __webpack_require__(133);
-var html = __webpack_require__(91);
-var cel = __webpack_require__(87);
+var invoke = __webpack_require__(134);
+var html = __webpack_require__(92);
+var cel = __webpack_require__(88);
 var global = __webpack_require__(3);
 var process = global.process;
 var setTask = global.setImmediate;
@@ -4011,11 +4073,11 @@ module.exports = {
 };
 
 /***/ }),
-/* 111 */
+/* 112 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
-var macrotask = __webpack_require__(110).set;
+var macrotask = __webpack_require__(111).set;
 var Observer = global.MutationObserver || global.WebKitMutationObserver;
 var process = global.process;
 var Promise = global.Promise;
@@ -4084,7 +4146,7 @@ module.exports = function () {
 };
 
 /***/ }),
-/* 112 */
+/* 113 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -4109,7 +4171,7 @@ module.exports.f = function (C) {
 };
 
 /***/ }),
-/* 113 */
+/* 114 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -4118,18 +4180,18 @@ module.exports.f = function (C) {
 var global = __webpack_require__(3);
 var DESCRIPTORS = __webpack_require__(8);
 var LIBRARY = __webpack_require__(33);
-var $typed = __webpack_require__(76);
+var $typed = __webpack_require__(77);
 var hide = __webpack_require__(14);
 var redefineAll = __webpack_require__(45);
 var fails = __webpack_require__(4);
 var anInstance = __webpack_require__(43);
 var toInteger = __webpack_require__(24);
 var toLength = __webpack_require__(7);
-var toIndex = __webpack_require__(153);
+var toIndex = __webpack_require__(154);
 var gOPN = __webpack_require__(41).f;
 var dP = __webpack_require__(9).f;
-var arrayFill = __webpack_require__(106);
-var setToStringTag = __webpack_require__(48);
+var arrayFill = __webpack_require__(107);
+var setToStringTag = __webpack_require__(49);
 var ARRAY_BUFFER = 'ArrayBuffer';
 var DATA_VIEW = 'DataView';
 var PROTOTYPE = 'prototype';
@@ -4396,12 +4458,12 @@ exports[ARRAY_BUFFER] = $ArrayBuffer;
 exports[DATA_VIEW] = $DataView;
 
 /***/ }),
-/* 114 */
+/* 115 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VErrors; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(162);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(163);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
@@ -4689,30 +4751,28 @@ var VErrors = function () {
 }();
 
 /***/ }),
-/* 115 */
+/* 116 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // toObject with fallback for non-array-like ES3 strings
 var IndexedObject = __webpack_require__(412);
-var requireObjectCoercible = __webpack_require__(167);
+var requireObjectCoercible = __webpack_require__(168);
 
 module.exports = function (it) {
   return IndexedObject(requireObjectCoercible(it));
 };
 
 /***/ }),
-/* 116 */
+/* 117 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(57);
-var IE8_DOM_DEFINE = __webpack_require__(169);
-var anObject = __webpack_require__(80);
-var toPrimitive = __webpack_require__(168);
+var DESCRIPTORS = __webpack_require__(58);
+var IE8_DOM_DEFINE = __webpack_require__(170);
+var anObject = __webpack_require__(81);
+var toPrimitive = __webpack_require__(169);
 
 var nativeDefineProperty = Object.defineProperty;
 
-// `Object.defineProperty` method
-// https://tc39.github.io/ecma262/#sec-object.defineproperty
 exports.f = DESCRIPTORS ? nativeDefineProperty : function defineProperty(O, P, Attributes) {
   anObject(O);
   P = toPrimitive(P, true);
@@ -4726,11 +4786,11 @@ exports.f = DESCRIPTORS ? nativeDefineProperty : function defineProperty(O, P, A
 };
 
 /***/ }),
-/* 117 */
+/* 118 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
-var hide = __webpack_require__(61);
+var hide = __webpack_require__(62);
 
 module.exports = function (key, value) {
   try {
@@ -4741,13 +4801,13 @@ module.exports = function (key, value) {
 };
 
 /***/ }),
-/* 118 */
+/* 119 */
 /***/ (function(module, exports) {
 
 module.exports = {};
 
 /***/ }),
-/* 119 */
+/* 120 */
 /***/ (function(module, exports) {
 
 var ceil = Math.ceil;
@@ -4760,14 +4820,14 @@ module.exports = function (argument) {
 };
 
 /***/ }),
-/* 120 */
+/* 121 */
 /***/ (function(module, exports) {
 
 // IE8- don't enum bug keys
 module.exports = ['constructor', 'hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable', 'toLocaleString', 'toString', 'valueOf'];
 
 /***/ }),
-/* 121 */
+/* 122 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -4829,27 +4889,27 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 };
 
 /***/ }),
-/* 122 */
+/* 123 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VEvents; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = initEvents;
 /* harmony export (immutable) */ __webpack_exports__["c"] = removeEvents;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(435);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(436);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(442);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(434);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(435);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(441);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(189);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(114);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(445);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(446);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(447);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(448);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(449);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(450);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(451);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(452);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(453);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(115);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(444);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(445);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(446);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(447);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(448);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(449);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(450);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(451);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(452);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -5174,7 +5234,7 @@ function fireAfterLoad(e) {
 }
 
 /***/ }),
-/* 123 */
+/* 124 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -5283,7 +5343,7 @@ var MDCFoundation = function () {
 /* harmony default export */ __webpack_exports__["a"] = (MDCFoundation);
 
 /***/ }),
-/* 124 */
+/* 125 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -5612,29 +5672,29 @@ function __importDefault(mod) {
 }
 
 /***/ }),
-/* 125 */
+/* 126 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = !__webpack_require__(8) && !__webpack_require__(4)(function () {
-  return Object.defineProperty(__webpack_require__(87)('div'), 'a', { get: function get() {
+  return Object.defineProperty(__webpack_require__(88)('div'), 'a', { get: function get() {
       return 7;
     } }).a != 7;
 });
 
 /***/ }),
-/* 126 */
+/* 127 */
 /***/ (function(module, exports, __webpack_require__) {
 
 exports.f = __webpack_require__(6);
 
 /***/ }),
-/* 127 */
+/* 128 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var has = __webpack_require__(17);
 var toIObject = __webpack_require__(18);
-var arrayIndexOf = __webpack_require__(66)(false);
-var IE_PROTO = __webpack_require__(89)('IE_PROTO');
+var arrayIndexOf = __webpack_require__(67)(false);
+var IE_PROTO = __webpack_require__(90)('IE_PROTO');
 
 module.exports = function (object, names) {
   var O = toIObject(object);
@@ -5652,7 +5712,7 @@ module.exports = function (object, names) {
 };
 
 /***/ }),
-/* 128 */
+/* 129 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var dP = __webpack_require__(9);
@@ -5671,7 +5731,7 @@ module.exports = __webpack_require__(8) ? Object.defineProperties : function def
 };
 
 /***/ }),
-/* 129 */
+/* 130 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -5696,7 +5756,7 @@ module.exports.f = function getOwnPropertyNames(it) {
 };
 
 /***/ }),
-/* 130 */
+/* 131 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5705,10 +5765,10 @@ module.exports.f = function getOwnPropertyNames(it) {
 
 var DESCRIPTORS = __webpack_require__(8);
 var getKeys = __webpack_require__(38);
-var gOPS = __webpack_require__(67);
-var pIE = __webpack_require__(54);
+var gOPS = __webpack_require__(68);
+var pIE = __webpack_require__(55);
 var toObject = __webpack_require__(10);
-var IObject = __webpack_require__(53);
+var IObject = __webpack_require__(54);
 var $assign = Object.assign;
 
 // should work with symbols and should have deterministic property order (V8 bug)
@@ -5744,7 +5804,7 @@ module.exports = !$assign || __webpack_require__(4)(function () {
 } : $assign;
 
 /***/ }),
-/* 131 */
+/* 132 */
 /***/ (function(module, exports) {
 
 // 7.2.9 SameValue(x, y)
@@ -5754,7 +5814,7 @@ module.exports = Object.is || function is(x, y) {
 };
 
 /***/ }),
-/* 132 */
+/* 133 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5762,7 +5822,7 @@ module.exports = Object.is || function is(x, y) {
 
 var aFunction = __webpack_require__(13);
 var isObject = __webpack_require__(5);
-var invoke = __webpack_require__(133);
+var invoke = __webpack_require__(134);
 var arraySlice = [].slice;
 var factories = {};
 
@@ -5787,7 +5847,7 @@ module.exports = Function.bind || function bind(that /* , ...args */) {
 };
 
 /***/ }),
-/* 133 */
+/* 134 */
 /***/ (function(module, exports) {
 
 // fast apply, http://jsperf.lnkit.com/fast-apply/5
@@ -5808,12 +5868,12 @@ module.exports = function (fn, args, that) {
 };
 
 /***/ }),
-/* 134 */
+/* 135 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $parseInt = __webpack_require__(3).parseInt;
-var $trim = __webpack_require__(50).trim;
-var ws = __webpack_require__(93);
+var $trim = __webpack_require__(51).trim;
+var ws = __webpack_require__(94);
 var hex = /^[-+]?0[xX]/;
 
 module.exports = $parseInt(ws + '08') !== 8 || $parseInt(ws + '0x16') !== 22 ? function parseInt(str, radix) {
@@ -5822,20 +5882,20 @@ module.exports = $parseInt(ws + '08') !== 8 || $parseInt(ws + '0x16') !== 22 ? f
 } : $parseInt;
 
 /***/ }),
-/* 135 */
+/* 136 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $parseFloat = __webpack_require__(3).parseFloat;
-var $trim = __webpack_require__(50).trim;
+var $trim = __webpack_require__(51).trim;
 
-module.exports = 1 / $parseFloat(__webpack_require__(93) + '-0') !== -Infinity ? function parseFloat(str) {
+module.exports = 1 / $parseFloat(__webpack_require__(94) + '-0') !== -Infinity ? function parseFloat(str) {
   var string = $trim(String(str), 3);
   var result = $parseFloat(string);
   return result === 0 && string.charAt(0) == '-' ? -0 : result;
 } : $parseFloat;
 
 /***/ }),
-/* 136 */
+/* 137 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var cof = __webpack_require__(23);
@@ -5845,7 +5905,7 @@ module.exports = function (it, msg) {
 };
 
 /***/ }),
-/* 137 */
+/* 138 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.3 Number.isInteger(number)
@@ -5856,7 +5916,7 @@ module.exports = function isInteger(it) {
 };
 
 /***/ }),
-/* 138 */
+/* 139 */
 /***/ (function(module, exports) {
 
 // 20.2.2.20 Math.log1p(x)
@@ -5865,11 +5925,11 @@ module.exports = Math.log1p || function log1p(x) {
 };
 
 /***/ }),
-/* 139 */
+/* 140 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.16 Math.fround(x)
-var sign = __webpack_require__(96);
+var sign = __webpack_require__(97);
 var pow = Math.pow;
 var EPSILON = pow(2, -52);
 var EPSILON32 = pow(2, -23);
@@ -5893,7 +5953,7 @@ module.exports = Math.fround || function fround(x) {
 };
 
 /***/ }),
-/* 140 */
+/* 141 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // call something on iterator step with safe closing on error
@@ -5910,12 +5970,12 @@ module.exports = function (iterator, fn, value, entries) {
 };
 
 /***/ }),
-/* 141 */
+/* 142 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var aFunction = __webpack_require__(13);
 var toObject = __webpack_require__(10);
-var IObject = __webpack_require__(53);
+var IObject = __webpack_require__(54);
 var toLength = __webpack_require__(7);
 
 module.exports = function (that, callbackfn, aLen, memo, isRight) {
@@ -5944,7 +6004,7 @@ module.exports = function (that, callbackfn, aLen, memo, isRight) {
 };
 
 /***/ }),
-/* 142 */
+/* 143 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -5976,7 +6036,7 @@ module.exports = [].copyWithin || function copyWithin(target /* = 0 */, start /*
 };
 
 /***/ }),
-/* 143 */
+/* 144 */
 /***/ (function(module, exports) {
 
 module.exports = function (done, value) {
@@ -5984,13 +6044,13 @@ module.exports = function (done, value) {
 };
 
 /***/ }),
-/* 144 */
+/* 145 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var regexpExec = __webpack_require__(108);
+var regexpExec = __webpack_require__(109);
 __webpack_require__(0)({
   target: 'RegExp',
   proto: true,
@@ -6000,17 +6060,17 @@ __webpack_require__(0)({
 });
 
 /***/ }),
-/* 145 */
+/* 146 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 21.2.5.3 get RegExp.prototype.flags()
 if (__webpack_require__(8) && /./g.flags != 'g') __webpack_require__(9).f(RegExp.prototype, 'flags', {
   configurable: true,
-  get: __webpack_require__(55)
+  get: __webpack_require__(56)
 });
 
 /***/ }),
-/* 146 */
+/* 147 */
 /***/ (function(module, exports) {
 
 module.exports = function (exec) {
@@ -6022,12 +6082,12 @@ module.exports = function (exec) {
 };
 
 /***/ }),
-/* 147 */
+/* 148 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
-var newPromiseCapability = __webpack_require__(112);
+var newPromiseCapability = __webpack_require__(113);
 
 module.exports = function (C, x) {
   anObject(C);
@@ -6039,18 +6099,18 @@ module.exports = function (C, x) {
 };
 
 /***/ }),
-/* 148 */
+/* 149 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var strong = __webpack_require__(149);
+var strong = __webpack_require__(150);
 var validate = __webpack_require__(46);
 var MAP = 'Map';
 
 // 23.1 Map Objects
-module.exports = __webpack_require__(75)(MAP, function (get) {
+module.exports = __webpack_require__(76)(MAP, function (get) {
   return function Map() {
     return get(this, arguments.length > 0 ? arguments[0] : undefined);
   };
@@ -6067,7 +6127,7 @@ module.exports = __webpack_require__(75)(MAP, function (get) {
 }, strong, true);
 
 /***/ }),
-/* 149 */
+/* 150 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6079,8 +6139,8 @@ var redefineAll = __webpack_require__(45);
 var ctx = __webpack_require__(22);
 var anInstance = __webpack_require__(43);
 var forOf = __webpack_require__(44);
-var $iterDefine = __webpack_require__(98);
-var step = __webpack_require__(143);
+var $iterDefine = __webpack_require__(99);
+var step = __webpack_require__(144);
 var setSpecies = __webpack_require__(42);
 var DESCRIPTORS = __webpack_require__(8);
 var fastKey = __webpack_require__(34).fastKey;
@@ -6221,18 +6281,18 @@ module.exports = {
 };
 
 /***/ }),
-/* 150 */
+/* 151 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var strong = __webpack_require__(149);
+var strong = __webpack_require__(150);
 var validate = __webpack_require__(46);
 var SET = 'Set';
 
 // 23.2 Set Objects
-module.exports = __webpack_require__(75)(SET, function (get) {
+module.exports = __webpack_require__(76)(SET, function (get) {
   return function Set() {
     return get(this, arguments.length > 0 ? arguments[0] : undefined);
   };
@@ -6244,7 +6304,7 @@ module.exports = __webpack_require__(75)(SET, function (get) {
 }, strong);
 
 /***/ }),
-/* 151 */
+/* 152 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6254,8 +6314,8 @@ var global = __webpack_require__(3);
 var each = __webpack_require__(30)(0);
 var redefine = __webpack_require__(15);
 var meta = __webpack_require__(34);
-var assign = __webpack_require__(130);
-var weak = __webpack_require__(152);
+var assign = __webpack_require__(131);
+var weak = __webpack_require__(153);
 var isObject = __webpack_require__(5);
 var validate = __webpack_require__(46);
 var NATIVE_WEAK_MAP = __webpack_require__(46);
@@ -6288,7 +6348,7 @@ var methods = {
 };
 
 // 23.3 WeakMap Objects
-var $WeakMap = module.exports = __webpack_require__(75)(WEAK_MAP, wrapper, methods, weak, true, true);
+var $WeakMap = module.exports = __webpack_require__(76)(WEAK_MAP, wrapper, methods, weak, true, true);
 
 // IE11 WeakMap frozen keys fix
 if (NATIVE_WEAK_MAP && IS_IE11) {
@@ -6311,7 +6371,7 @@ if (NATIVE_WEAK_MAP && IS_IE11) {
 }
 
 /***/ }),
-/* 152 */
+/* 153 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -6401,7 +6461,7 @@ module.exports = {
 };
 
 /***/ }),
-/* 153 */
+/* 154 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/ecma262/#sec-toindex
@@ -6416,12 +6476,12 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 154 */
+/* 155 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // all object keys, includes non-enumerable and symbols
 var gOPN = __webpack_require__(41);
-var gOPS = __webpack_require__(67);
+var gOPS = __webpack_require__(68);
 var anObject = __webpack_require__(1);
 var Reflect = __webpack_require__(3).Reflect;
 module.exports = Reflect && Reflect.ownKeys || function ownKeys(it) {
@@ -6431,14 +6491,14 @@ module.exports = Reflect && Reflect.ownKeys || function ownKeys(it) {
 };
 
 /***/ }),
-/* 155 */
+/* 156 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 // https://tc39.github.io/proposal-flatMap/#sec-FlattenIntoArray
 
-var isArray = __webpack_require__(68);
+var isArray = __webpack_require__(69);
 var isObject = __webpack_require__(5);
 var toLength = __webpack_require__(7);
 var ctx = __webpack_require__(22);
@@ -6477,12 +6537,12 @@ function flattenIntoArray(target, original, source, sourceLen, start, depth, map
 module.exports = flattenIntoArray;
 
 /***/ }),
-/* 156 */
+/* 157 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-string-pad-start-end
 var toLength = __webpack_require__(7);
-var repeat = __webpack_require__(95);
+var repeat = __webpack_require__(96);
 var defined = __webpack_require__(28);
 
 module.exports = function (that, maxLength, fillString, left) {
@@ -6498,13 +6558,13 @@ module.exports = function (that, maxLength, fillString, left) {
 };
 
 /***/ }),
-/* 157 */
+/* 158 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(8);
 var getKeys = __webpack_require__(38);
 var toIObject = __webpack_require__(18);
-var isEnum = __webpack_require__(54).f;
+var isEnum = __webpack_require__(55).f;
 module.exports = function (isEntries) {
   return function (it) {
     var O = toIObject(it);
@@ -6524,12 +6584,12 @@ module.exports = function (isEntries) {
 };
 
 /***/ }),
-/* 158 */
+/* 159 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
-var classof = __webpack_require__(49);
-var from = __webpack_require__(159);
+var classof = __webpack_require__(50);
+var from = __webpack_require__(160);
 module.exports = function (NAME) {
   return function toJSON() {
     if (classof(this) != NAME) throw TypeError(NAME + "#toJSON isn't generic");
@@ -6538,7 +6598,7 @@ module.exports = function (NAME) {
 };
 
 /***/ }),
-/* 159 */
+/* 160 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var forOf = __webpack_require__(44);
@@ -6550,7 +6610,7 @@ module.exports = function (iter, ITERATOR) {
 };
 
 /***/ }),
-/* 160 */
+/* 161 */
 /***/ (function(module, exports) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -6571,46 +6631,46 @@ module.exports = Math.scale || function scale(x, inLow, inHigh, outLow, outHigh)
 };
 
 /***/ }),
-/* 161 */
+/* 162 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony export (immutable) */ __webpack_exports__["initialize"] = initialize;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(407);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(431);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(433);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(430);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(432);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(186);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(122);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(454);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(455);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(457);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(465);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(453);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(454);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(456);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(464);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(188);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(467);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(469);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(470);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(471);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(472);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(474);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(476);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(478);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(484);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(485);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(487);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(489);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(490);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(491);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(492);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(494);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(495);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(496);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(498);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(499);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(500);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(501);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(502);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(508);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(466);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(468);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(469);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(470);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(471);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(473);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(475);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(477);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(483);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(484);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(486);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(488);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(489);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(490);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(491);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(493);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(494);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(495);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(497);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(498);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(499);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(500);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(501);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(507);
 
 
 
@@ -6693,24 +6753,24 @@ function initialize(root, setRoot) {
 }
 
 /***/ }),
-/* 162 */
+/* 163 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(409);
 
 /***/ }),
-/* 163 */
+/* 164 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var global = __webpack_require__(26);
-var getOwnPropertyDescriptor = __webpack_require__(164).f;
-var hide = __webpack_require__(61);
+var getOwnPropertyDescriptor = __webpack_require__(165).f;
+var hide = __webpack_require__(62);
 var redefine = __webpack_require__(413);
-var setGlobal = __webpack_require__(117);
+var setGlobal = __webpack_require__(118);
 var copyConstructorProperties = __webpack_require__(417);
-var isForced = __webpack_require__(424);
+var isForced = __webpack_require__(423);
 
 /*
   options.target      - name of the target object
@@ -6760,21 +6820,19 @@ module.exports = function (options, source) {
 };
 
 /***/ }),
-/* 164 */
+/* 165 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(57);
+var DESCRIPTORS = __webpack_require__(58);
 var propertyIsEnumerableModule = __webpack_require__(411);
-var createPropertyDescriptor = __webpack_require__(165);
-var toIndexedObject = __webpack_require__(115);
-var toPrimitive = __webpack_require__(168);
-var has = __webpack_require__(60);
-var IE8_DOM_DEFINE = __webpack_require__(169);
+var createPropertyDescriptor = __webpack_require__(166);
+var toIndexedObject = __webpack_require__(116);
+var toPrimitive = __webpack_require__(169);
+var has = __webpack_require__(61);
+var IE8_DOM_DEFINE = __webpack_require__(170);
 
 var nativeGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 
-// `Object.getOwnPropertyDescriptor` method
-// https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptor
 exports.f = DESCRIPTORS ? nativeGetOwnPropertyDescriptor : function getOwnPropertyDescriptor(O, P) {
   O = toIndexedObject(O);
   P = toPrimitive(P, true);
@@ -6785,7 +6843,7 @@ exports.f = DESCRIPTORS ? nativeGetOwnPropertyDescriptor : function getOwnProper
 };
 
 /***/ }),
-/* 165 */
+/* 166 */
 /***/ (function(module, exports) {
 
 module.exports = function (bitmap, value) {
@@ -6798,7 +6856,7 @@ module.exports = function (bitmap, value) {
 };
 
 /***/ }),
-/* 166 */
+/* 167 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -6808,7 +6866,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 167 */
+/* 168 */
 /***/ (function(module, exports) {
 
 // `RequireObjectCoercible` abstract operation
@@ -6819,31 +6877,30 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 168 */
+/* 169 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(59);
+var isObject = __webpack_require__(60);
 
-// `ToPrimitive` abstract operation
-// https://tc39.github.io/ecma262/#sec-toprimitive
+// 7.1.1 ToPrimitive(input [, PreferredType])
 // instead of the ES6 spec version, we didn't implement @@toPrimitive case
 // and the second argument - flag - preferred type is a string
-module.exports = function (input, PREFERRED_STRING) {
-  if (!isObject(input)) return input;
+module.exports = function (it, S) {
+  if (!isObject(it)) return it;
   var fn, val;
-  if (PREFERRED_STRING && typeof (fn = input.toString) == 'function' && !isObject(val = fn.call(input))) return val;
-  if (typeof (fn = input.valueOf) == 'function' && !isObject(val = fn.call(input))) return val;
-  if (!PREFERRED_STRING && typeof (fn = input.toString) == 'function' && !isObject(val = fn.call(input))) return val;
+  if (S && typeof (fn = it.toString) == 'function' && !isObject(val = fn.call(it))) return val;
+  if (typeof (fn = it.valueOf) == 'function' && !isObject(val = fn.call(it))) return val;
+  if (!S && typeof (fn = it.toString) == 'function' && !isObject(val = fn.call(it))) return val;
   throw TypeError("Can't convert object to primitive value");
 };
 
 /***/ }),
-/* 169 */
+/* 170 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(57);
-var fails = __webpack_require__(58);
-var createElement = __webpack_require__(170);
+var DESCRIPTORS = __webpack_require__(58);
+var fails = __webpack_require__(59);
+var createElement = __webpack_require__(171);
 
 // Thank's IE8 for his funny defineProperty
 module.exports = !DESCRIPTORS && !fails(function () {
@@ -6855,34 +6912,34 @@ module.exports = !DESCRIPTORS && !fails(function () {
 });
 
 /***/ }),
-/* 170 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var global = __webpack_require__(26);
-var isObject = __webpack_require__(59);
-
-var document = global.document;
-// typeof document.createElement is 'object' in old IE
-var EXISTS = isObject(document) && isObject(document.createElement);
-
-module.exports = function (it) {
-  return EXISTS ? document.createElement(it) : {};
-};
-
-/***/ }),
 /* 171 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var shared = __webpack_require__(81);
+var global = __webpack_require__(26);
+var isObject = __webpack_require__(60);
 
-module.exports = shared('native-function-to-string', Function.toString);
+var document = global.document;
+// typeof document.createElement is 'object' in old IE
+var exist = isObject(document) && isObject(document.createElement);
+
+module.exports = function (it) {
+  return exist ? document.createElement(it) : {};
+};
 
 /***/ }),
 /* 172 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var shared = __webpack_require__(81);
-var uid = __webpack_require__(173);
+var shared = __webpack_require__(82);
+
+module.exports = shared('native-function-to-string', Function.toString);
+
+/***/ }),
+/* 173 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var shared = __webpack_require__(82);
+var uid = __webpack_require__(174);
 
 var keys = shared('keys');
 
@@ -6891,39 +6948,26 @@ module.exports = function (key) {
 };
 
 /***/ }),
-/* 173 */
+/* 174 */
 /***/ (function(module, exports) {
 
 var id = 0;
 var postfix = Math.random();
 
 module.exports = function (key) {
-  return 'Symbol(' + String(key === undefined ? '' : key) + ')_' + (++id + postfix).toString(36);
-};
-
-/***/ }),
-/* 174 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var path = __webpack_require__(419);
-var global = __webpack_require__(26);
-
-var aFunction = function aFunction(variable) {
-  return typeof variable == 'function' ? variable : undefined;
-};
-
-module.exports = function (namespace, method) {
-  return arguments.length < 2 ? aFunction(path[namespace]) || aFunction(global[namespace]) : path[namespace] && path[namespace][method] || global[namespace] && global[namespace][method];
+  return 'Symbol('.concat(key === undefined ? '' : key, ')_', (++id + postfix).toString(36));
 };
 
 /***/ }),
 /* 175 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var has = __webpack_require__(60);
-var toIndexedObject = __webpack_require__(115);
-var indexOf = __webpack_require__(421).indexOf;
-var hiddenKeys = __webpack_require__(118);
+var has = __webpack_require__(61);
+var toIndexedObject = __webpack_require__(116);
+var arrayIncludes = __webpack_require__(420);
+var hiddenKeys = __webpack_require__(119);
+
+var arrayIndexOf = arrayIncludes(false);
 
 module.exports = function (object, names) {
   var O = toIndexedObject(object);
@@ -6935,7 +6979,7 @@ module.exports = function (object, names) {
   } // Don't enum bug & hidden keys
   while (names.length > i) {
     if (has(O, key = names[i++])) {
-      ~indexOf(result, key) || result.push(key);
+      ~arrayIndexOf(result, key) || result.push(key);
     }
   }return result;
 };
@@ -6948,7 +6992,7 @@ module.exports = function (object, names) {
 
 
 var isArray = __webpack_require__(177);
-var toLength = __webpack_require__(82);
+var toLength = __webpack_require__(83);
 var bind = __webpack_require__(178);
 
 // `FlattenIntoArray` abstract operation
@@ -6983,7 +7027,7 @@ module.exports = flattenIntoArray;
 /* 177 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var classof = __webpack_require__(166);
+var classof = __webpack_require__(167);
 
 // `IsArray` abstract operation
 // https://tc39.github.io/ecma262/#sec-isarray
@@ -7038,7 +7082,7 @@ module.exports = function (it) {
 /* 180 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var requireObjectCoercible = __webpack_require__(167);
+var requireObjectCoercible = __webpack_require__(168);
 
 // `ToObject` abstract operation
 // https://tc39.github.io/ecma262/#sec-toobject
@@ -7050,7 +7094,7 @@ module.exports = function (argument) {
 /* 181 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(59);
+var isObject = __webpack_require__(60);
 var isArray = __webpack_require__(177);
 var wellKnownSymbol = __webpack_require__(182);
 
@@ -7075,9 +7119,9 @@ module.exports = function (originalArray, length) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
-var shared = __webpack_require__(81);
-var uid = __webpack_require__(173);
-var NATIVE_SYMBOL = __webpack_require__(425);
+var shared = __webpack_require__(82);
+var uid = __webpack_require__(174);
+var NATIVE_SYMBOL = __webpack_require__(424);
 
 var _Symbol = global.Symbol;
 var store = shared('wks');
@@ -7091,8 +7135,8 @@ module.exports = function (name) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var wellKnownSymbol = __webpack_require__(182);
-var create = __webpack_require__(427);
-var hide = __webpack_require__(61);
+var create = __webpack_require__(426);
+var hide = __webpack_require__(62);
 
 var UNSCOPABLES = wellKnownSymbol('unscopables');
 var ArrayPrototype = Array.prototype;
@@ -13543,7 +13587,8 @@ module.exports = function (CONSTRUCTOR, METHOD, length) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_textfield__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(121);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(122);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__ = __webpack_require__(48);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -13551,6 +13596,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 
 
 
@@ -13565,8 +13611,8 @@ function initTextFields(e) {
     Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-text-field', VTextField, __WEBPACK_IMPORTED_MODULE_0__material_textfield__["MDCTextField"]);
 }
 
-var VTextField = function (_visibilityObserverMi) {
-    _inherits(VTextField, _visibilityObserverMi);
+var VTextField = function (_dirtyableMixin) {
+    _inherits(VTextField, _dirtyableMixin);
 
     function VTextField(element, mdcComponent) {
         _classCallCheck(this, VTextField);
@@ -13585,6 +13631,8 @@ var VTextField = function (_visibilityObserverMi) {
                 _this.element.dispatchEvent(new Event(AFTER_INPUT_EVENT));
             }, AFTER_INPUT_TIMEOUT);
         });
+
+        _this.originalValue = _this.value();
         return _this;
     }
 
@@ -13681,7 +13729,7 @@ var VTextField = function (_visibilityObserverMi) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.input.value = this.element.dataset.originalValue;
+            this.input.value = this.originalValue;
         }
     }, {
         key: 'setValue',
@@ -13691,7 +13739,7 @@ var VTextField = function (_visibilityObserverMi) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.value() !== this.element.dataset.originalValue;
+            return this.dirtyable && this.value().localeCompare(this.originalValue) !== 0;
         }
     }, {
         key: 'onShow',
@@ -13722,7 +13770,7 @@ var VTextField = function (_visibilityObserverMi) {
     }]);
 
     return VTextField;
-}(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */])));
+}(Object(__WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]))));
 
 /***/ }),
 /* 187 */
@@ -13855,11 +13903,11 @@ var VUrls = function () {
 /* harmony export (immutable) */ __webpack_exports__["b"] = uninitMenus;
 /* harmony export (immutable) */ __webpack_exports__["a"] = initMenus;
 /* unused harmony export VMenu */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(444);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(443);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_menu__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events__ = __webpack_require__(122);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events__ = __webpack_require__(123);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -14025,7 +14073,7 @@ var VDialog = function () {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__foundation__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__foundation__ = __webpack_require__(124);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -31071,7 +31119,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
     /******/)["default"]
   );
 });
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(479).Buffer, __webpack_require__(12)(module)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(478).Buffer, __webpack_require__(12)(module)))
 
 /***/ }),
 /* 195 */
@@ -31164,10 +31212,10 @@ var MDCFoundation = /** @class */function () {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgressFoundation; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(124);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(506);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(505);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(195);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(507);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(506);
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -31308,7 +31356,7 @@ module.exports = __webpack_require__(198);
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_compatibility__ = __webpack_require__(199);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(65);
 
 
 
@@ -31328,7 +31376,7 @@ document.addEventListener('DOMContentLoaded', function () {
     __webpack_require__(204);
     __webpack_require__(205);
 
-    __webpack_require__(161).initialize(document, true);
+    __webpack_require__(162).initialize(document, true);
 
     // Focus first valid input control
     var focusable = document.querySelectorAll('.v-focusable');
@@ -31348,7 +31396,7 @@ document.addEventListener('DOMContentLoaded', function () {
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser__ = __webpack_require__(200);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_detect_browser__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(65);
 
 
 
@@ -36888,7 +36936,7 @@ define(String.prototype, "padRight", "".padEnd);
 "pop,reverse,shift,keys,values,entries,indexOf,every,some,forEach,map,filter,find,findIndex,includes,join,slice,concat,push,splice,unshift,sort,lastIndexOf,reduce,reduceRight,copyWithin,fill".split(",").forEach(function (key) {
   [][key] && define(Array, key, Function.call.bind([][key]));
 });
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(65)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(66)))
 
 /***/ }),
 /* 206 */
@@ -36993,19 +37041,19 @@ __webpack_require__(307);
 __webpack_require__(308);
 __webpack_require__(309);
 __webpack_require__(310);
-__webpack_require__(107);
+__webpack_require__(108);
 __webpack_require__(311);
-__webpack_require__(144);
-__webpack_require__(312);
 __webpack_require__(145);
+__webpack_require__(312);
+__webpack_require__(146);
 __webpack_require__(313);
 __webpack_require__(314);
 __webpack_require__(315);
 __webpack_require__(316);
 __webpack_require__(317);
-__webpack_require__(148);
-__webpack_require__(150);
+__webpack_require__(149);
 __webpack_require__(151);
+__webpack_require__(152);
 __webpack_require__(318);
 __webpack_require__(319);
 __webpack_require__(320);
@@ -37110,14 +37158,14 @@ var $export = __webpack_require__(0);
 var redefine = __webpack_require__(15);
 var META = __webpack_require__(34).KEY;
 var $fails = __webpack_require__(4);
-var shared = __webpack_require__(52);
-var setToStringTag = __webpack_require__(48);
+var shared = __webpack_require__(53);
+var setToStringTag = __webpack_require__(49);
 var uid = __webpack_require__(37);
 var wks = __webpack_require__(6);
-var wksExt = __webpack_require__(126);
-var wksDefine = __webpack_require__(88);
+var wksExt = __webpack_require__(127);
+var wksDefine = __webpack_require__(89);
 var enumKeys = __webpack_require__(209);
-var isArray = __webpack_require__(68);
+var isArray = __webpack_require__(69);
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
 var toObject = __webpack_require__(10);
@@ -37125,9 +37173,9 @@ var toIObject = __webpack_require__(18);
 var toPrimitive = __webpack_require__(27);
 var createDesc = __webpack_require__(36);
 var _create = __webpack_require__(40);
-var gOPNExt = __webpack_require__(129);
+var gOPNExt = __webpack_require__(130);
 var $GOPD = __webpack_require__(19);
-var $GOPS = __webpack_require__(67);
+var $GOPS = __webpack_require__(68);
 var $DP = __webpack_require__(9);
 var $keys = __webpack_require__(38);
 var gOPD = $GOPD.f;
@@ -37256,7 +37304,7 @@ if (!USE_NATIVE) {
   $GOPD.f = $getOwnPropertyDescriptor;
   $DP.f = $defineProperty;
   __webpack_require__(41).f = gOPNExt.f = $getOwnPropertyNames;
-  __webpack_require__(54).f = $propertyIsEnumerable;
+  __webpack_require__(55).f = $propertyIsEnumerable;
   $GOPS.f = $getOwnPropertySymbols;
 
   if (DESCRIPTORS && !__webpack_require__(33)) {
@@ -37361,7 +37409,7 @@ setToStringTag(global.JSON, 'JSON', true);
 /* 208 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(52)('native-function-to-string', Function.toString);
+module.exports = __webpack_require__(53)('native-function-to-string', Function.toString);
 
 /***/ }),
 /* 209 */
@@ -37369,8 +37417,8 @@ module.exports = __webpack_require__(52)('native-function-to-string', Function.t
 
 // all enumerable object keys, includes symbols
 var getKeys = __webpack_require__(38);
-var gOPS = __webpack_require__(67);
-var pIE = __webpack_require__(54);
+var gOPS = __webpack_require__(68);
+var pIE = __webpack_require__(55);
 module.exports = function (it) {
   var result = getKeys(it);
   var getSymbols = gOPS.f;
@@ -37407,7 +37455,7 @@ $export($export.S + $export.F * !__webpack_require__(8), 'Object', { definePrope
 
 var $export = __webpack_require__(0);
 // 19.1.2.3 / 15.2.3.7 Object.defineProperties(O, Properties)
-$export($export.S + $export.F * !__webpack_require__(8), 'Object', { defineProperties: __webpack_require__(128) });
+$export($export.S + $export.F * !__webpack_require__(8), 'Object', { defineProperties: __webpack_require__(129) });
 
 /***/ }),
 /* 213 */
@@ -37457,7 +37505,7 @@ __webpack_require__(29)('keys', function () {
 
 // 19.1.2.7 Object.getOwnPropertyNames(O)
 __webpack_require__(29)('getOwnPropertyNames', function () {
-  return __webpack_require__(129).f;
+  return __webpack_require__(130).f;
 });
 
 /***/ }),
@@ -37548,7 +37596,7 @@ __webpack_require__(29)('isExtensible', function ($isExtensible) {
 // 19.1.3.1 Object.assign(target, source)
 var $export = __webpack_require__(0);
 
-$export($export.S + $export.F, 'Object', { assign: __webpack_require__(130) });
+$export($export.S + $export.F, 'Object', { assign: __webpack_require__(131) });
 
 /***/ }),
 /* 224 */
@@ -37556,7 +37604,7 @@ $export($export.S + $export.F, 'Object', { assign: __webpack_require__(130) });
 
 // 19.1.3.10 Object.is(value1, value2)
 var $export = __webpack_require__(0);
-$export($export.S, 'Object', { is: __webpack_require__(131) });
+$export($export.S, 'Object', { is: __webpack_require__(132) });
 
 /***/ }),
 /* 225 */
@@ -37564,7 +37612,7 @@ $export($export.S, 'Object', { is: __webpack_require__(131) });
 
 // 19.1.3.19 Object.setPrototypeOf(O, proto)
 var $export = __webpack_require__(0);
-$export($export.S, 'Object', { setPrototypeOf: __webpack_require__(92).set });
+$export($export.S, 'Object', { setPrototypeOf: __webpack_require__(93).set });
 
 /***/ }),
 /* 226 */
@@ -37574,7 +37622,7 @@ $export($export.S, 'Object', { setPrototypeOf: __webpack_require__(92).set });
 
 // 19.1.3.6 Object.prototype.toString()
 
-var classof = __webpack_require__(49);
+var classof = __webpack_require__(50);
 var test = {};
 test[__webpack_require__(6)('toStringTag')] = 'z';
 if (test + '' != '[object z]') {
@@ -37590,7 +37638,7 @@ if (test + '' != '[object z]') {
 // 19.2.3.2 / 15.3.4.5 Function.prototype.bind(thisArg, args...)
 var $export = __webpack_require__(0);
 
-$export($export.P, 'Function', { bind: __webpack_require__(132) });
+$export($export.P, 'Function', { bind: __webpack_require__(133) });
 
 /***/ }),
 /* 228 */
@@ -37639,7 +37687,7 @@ if (!(HAS_INSTANCE in FunctionProto)) __webpack_require__(9).f(FunctionProto, HA
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $parseInt = __webpack_require__(134);
+var $parseInt = __webpack_require__(135);
 // 18.2.5 parseInt(string, radix)
 $export($export.G + $export.F * (parseInt != $parseInt), { parseInt: $parseInt });
 
@@ -37648,7 +37696,7 @@ $export($export.G + $export.F * (parseInt != $parseInt), { parseInt: $parseInt }
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $parseFloat = __webpack_require__(135);
+var $parseFloat = __webpack_require__(136);
 // 18.2.4 parseFloat(string)
 $export($export.G + $export.F * (parseFloat != $parseFloat), { parseFloat: $parseFloat });
 
@@ -37662,13 +37710,13 @@ $export($export.G + $export.F * (parseFloat != $parseFloat), { parseFloat: $pars
 var global = __webpack_require__(3);
 var has = __webpack_require__(17);
 var cof = __webpack_require__(23);
-var inheritIfRequired = __webpack_require__(94);
+var inheritIfRequired = __webpack_require__(95);
 var toPrimitive = __webpack_require__(27);
 var fails = __webpack_require__(4);
 var gOPN = __webpack_require__(41).f;
 var gOPD = __webpack_require__(19).f;
 var dP = __webpack_require__(9).f;
-var $trim = __webpack_require__(50).trim;
+var $trim = __webpack_require__(51).trim;
 var NUMBER = 'Number';
 var $Number = global[NUMBER];
 var Base = $Number;
@@ -37739,8 +37787,8 @@ if (!$Number(' 0o1') || !$Number('0b1') || $Number('+0x1')) {
 
 var $export = __webpack_require__(0);
 var toInteger = __webpack_require__(24);
-var aNumberValue = __webpack_require__(136);
-var repeat = __webpack_require__(95);
+var aNumberValue = __webpack_require__(137);
+var repeat = __webpack_require__(96);
 var $toFixed = 1.0.toFixed;
 var floor = Math.floor;
 var data = [0, 0, 0, 0, 0, 0];
@@ -37855,7 +37903,7 @@ $export($export.P + $export.F * (!!$toFixed && (0.00008.toFixed(3) !== '0.000' |
 
 var $export = __webpack_require__(0);
 var $fails = __webpack_require__(4);
-var aNumberValue = __webpack_require__(136);
+var aNumberValue = __webpack_require__(137);
 var $toPrecision = 1.0.toPrecision;
 
 $export($export.P + $export.F * ($fails(function () {
@@ -37901,7 +37949,7 @@ $export($export.S, 'Number', {
 // 20.1.2.3 Number.isInteger(number)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Number', { isInteger: __webpack_require__(137) });
+$export($export.S, 'Number', { isInteger: __webpack_require__(138) });
 
 /***/ }),
 /* 238 */
@@ -37923,7 +37971,7 @@ $export($export.S, 'Number', {
 
 // 20.1.2.5 Number.isSafeInteger(number)
 var $export = __webpack_require__(0);
-var isInteger = __webpack_require__(137);
+var isInteger = __webpack_require__(138);
 var abs = Math.abs;
 
 $export($export.S, 'Number', {
@@ -37955,7 +38003,7 @@ $export($export.S, 'Number', { MIN_SAFE_INTEGER: -0x1fffffffffffff });
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $parseFloat = __webpack_require__(135);
+var $parseFloat = __webpack_require__(136);
 // 20.1.2.12 Number.parseFloat(string)
 $export($export.S + $export.F * (Number.parseFloat != $parseFloat), 'Number', { parseFloat: $parseFloat });
 
@@ -37964,7 +38012,7 @@ $export($export.S + $export.F * (Number.parseFloat != $parseFloat), 'Number', { 
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $parseInt = __webpack_require__(134);
+var $parseInt = __webpack_require__(135);
 // 20.1.2.13 Number.parseInt(string, radix)
 $export($export.S + $export.F * (Number.parseInt != $parseInt), 'Number', { parseInt: $parseInt });
 
@@ -37974,7 +38022,7 @@ $export($export.S + $export.F * (Number.parseInt != $parseInt), 'Number', { pars
 
 // 20.2.2.3 Math.acosh(x)
 var $export = __webpack_require__(0);
-var log1p = __webpack_require__(138);
+var log1p = __webpack_require__(139);
 var sqrt = Math.sqrt;
 var $acosh = Math.acosh;
 
@@ -38024,7 +38072,7 @@ $export($export.S + $export.F * !($atanh && 1 / $atanh(-0) < 0), 'Math', {
 
 // 20.2.2.9 Math.cbrt(x)
 var $export = __webpack_require__(0);
-var sign = __webpack_require__(96);
+var sign = __webpack_require__(97);
 
 $export($export.S, 'Math', {
   cbrt: function cbrt(x) {
@@ -38065,7 +38113,7 @@ $export($export.S, 'Math', {
 
 // 20.2.2.14 Math.expm1(x)
 var $export = __webpack_require__(0);
-var $expm1 = __webpack_require__(97);
+var $expm1 = __webpack_require__(98);
 
 $export($export.S + $export.F * ($expm1 != Math.expm1), 'Math', { expm1: $expm1 });
 
@@ -38076,7 +38124,7 @@ $export($export.S + $export.F * ($expm1 != Math.expm1), 'Math', { expm1: $expm1 
 // 20.2.2.16 Math.fround(x)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Math', { fround: __webpack_require__(139) });
+$export($export.S, 'Math', { fround: __webpack_require__(140) });
 
 /***/ }),
 /* 252 */
@@ -38151,7 +38199,7 @@ $export($export.S, 'Math', {
 // 20.2.2.20 Math.log1p(x)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Math', { log1p: __webpack_require__(138) });
+$export($export.S, 'Math', { log1p: __webpack_require__(139) });
 
 /***/ }),
 /* 256 */
@@ -38173,7 +38221,7 @@ $export($export.S, 'Math', {
 // 20.2.2.28 Math.sign(x)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Math', { sign: __webpack_require__(96) });
+$export($export.S, 'Math', { sign: __webpack_require__(97) });
 
 /***/ }),
 /* 258 */
@@ -38181,7 +38229,7 @@ $export($export.S, 'Math', { sign: __webpack_require__(96) });
 
 // 20.2.2.30 Math.sinh(x)
 var $export = __webpack_require__(0);
-var expm1 = __webpack_require__(97);
+var expm1 = __webpack_require__(98);
 var exp = Math.exp;
 
 // V8 near Chromium 38 has a problem with very small numbers
@@ -38199,7 +38247,7 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 
 // 20.2.2.33 Math.tanh(x)
 var $export = __webpack_require__(0);
-var expm1 = __webpack_require__(97);
+var expm1 = __webpack_require__(98);
 var exp = Math.exp;
 
 $export($export.S, 'Math', {
@@ -38280,7 +38328,7 @@ $export($export.S, 'String', {
 
 // 21.1.3.25 String.prototype.trim()
 
-__webpack_require__(50)('trim', function ($trim) {
+__webpack_require__(51)('trim', function ($trim) {
   return function trim() {
     return $trim(this, 3);
   };
@@ -38293,10 +38341,10 @@ __webpack_require__(50)('trim', function ($trim) {
 "use strict";
 
 
-var $at = __webpack_require__(69)(true);
+var $at = __webpack_require__(70)(true);
 
 // 21.1.3.27 String.prototype[@@iterator]()
-__webpack_require__(98)(String, 'String', function (iterated) {
+__webpack_require__(99)(String, 'String', function (iterated) {
   this._t = String(iterated); // target
   this._i = 0; // next index
   // 21.1.5.2.1 %StringIteratorPrototype%.next()
@@ -38318,7 +38366,7 @@ __webpack_require__(98)(String, 'String', function (iterated) {
 
 
 var $export = __webpack_require__(0);
-var $at = __webpack_require__(69)(false);
+var $at = __webpack_require__(70)(false);
 $export($export.P, 'String', {
   // 21.1.3.3 String.prototype.codePointAt(pos)
   codePointAt: function codePointAt(pos) {
@@ -38336,11 +38384,11 @@ $export($export.P, 'String', {
 
 var $export = __webpack_require__(0);
 var toLength = __webpack_require__(7);
-var context = __webpack_require__(100);
+var context = __webpack_require__(101);
 var ENDS_WITH = 'endsWith';
 var $endsWith = ''[ENDS_WITH];
 
-$export($export.P + $export.F * __webpack_require__(101)(ENDS_WITH), 'String', {
+$export($export.P + $export.F * __webpack_require__(102)(ENDS_WITH), 'String', {
   endsWith: function endsWith(searchString /* , endPosition = @length */) {
     var that = context(this, searchString, ENDS_WITH);
     var endPosition = arguments.length > 1 ? arguments[1] : undefined;
@@ -38360,10 +38408,10 @@ $export($export.P + $export.F * __webpack_require__(101)(ENDS_WITH), 'String', {
 
 
 var $export = __webpack_require__(0);
-var context = __webpack_require__(100);
+var context = __webpack_require__(101);
 var INCLUDES = 'includes';
 
-$export($export.P + $export.F * __webpack_require__(101)(INCLUDES), 'String', {
+$export($export.P + $export.F * __webpack_require__(102)(INCLUDES), 'String', {
   includes: function includes(searchString /* , position = 0 */) {
     return !!~context(this, searchString, INCLUDES).indexOf(searchString, arguments.length > 1 ? arguments[1] : undefined);
   }
@@ -38377,7 +38425,7 @@ var $export = __webpack_require__(0);
 
 $export($export.P, 'String', {
   // 21.1.3.13 String.prototype.repeat(count)
-  repeat: __webpack_require__(95)
+  repeat: __webpack_require__(96)
 });
 
 /***/ }),
@@ -38390,11 +38438,11 @@ $export($export.P, 'String', {
 
 var $export = __webpack_require__(0);
 var toLength = __webpack_require__(7);
-var context = __webpack_require__(100);
+var context = __webpack_require__(101);
 var STARTS_WITH = 'startsWith';
 var $startsWith = ''[STARTS_WITH];
 
-$export($export.P + $export.F * __webpack_require__(101)(STARTS_WITH), 'String', {
+$export($export.P + $export.F * __webpack_require__(102)(STARTS_WITH), 'String', {
   startsWith: function startsWith(searchString /* , position = 0 */) {
     var that = context(this, searchString, STARTS_WITH);
     var index = toLength(Math.min(arguments.length > 1 ? arguments[1] : undefined, that.length));
@@ -38712,7 +38760,7 @@ module.exports = function (hint) {
 // 22.1.2.2 / 15.4.3.2 Array.isArray(arg)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Array', { isArray: __webpack_require__(68) });
+$export($export.S, 'Array', { isArray: __webpack_require__(69) });
 
 /***/ }),
 /* 291 */
@@ -38724,13 +38772,13 @@ $export($export.S, 'Array', { isArray: __webpack_require__(68) });
 var ctx = __webpack_require__(22);
 var $export = __webpack_require__(0);
 var toObject = __webpack_require__(10);
-var call = __webpack_require__(140);
-var isArrayIter = __webpack_require__(102);
+var call = __webpack_require__(141);
+var isArrayIter = __webpack_require__(103);
 var toLength = __webpack_require__(7);
-var createProperty = __webpack_require__(103);
-var getIterFn = __webpack_require__(104);
+var createProperty = __webpack_require__(104);
+var getIterFn = __webpack_require__(105);
 
-$export($export.S + $export.F * !__webpack_require__(71)(function (iter) {
+$export($export.S + $export.F * !__webpack_require__(72)(function (iter) {
   Array.from(iter);
 }), 'Array', {
   // 22.1.2.1 Array.from(arrayLike, mapfn = undefined, thisArg = undefined)
@@ -38768,7 +38816,7 @@ $export($export.S + $export.F * !__webpack_require__(71)(function (iter) {
 
 
 var $export = __webpack_require__(0);
-var createProperty = __webpack_require__(103);
+var createProperty = __webpack_require__(104);
 
 // WebKit Array.of isn't generic
 $export($export.S + $export.F * __webpack_require__(4)(function () {
@@ -38800,7 +38848,7 @@ var toIObject = __webpack_require__(18);
 var arrayJoin = [].join;
 
 // fallback for not array-like strings
-$export($export.P + $export.F * (__webpack_require__(53) != Object || !__webpack_require__(25)(arrayJoin)), 'Array', {
+$export($export.P + $export.F * (__webpack_require__(54) != Object || !__webpack_require__(25)(arrayJoin)), 'Array', {
   join: function join(separator) {
     return arrayJoin.call(toIObject(this), separator === undefined ? ',' : separator);
   }
@@ -38814,7 +38862,7 @@ $export($export.P + $export.F * (__webpack_require__(53) != Object || !__webpack
 
 
 var $export = __webpack_require__(0);
-var html = __webpack_require__(91);
+var html = __webpack_require__(92);
 var cof = __webpack_require__(23);
 var toAbsoluteIndex = __webpack_require__(39);
 var toLength = __webpack_require__(7);
@@ -38891,7 +38939,7 @@ $export($export.P + $export.F * !STRICT, 'Array', {
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(5);
-var isArray = __webpack_require__(68);
+var isArray = __webpack_require__(69);
 var SPECIES = __webpack_require__(6)('species');
 
 module.exports = function (original) {
@@ -38983,7 +39031,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].every, true), 'Array
 
 
 var $export = __webpack_require__(0);
-var $reduce = __webpack_require__(141);
+var $reduce = __webpack_require__(142);
 
 $export($export.P + $export.F * !__webpack_require__(25)([].reduce, true), 'Array', {
   // 22.1.3.18 / 15.4.4.21 Array.prototype.reduce(callbackfn [, initialValue])
@@ -39000,7 +39048,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].reduce, true), 'Arra
 
 
 var $export = __webpack_require__(0);
-var $reduce = __webpack_require__(141);
+var $reduce = __webpack_require__(142);
 
 $export($export.P + $export.F * !__webpack_require__(25)([].reduceRight, true), 'Array', {
   // 22.1.3.19 / 15.4.4.22 Array.prototype.reduceRight(callbackfn [, initialValue])
@@ -39017,7 +39065,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].reduceRight, true), 
 
 
 var $export = __webpack_require__(0);
-var $indexOf = __webpack_require__(66)(false);
+var $indexOf = __webpack_require__(67)(false);
 var $native = [].indexOf;
 var NEGATIVE_ZERO = !!$native && 1 / [1].indexOf(1, -0) < 0;
 
@@ -39067,7 +39115,7 @@ $export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(25)($nati
 // 22.1.3.3 Array.prototype.copyWithin(target, start, end = this.length)
 var $export = __webpack_require__(0);
 
-$export($export.P, 'Array', { copyWithin: __webpack_require__(142) });
+$export($export.P, 'Array', { copyWithin: __webpack_require__(143) });
 
 __webpack_require__(35)('copyWithin');
 
@@ -39078,7 +39126,7 @@ __webpack_require__(35)('copyWithin');
 // 22.1.3.6 Array.prototype.fill(value, start = 0, end = this.length)
 var $export = __webpack_require__(0);
 
-$export($export.P, 'Array', { fill: __webpack_require__(106) });
+$export($export.P, 'Array', { fill: __webpack_require__(107) });
 
 __webpack_require__(35)('fill');
 
@@ -39139,11 +39187,11 @@ __webpack_require__(42)('Array');
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
-var inheritIfRequired = __webpack_require__(94);
+var inheritIfRequired = __webpack_require__(95);
 var dP = __webpack_require__(9).f;
 var gOPN = __webpack_require__(41).f;
-var isRegExp = __webpack_require__(70);
-var $flags = __webpack_require__(55);
+var isRegExp = __webpack_require__(71);
+var $flags = __webpack_require__(56);
 var $RegExp = global.RegExp;
 var Base = $RegExp;
 var proto = $RegExp.prototype;
@@ -39190,9 +39238,9 @@ __webpack_require__(42)('RegExp');
 "use strict";
 
 
-__webpack_require__(145);
+__webpack_require__(146);
 var anObject = __webpack_require__(1);
-var $flags = __webpack_require__(55);
+var $flags = __webpack_require__(56);
 var DESCRIPTORS = __webpack_require__(8);
 var TO_STRING = 'toString';
 var $toString = /./[TO_STRING];
@@ -39225,11 +39273,11 @@ if (__webpack_require__(4)(function () {
 
 var anObject = __webpack_require__(1);
 var toLength = __webpack_require__(7);
-var advanceStringIndex = __webpack_require__(109);
-var regExpExec = __webpack_require__(72);
+var advanceStringIndex = __webpack_require__(110);
+var regExpExec = __webpack_require__(73);
 
 // @@match logic
-__webpack_require__(73)('match', 1, function (defined, MATCH, $match, maybeCallNative) {
+__webpack_require__(74)('match', 1, function (defined, MATCH, $match, maybeCallNative) {
   return [
   // `String.prototype.match` method
   // https://tc39.github.io/ecma262/#sec-string.prototype.match
@@ -39272,8 +39320,8 @@ var anObject = __webpack_require__(1);
 var toObject = __webpack_require__(10);
 var toLength = __webpack_require__(7);
 var toInteger = __webpack_require__(24);
-var advanceStringIndex = __webpack_require__(109);
-var regExpExec = __webpack_require__(72);
+var advanceStringIndex = __webpack_require__(110);
+var regExpExec = __webpack_require__(73);
 var max = Math.max;
 var min = Math.min;
 var floor = Math.floor;
@@ -39285,7 +39333,7 @@ var maybeToString = function maybeToString(it) {
 };
 
 // @@replace logic
-__webpack_require__(73)('replace', 2, function (defined, REPLACE, $replace, maybeCallNative) {
+__webpack_require__(74)('replace', 2, function (defined, REPLACE, $replace, maybeCallNative) {
   return [
   // `String.prototype.replace` method
   // https://tc39.github.io/ecma262/#sec-string.prototype.replace
@@ -39396,11 +39444,11 @@ __webpack_require__(73)('replace', 2, function (defined, REPLACE, $replace, mayb
 
 
 var anObject = __webpack_require__(1);
-var sameValue = __webpack_require__(131);
-var regExpExec = __webpack_require__(72);
+var sameValue = __webpack_require__(132);
+var regExpExec = __webpack_require__(73);
 
 // @@search logic
-__webpack_require__(73)('search', 1, function (defined, SEARCH, $search, maybeCallNative) {
+__webpack_require__(74)('search', 1, function (defined, SEARCH, $search, maybeCallNative) {
   return [
   // `String.prototype.search` method
   // https://tc39.github.io/ecma262/#sec-string.prototype.search
@@ -39431,13 +39479,13 @@ __webpack_require__(73)('search', 1, function (defined, SEARCH, $search, maybeCa
 "use strict";
 
 
-var isRegExp = __webpack_require__(70);
+var isRegExp = __webpack_require__(71);
 var anObject = __webpack_require__(1);
-var speciesConstructor = __webpack_require__(56);
-var advanceStringIndex = __webpack_require__(109);
+var speciesConstructor = __webpack_require__(57);
+var advanceStringIndex = __webpack_require__(110);
 var toLength = __webpack_require__(7);
-var callRegExpExec = __webpack_require__(72);
-var regexpExec = __webpack_require__(108);
+var callRegExpExec = __webpack_require__(73);
+var regexpExec = __webpack_require__(109);
 var fails = __webpack_require__(4);
 var $min = Math.min;
 var $push = [].push;
@@ -39452,7 +39500,7 @@ var SUPPORTS_Y = !fails(function () {
 });
 
 // @@split logic
-__webpack_require__(73)('split', 2, function (defined, SPLIT, $split, maybeCallNative) {
+__webpack_require__(74)('split', 2, function (defined, SPLIT, $split, maybeCallNative) {
   var internalSplit;
   if ('abbc'[$SPLIT](/(b)*/)[1] == 'c' || 'test'[$SPLIT](/(?:)/, -1)[LENGTH] != 4 || 'ab'[$SPLIT](/(?:ab)*/)[LENGTH] != 2 || '.'[$SPLIT](/(.?)(.?)/)[LENGTH] != 4 || '.'[$SPLIT](/()()/)[LENGTH] > 1 || ''[$SPLIT](/.?/)[LENGTH]) {
     // based on es5-shim implementation, need to rework it
@@ -39557,19 +39605,19 @@ __webpack_require__(73)('split', 2, function (defined, SPLIT, $split, maybeCallN
 var LIBRARY = __webpack_require__(33);
 var global = __webpack_require__(3);
 var ctx = __webpack_require__(22);
-var classof = __webpack_require__(49);
+var classof = __webpack_require__(50);
 var $export = __webpack_require__(0);
 var isObject = __webpack_require__(5);
 var aFunction = __webpack_require__(13);
 var anInstance = __webpack_require__(43);
 var forOf = __webpack_require__(44);
-var speciesConstructor = __webpack_require__(56);
-var task = __webpack_require__(110).set;
-var microtask = __webpack_require__(111)();
-var newPromiseCapabilityModule = __webpack_require__(112);
-var perform = __webpack_require__(146);
-var userAgent = __webpack_require__(74);
-var promiseResolve = __webpack_require__(147);
+var speciesConstructor = __webpack_require__(57);
+var task = __webpack_require__(111).set;
+var microtask = __webpack_require__(112)();
+var newPromiseCapabilityModule = __webpack_require__(113);
+var perform = __webpack_require__(147);
+var userAgent = __webpack_require__(75);
+var promiseResolve = __webpack_require__(148);
 var PROMISE = 'Promise';
 var TypeError = global.TypeError;
 var process = global.process;
@@ -39772,7 +39820,7 @@ if (!USE_NATIVE) {
 }
 
 $export($export.G + $export.W + $export.F * !USE_NATIVE, { Promise: $Promise });
-__webpack_require__(48)($Promise, PROMISE);
+__webpack_require__(49)($Promise, PROMISE);
 __webpack_require__(42)(PROMISE);
 Wrapper = __webpack_require__(21)[PROMISE];
 
@@ -39792,7 +39840,7 @@ $export($export.S + $export.F * (LIBRARY || !USE_NATIVE), PROMISE, {
     return promiseResolve(LIBRARY && this === Wrapper ? $Promise : this, x);
   }
 });
-$export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(71)(function (iter) {
+$export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(72)(function (iter) {
   $Promise.all(iter)['catch'](empty);
 })), PROMISE, {
   // 25.4.4.1 Promise.all(iterable)
@@ -39844,12 +39892,12 @@ $export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(71)(function
 "use strict";
 
 
-var weak = __webpack_require__(152);
+var weak = __webpack_require__(153);
 var validate = __webpack_require__(46);
 var WEAK_SET = 'WeakSet';
 
 // 23.4 WeakSet Objects
-__webpack_require__(75)(WEAK_SET, function (get) {
+__webpack_require__(76)(WEAK_SET, function (get) {
   return function WeakSet() {
     return get(this, arguments.length > 0 ? arguments[0] : undefined);
   };
@@ -39868,14 +39916,14 @@ __webpack_require__(75)(WEAK_SET, function (get) {
 
 
 var $export = __webpack_require__(0);
-var $typed = __webpack_require__(76);
-var buffer = __webpack_require__(113);
+var $typed = __webpack_require__(77);
+var buffer = __webpack_require__(114);
 var anObject = __webpack_require__(1);
 var toAbsoluteIndex = __webpack_require__(39);
 var toLength = __webpack_require__(7);
 var isObject = __webpack_require__(5);
 var ArrayBuffer = __webpack_require__(3).ArrayBuffer;
-var speciesConstructor = __webpack_require__(56);
+var speciesConstructor = __webpack_require__(57);
 var $ArrayBuffer = buffer.ArrayBuffer;
 var $DataView = buffer.DataView;
 var $isView = $typed.ABV && ArrayBuffer.isView;
@@ -39918,8 +39966,8 @@ __webpack_require__(42)(ARRAY_BUFFER);
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-$export($export.G + $export.W + $export.F * !__webpack_require__(76).ABV, {
-  DataView: __webpack_require__(113).DataView
+$export($export.G + $export.W + $export.F * !__webpack_require__(77).ABV, {
+  DataView: __webpack_require__(114).DataView
 });
 
 /***/ }),
@@ -40044,7 +40092,7 @@ var aFunction = __webpack_require__(13);
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
 var fails = __webpack_require__(4);
-var bind = __webpack_require__(132);
+var bind = __webpack_require__(133);
 var rConstruct = (__webpack_require__(3).Reflect || {}).construct;
 
 // MS Edge supports only 2 arguments and argumentsList argument is optional
@@ -40153,7 +40201,7 @@ var Enumerate = function Enumerate(iterated) {
     keys.push(key);
   }
 };
-__webpack_require__(99)(Enumerate, 'Object', function () {
+__webpack_require__(100)(Enumerate, 'Object', function () {
   var that = this;
   var keys = that._k;
   var key;
@@ -40257,7 +40305,7 @@ $export($export.S, 'Reflect', {
 // 26.1.11 Reflect.ownKeys(target)
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Reflect', { ownKeys: __webpack_require__(154) });
+$export($export.S, 'Reflect', { ownKeys: __webpack_require__(155) });
 
 /***/ }),
 /* 341 */
@@ -40324,7 +40372,7 @@ $export($export.S, 'Reflect', { set: set });
 
 // 26.1.14 Reflect.setPrototypeOf(target, proto)
 var $export = __webpack_require__(0);
-var setProto = __webpack_require__(92);
+var setProto = __webpack_require__(93);
 
 if (setProto) $export($export.S, 'Reflect', {
   setPrototypeOf: function setPrototypeOf(target, proto) {
@@ -40347,7 +40395,7 @@ if (setProto) $export($export.S, 'Reflect', {
 // https://github.com/tc39/Array.prototype.includes
 
 var $export = __webpack_require__(0);
-var $includes = __webpack_require__(66)(true);
+var $includes = __webpack_require__(67)(true);
 
 $export($export.P, 'Array', {
   includes: function includes(el /* , fromIndex = 0 */) {
@@ -40366,11 +40414,11 @@ __webpack_require__(35)('includes');
 // https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flatMap
 
 var $export = __webpack_require__(0);
-var flattenIntoArray = __webpack_require__(155);
+var flattenIntoArray = __webpack_require__(156);
 var toObject = __webpack_require__(10);
 var toLength = __webpack_require__(7);
 var aFunction = __webpack_require__(13);
-var arraySpeciesCreate = __webpack_require__(105);
+var arraySpeciesCreate = __webpack_require__(106);
 
 $export($export.P, 'Array', {
   flatMap: function flatMap(callbackfn /* , thisArg */) {
@@ -40395,11 +40443,11 @@ __webpack_require__(35)('flatMap');
 // https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flatten
 
 var $export = __webpack_require__(0);
-var flattenIntoArray = __webpack_require__(155);
+var flattenIntoArray = __webpack_require__(156);
 var toObject = __webpack_require__(10);
 var toLength = __webpack_require__(7);
 var toInteger = __webpack_require__(24);
-var arraySpeciesCreate = __webpack_require__(105);
+var arraySpeciesCreate = __webpack_require__(106);
 
 $export($export.P, 'Array', {
   flatten: function flatten() /* depthArg = 1 */{
@@ -40423,7 +40471,7 @@ __webpack_require__(35)('flatten');
 // https://github.com/mathiasbynens/String.prototype.at
 
 var $export = __webpack_require__(0);
-var $at = __webpack_require__(69)(true);
+var $at = __webpack_require__(70)(true);
 
 $export($export.P, 'String', {
   at: function at(pos) {
@@ -40440,8 +40488,8 @@ $export($export.P, 'String', {
 // https://github.com/tc39/proposal-string-pad-start-end
 
 var $export = __webpack_require__(0);
-var $pad = __webpack_require__(156);
-var userAgent = __webpack_require__(74);
+var $pad = __webpack_require__(157);
+var userAgent = __webpack_require__(75);
 
 // https://github.com/zloirock/core-js/issues/280
 var WEBKIT_BUG = /Version\/10\.\d+(\.\d+)?( Mobile\/\w+)? Safari\//.test(userAgent);
@@ -40461,8 +40509,8 @@ $export($export.P + $export.F * WEBKIT_BUG, 'String', {
 // https://github.com/tc39/proposal-string-pad-start-end
 
 var $export = __webpack_require__(0);
-var $pad = __webpack_require__(156);
-var userAgent = __webpack_require__(74);
+var $pad = __webpack_require__(157);
+var userAgent = __webpack_require__(75);
 
 // https://github.com/zloirock/core-js/issues/280
 var WEBKIT_BUG = /Version\/10\.\d+(\.\d+)?( Mobile\/\w+)? Safari\//.test(userAgent);
@@ -40481,7 +40529,7 @@ $export($export.P + $export.F * WEBKIT_BUG, 'String', {
 
 // https://github.com/sebmarkbage/ecmascript-string-left-right-trim
 
-__webpack_require__(50)('trimLeft', function ($trim) {
+__webpack_require__(51)('trimLeft', function ($trim) {
   return function trimLeft() {
     return $trim(this, 1);
   };
@@ -40495,7 +40543,7 @@ __webpack_require__(50)('trimLeft', function ($trim) {
 
 // https://github.com/sebmarkbage/ecmascript-string-left-right-trim
 
-__webpack_require__(50)('trimRight', function ($trim) {
+__webpack_require__(51)('trimRight', function ($trim) {
   return function trimRight() {
     return $trim(this, 2);
   };
@@ -40512,8 +40560,8 @@ __webpack_require__(50)('trimRight', function ($trim) {
 var $export = __webpack_require__(0);
 var defined = __webpack_require__(28);
 var toLength = __webpack_require__(7);
-var isRegExp = __webpack_require__(70);
-var getFlags = __webpack_require__(55);
+var isRegExp = __webpack_require__(71);
+var getFlags = __webpack_require__(56);
 var RegExpProto = RegExp.prototype;
 
 var $RegExpStringIterator = function $RegExpStringIterator(regexp, string) {
@@ -40521,7 +40569,7 @@ var $RegExpStringIterator = function $RegExpStringIterator(regexp, string) {
   this._s = string;
 };
 
-__webpack_require__(99)($RegExpStringIterator, 'RegExp String', function next() {
+__webpack_require__(100)($RegExpStringIterator, 'RegExp String', function next() {
   var match = this._r.exec(this._s);
   return { value: match, done: match === null };
 });
@@ -40542,13 +40590,13 @@ $export($export.P, 'String', {
 /* 353 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(88)('asyncIterator');
+__webpack_require__(89)('asyncIterator');
 
 /***/ }),
 /* 354 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(88)('observable');
+__webpack_require__(89)('observable');
 
 /***/ }),
 /* 355 */
@@ -40556,10 +40604,10 @@ __webpack_require__(88)('observable');
 
 // https://github.com/tc39/proposal-object-getownpropertydescriptors
 var $export = __webpack_require__(0);
-var ownKeys = __webpack_require__(154);
+var ownKeys = __webpack_require__(155);
 var toIObject = __webpack_require__(18);
 var gOPD = __webpack_require__(19);
-var createProperty = __webpack_require__(103);
+var createProperty = __webpack_require__(104);
 
 $export($export.S, 'Object', {
   getOwnPropertyDescriptors: function getOwnPropertyDescriptors(object) {
@@ -40583,7 +40631,7 @@ $export($export.S, 'Object', {
 
 // https://github.com/tc39/proposal-object-values-entries
 var $export = __webpack_require__(0);
-var $values = __webpack_require__(157)(false);
+var $values = __webpack_require__(158)(false);
 
 $export($export.S, 'Object', {
   values: function values(it) {
@@ -40597,7 +40645,7 @@ $export($export.S, 'Object', {
 
 // https://github.com/tc39/proposal-object-values-entries
 var $export = __webpack_require__(0);
-var $entries = __webpack_require__(157)(true);
+var $entries = __webpack_require__(158)(true);
 
 $export($export.S, 'Object', {
   entries: function entries(it) {
@@ -40618,7 +40666,7 @@ var aFunction = __webpack_require__(13);
 var $defineProperty = __webpack_require__(9);
 
 // B.2.2.2 Object.prototype.__defineGetter__(P, getter)
-__webpack_require__(8) && $export($export.P + __webpack_require__(77), 'Object', {
+__webpack_require__(8) && $export($export.P + __webpack_require__(78), 'Object', {
   __defineGetter__: function __defineGetter__(P, getter) {
     $defineProperty.f(toObject(this), P, { get: aFunction(getter), enumerable: true, configurable: true });
   }
@@ -40637,7 +40685,7 @@ var aFunction = __webpack_require__(13);
 var $defineProperty = __webpack_require__(9);
 
 // B.2.2.3 Object.prototype.__defineSetter__(P, setter)
-__webpack_require__(8) && $export($export.P + __webpack_require__(77), 'Object', {
+__webpack_require__(8) && $export($export.P + __webpack_require__(78), 'Object', {
   __defineSetter__: function __defineSetter__(P, setter) {
     $defineProperty.f(toObject(this), P, { set: aFunction(setter), enumerable: true, configurable: true });
   }
@@ -40657,7 +40705,7 @@ var getPrototypeOf = __webpack_require__(20);
 var getOwnPropertyDescriptor = __webpack_require__(19).f;
 
 // B.2.2.4 Object.prototype.__lookupGetter__(P)
-__webpack_require__(8) && $export($export.P + __webpack_require__(77), 'Object', {
+__webpack_require__(8) && $export($export.P + __webpack_require__(78), 'Object', {
   __lookupGetter__: function __lookupGetter__(P) {
     var O = toObject(this);
     var K = toPrimitive(P, true);
@@ -40682,7 +40730,7 @@ var getPrototypeOf = __webpack_require__(20);
 var getOwnPropertyDescriptor = __webpack_require__(19).f;
 
 // B.2.2.5 Object.prototype.__lookupSetter__(P)
-__webpack_require__(8) && $export($export.P + __webpack_require__(77), 'Object', {
+__webpack_require__(8) && $export($export.P + __webpack_require__(78), 'Object', {
   __lookupSetter__: function __lookupSetter__(P) {
     var O = toObject(this);
     var K = toPrimitive(P, true);
@@ -40700,7 +40748,7 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(77), 'Object',
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
 var $export = __webpack_require__(0);
 
-$export($export.P + $export.R, 'Map', { toJSON: __webpack_require__(158)('Map') });
+$export($export.P + $export.R, 'Map', { toJSON: __webpack_require__(159)('Map') });
 
 /***/ }),
 /* 363 */
@@ -40709,63 +40757,63 @@ $export($export.P + $export.R, 'Map', { toJSON: __webpack_require__(158)('Map') 
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
 var $export = __webpack_require__(0);
 
-$export($export.P + $export.R, 'Set', { toJSON: __webpack_require__(158)('Set') });
+$export($export.P + $export.R, 'Set', { toJSON: __webpack_require__(159)('Set') });
 
 /***/ }),
 /* 364 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-map.of
-__webpack_require__(78)('Map');
+__webpack_require__(79)('Map');
 
 /***/ }),
 /* 365 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-set.of
-__webpack_require__(78)('Set');
+__webpack_require__(79)('Set');
 
 /***/ }),
 /* 366 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.of
-__webpack_require__(78)('WeakMap');
+__webpack_require__(79)('WeakMap');
 
 /***/ }),
 /* 367 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.of
-__webpack_require__(78)('WeakSet');
+__webpack_require__(79)('WeakSet');
 
 /***/ }),
 /* 368 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-map.from
-__webpack_require__(79)('Map');
+__webpack_require__(80)('Map');
 
 /***/ }),
 /* 369 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-set.from
-__webpack_require__(79)('Set');
+__webpack_require__(80)('Set');
 
 /***/ }),
 /* 370 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.from
-__webpack_require__(79)('WeakMap');
+__webpack_require__(80)('WeakMap');
 
 /***/ }),
 /* 371 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.from
-__webpack_require__(79)('WeakSet');
+__webpack_require__(80)('WeakSet');
 
 /***/ }),
 /* 372 */
@@ -40841,8 +40889,8 @@ $export($export.S, 'Math', {
 
 // https://rwaldron.github.io/proposal-math-extensions/
 var $export = __webpack_require__(0);
-var scale = __webpack_require__(160);
-var fround = __webpack_require__(139);
+var scale = __webpack_require__(161);
+var fround = __webpack_require__(140);
 
 $export($export.S, 'Math', {
   fscale: function fscale(x, inLow, inHigh, outLow, outHigh) {
@@ -40933,7 +40981,7 @@ $export($export.S, 'Math', {
 // https://rwaldron.github.io/proposal-math-extensions/
 var $export = __webpack_require__(0);
 
-$export($export.S, 'Math', { scale: __webpack_require__(160) });
+$export($export.S, 'Math', { scale: __webpack_require__(161) });
 
 /***/ }),
 /* 385 */
@@ -40979,8 +41027,8 @@ $export($export.S, 'Math', { signbit: function signbit(x) {
 var $export = __webpack_require__(0);
 var core = __webpack_require__(21);
 var global = __webpack_require__(3);
-var speciesConstructor = __webpack_require__(56);
-var promiseResolve = __webpack_require__(147);
+var speciesConstructor = __webpack_require__(57);
+var promiseResolve = __webpack_require__(148);
 
 $export($export.P + $export.R, 'Promise', { 'finally': function _finally(onFinally) {
     var C = speciesConstructor(this, core.Promise || global.Promise);
@@ -41005,8 +41053,8 @@ $export($export.P + $export.R, 'Promise', { 'finally': function _finally(onFinal
 // https://github.com/tc39/proposal-promise-try
 
 var $export = __webpack_require__(0);
-var newPromiseCapability = __webpack_require__(112);
-var perform = __webpack_require__(146);
+var newPromiseCapability = __webpack_require__(113);
+var perform = __webpack_require__(147);
 
 $export($export.S, 'Promise', { 'try': function _try(callbackfn) {
     var promiseCapability = newPromiseCapability.f(this);
@@ -41074,8 +41122,8 @@ metadata.exp({ getMetadata: function getMetadata(metadataKey, target /* , target
 /* 392 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Set = __webpack_require__(150);
-var from = __webpack_require__(159);
+var Set = __webpack_require__(151);
+var from = __webpack_require__(160);
 var metadata = __webpack_require__(32);
 var anObject = __webpack_require__(1);
 var getPrototypeOf = __webpack_require__(20);
@@ -41176,7 +41224,7 @@ $metadata.exp({ metadata: function metadata(metadataKey, metadataValue) {
 
 // https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-09/sept-25.md#510-globalasap-for-enqueuing-a-microtask
 var $export = __webpack_require__(0);
-var microtask = __webpack_require__(111)();
+var microtask = __webpack_require__(112)();
 var process = __webpack_require__(3).process;
 var isNode = __webpack_require__(23)(process) == 'process';
 
@@ -41198,7 +41246,7 @@ $export($export.G, {
 var $export = __webpack_require__(0);
 var global = __webpack_require__(3);
 var core = __webpack_require__(21);
-var microtask = __webpack_require__(111)();
+var microtask = __webpack_require__(112)();
 var OBSERVABLE = __webpack_require__(6)('observable');
 var aFunction = __webpack_require__(13);
 var anObject = __webpack_require__(1);
@@ -41410,7 +41458,7 @@ __webpack_require__(42)('Observable');
 // ie9- setTimeout & setInterval additional parameters fix
 var global = __webpack_require__(3);
 var $export = __webpack_require__(0);
-var userAgent = __webpack_require__(74);
+var userAgent = __webpack_require__(75);
 var slice = [].slice;
 var MSIE = /MSIE .\./.test(userAgent); // <- dirty ie9- check
 var wrap = function wrap(set) {
@@ -41433,7 +41481,7 @@ $export($export.G + $export.B + $export.F * MSIE, {
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
-var $task = __webpack_require__(110);
+var $task = __webpack_require__(111);
 $export($export.G + $export.B, {
   setImmediate: $task.set,
   clearImmediate: $task.clear
@@ -41443,12 +41491,12 @@ $export($export.G + $export.B, {
 /* 402 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var $iterators = __webpack_require__(107);
+var $iterators = __webpack_require__(108);
 var getKeys = __webpack_require__(38);
 var redefine = __webpack_require__(15);
 var global = __webpack_require__(3);
 var hide = __webpack_require__(14);
-var Iterators = __webpack_require__(51);
+var Iterators = __webpack_require__(52);
 var wks = __webpack_require__(6);
 var ITERATOR = wks('iterator');
 var TO_STRING_TAG = wks('toStringTag');
@@ -42212,7 +42260,7 @@ for (var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++
 // object, this seems to be the most reliable technique that does not
 // use indirect eval (which violates Content Security Policy).
 (typeof global === "undefined" ? "undefined" : _typeof(global)) === "object" ? global : (typeof window === "undefined" ? "undefined" : _typeof(window)) === "object" ? window : (typeof self === "undefined" ? "undefined" : _typeof(self)) === "object" ? self : this);
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(65), __webpack_require__(12)(module)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(66), __webpack_require__(12)(module)))
 
 /***/ }),
 /* 404 */
@@ -44308,7 +44356,7 @@ var VButton = function (_eventHandlerMixin) {
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(410);
-__webpack_require__(426);
+__webpack_require__(425);
 var entryUnbind = __webpack_require__(184);
 
 module.exports = entryUnbind('Array', 'flat');
@@ -44320,18 +44368,18 @@ module.exports = entryUnbind('Array', 'flat');
 "use strict";
 
 
-var $ = __webpack_require__(163);
+var $ = __webpack_require__(164);
 var flattenIntoArray = __webpack_require__(176);
 var toObject = __webpack_require__(180);
-var toLength = __webpack_require__(82);
-var toInteger = __webpack_require__(119);
+var toLength = __webpack_require__(83);
+var toInteger = __webpack_require__(120);
 var arraySpeciesCreate = __webpack_require__(181);
 
 // `Array.prototype.flat` method
 // https://github.com/tc39/proposal-flatMap
 $({ target: 'Array', proto: true }, {
   flat: function flat() /* depthArg = 1 */{
-    var depthArg = arguments.length ? arguments[0] : undefined;
+    var depthArg = arguments[0];
     var O = toObject(this);
     var sourceLen = toLength(O.length);
     var A = arraySpeciesCreate(O, 0);
@@ -44353,8 +44401,6 @@ var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 // Nashorn ~ JDK8 bug
 var NASHORN_BUG = getOwnPropertyDescriptor && !nativePropertyIsEnumerable.call({ 1: 2 }, 1);
 
-// `Object.prototype.propertyIsEnumerable` method implementation
-// https://tc39.github.io/ecma262/#sec-object.prototype.propertyisenumerable
 exports.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
   var descriptor = getOwnPropertyDescriptor(this, V);
   return !!descriptor && descriptor.enumerable;
@@ -44364,12 +44410,12 @@ exports.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
 /* 412 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var fails = __webpack_require__(58);
-var classof = __webpack_require__(166);
+// fallback for non-array-like ES3 and non-enumerable old V8 strings
+var fails = __webpack_require__(59);
+var classof = __webpack_require__(167);
 
 var split = ''.split;
 
-// fallback for non-array-like ES3 and non-enumerable old V8 strings
 module.exports = fails(function () {
   // throws an error in rhino, see https://github.com/mozilla/rhino/issues/346
   // eslint-disable-next-line no-prototype-builtins
@@ -44383,11 +44429,11 @@ module.exports = fails(function () {
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
-var shared = __webpack_require__(81);
-var hide = __webpack_require__(61);
-var has = __webpack_require__(60);
-var setGlobal = __webpack_require__(117);
-var nativeFunctionToString = __webpack_require__(171);
+var shared = __webpack_require__(82);
+var hide = __webpack_require__(62);
+var has = __webpack_require__(61);
+var setGlobal = __webpack_require__(118);
+var nativeFunctionToString = __webpack_require__(172);
 var InternalStateModule = __webpack_require__(415);
 
 var getInternalState = InternalStateModule.get;
@@ -44432,11 +44478,11 @@ module.exports = false;
 
 var NATIVE_WEAK_MAP = __webpack_require__(416);
 var global = __webpack_require__(26);
-var isObject = __webpack_require__(59);
-var hide = __webpack_require__(61);
-var objectHas = __webpack_require__(60);
-var sharedKey = __webpack_require__(172);
-var hiddenKeys = __webpack_require__(118);
+var isObject = __webpack_require__(60);
+var hide = __webpack_require__(62);
+var objectHas = __webpack_require__(61);
+var sharedKey = __webpack_require__(173);
+var hiddenKeys = __webpack_require__(119);
 
 var WeakMap = global.WeakMap;
 var set, get, has;
@@ -44497,7 +44543,7 @@ module.exports = {
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
-var nativeFunctionToString = __webpack_require__(171);
+var nativeFunctionToString = __webpack_require__(172);
 
 var WeakMap = global.WeakMap;
 
@@ -44507,10 +44553,10 @@ module.exports = typeof WeakMap === 'function' && /native code/.test(nativeFunct
 /* 417 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var has = __webpack_require__(60);
+var has = __webpack_require__(61);
 var ownKeys = __webpack_require__(418);
-var getOwnPropertyDescriptorModule = __webpack_require__(164);
-var definePropertyModule = __webpack_require__(116);
+var getOwnPropertyDescriptorModule = __webpack_require__(165);
+var definePropertyModule = __webpack_require__(117);
 
 module.exports = function (target, source) {
   var keys = ownKeys(source);
@@ -44526,13 +44572,15 @@ module.exports = function (target, source) {
 /* 418 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var getBuiltIn = __webpack_require__(174);
-var getOwnPropertyNamesModule = __webpack_require__(420);
-var getOwnPropertySymbolsModule = __webpack_require__(423);
-var anObject = __webpack_require__(80);
+var global = __webpack_require__(26);
+var getOwnPropertyNamesModule = __webpack_require__(419);
+var getOwnPropertySymbolsModule = __webpack_require__(422);
+var anObject = __webpack_require__(81);
+
+var Reflect = global.Reflect;
 
 // all object keys, includes non-enumerable and symbols
-module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
+module.exports = Reflect && Reflect.ownKeys || function ownKeys(it) {
   var keys = getOwnPropertyNamesModule.f(anObject(it));
   var getOwnPropertySymbols = getOwnPropertySymbolsModule.f;
   return getOwnPropertySymbols ? keys.concat(getOwnPropertySymbols(it)) : keys;
@@ -44542,33 +44590,30 @@ module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
 /* 419 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(26);
-
-/***/ }),
-/* 420 */
-/***/ (function(module, exports, __webpack_require__) {
-
+// 19.1.2.7 / 15.2.3.4 Object.getOwnPropertyNames(O)
 var internalObjectKeys = __webpack_require__(175);
-var enumBugKeys = __webpack_require__(120);
+var enumBugKeys = __webpack_require__(121);
 
 var hiddenKeys = enumBugKeys.concat('length', 'prototype');
 
-// `Object.getOwnPropertyNames` method
-// https://tc39.github.io/ecma262/#sec-object.getownpropertynames
 exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
   return internalObjectKeys(O, hiddenKeys);
 };
 
 /***/ }),
-/* 421 */
+/* 420 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toIndexedObject = __webpack_require__(115);
-var toLength = __webpack_require__(82);
-var toAbsoluteIndex = __webpack_require__(422);
+var toIndexedObject = __webpack_require__(116);
+var toLength = __webpack_require__(83);
+var toAbsoluteIndex = __webpack_require__(421);
 
 // `Array.prototype.{ indexOf, includes }` methods implementation
-var createMethod = function createMethod(IS_INCLUDES) {
+// false -> Array#indexOf
+// https://tc39.github.io/ecma262/#sec-array.prototype.indexof
+// true  -> Array#includes
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+module.exports = function (IS_INCLUDES) {
   return function ($this, el, fromIndex) {
     var O = toIndexedObject($this);
     var length = toLength(O.length);
@@ -44582,25 +44627,18 @@ var createMethod = function createMethod(IS_INCLUDES) {
       if (value != value) return true;
       // Array#indexOf ignores holes, Array#includes - not
     } else for (; length > index; index++) {
-      if ((IS_INCLUDES || index in O) && O[index] === el) return IS_INCLUDES || index || 0;
+      if (IS_INCLUDES || index in O) {
+        if (O[index] === el) return IS_INCLUDES || index || 0;
+      }
     }return !IS_INCLUDES && -1;
   };
 };
 
-module.exports = {
-  // `Array.prototype.includes` method
-  // https://tc39.github.io/ecma262/#sec-array.prototype.includes
-  includes: createMethod(true),
-  // `Array.prototype.indexOf` method
-  // https://tc39.github.io/ecma262/#sec-array.prototype.indexof
-  indexOf: createMethod(false)
-};
-
 /***/ }),
-/* 422 */
+/* 421 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toInteger = __webpack_require__(119);
+var toInteger = __webpack_require__(120);
 
 var max = Math.max;
 var min = Math.min;
@@ -44614,16 +44652,16 @@ module.exports = function (index, length) {
 };
 
 /***/ }),
-/* 423 */
+/* 422 */
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 /***/ }),
-/* 424 */
+/* 423 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var fails = __webpack_require__(58);
+var fails = __webpack_require__(59);
 
 var replacement = /#|\.prototype\./;
 
@@ -44643,10 +44681,10 @@ var POLYFILL = isForced.POLYFILL = 'P';
 module.exports = isForced;
 
 /***/ }),
-/* 425 */
+/* 424 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var fails = __webpack_require__(58);
+var fails = __webpack_require__(59);
 
 module.exports = !!Object.getOwnPropertySymbols && !fails(function () {
   // Chrome 38 Symbol has incorrect toString conversion
@@ -44655,7 +44693,7 @@ module.exports = !!Object.getOwnPropertySymbols && !fails(function () {
 });
 
 /***/ }),
-/* 426 */
+/* 425 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -44665,16 +44703,16 @@ var addToUnscopables = __webpack_require__(183);
 addToUnscopables('flat');
 
 /***/ }),
-/* 427 */
+/* 426 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var anObject = __webpack_require__(80);
-var defineProperties = __webpack_require__(428);
-var enumBugKeys = __webpack_require__(120);
-var hiddenKeys = __webpack_require__(118);
-var html = __webpack_require__(430);
-var documentCreateElement = __webpack_require__(170);
-var sharedKey = __webpack_require__(172);
+var anObject = __webpack_require__(81);
+var defineProperties = __webpack_require__(427);
+var enumBugKeys = __webpack_require__(121);
+var hiddenKeys = __webpack_require__(119);
+var html = __webpack_require__(429);
+var documentCreateElement = __webpack_require__(171);
+var sharedKey = __webpack_require__(173);
 var IE_PROTO = sharedKey('IE_PROTO');
 
 var PROTOTYPE = 'prototype';
@@ -44703,8 +44741,7 @@ var _createDict = function createDict() {
   }return _createDict();
 };
 
-// `Object.create` method
-// https://tc39.github.io/ecma262/#sec-object.create
+// 19.1.2.2 / 15.2.3.5 Object.create(O [, Properties])
 module.exports = Object.create || function create(O, Properties) {
   var result;
   if (O !== null) {
@@ -44720,50 +44757,49 @@ module.exports = Object.create || function create(O, Properties) {
 hiddenKeys[IE_PROTO] = true;
 
 /***/ }),
-/* 428 */
+/* 427 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(57);
-var definePropertyModule = __webpack_require__(116);
-var anObject = __webpack_require__(80);
-var objectKeys = __webpack_require__(429);
+var DESCRIPTORS = __webpack_require__(58);
+var definePropertyModule = __webpack_require__(117);
+var anObject = __webpack_require__(81);
+var objectKeys = __webpack_require__(428);
 
-// `Object.defineProperties` method
-// https://tc39.github.io/ecma262/#sec-object.defineproperties
 module.exports = DESCRIPTORS ? Object.defineProperties : function defineProperties(O, Properties) {
   anObject(O);
   var keys = objectKeys(Properties);
   var length = keys.length;
-  var index = 0;
+  var i = 0;
   var key;
-  while (length > index) {
-    definePropertyModule.f(O, key = keys[index++], Properties[key]);
+  while (length > i) {
+    definePropertyModule.f(O, key = keys[i++], Properties[key]);
   }return O;
+};
+
+/***/ }),
+/* 428 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var internalObjectKeys = __webpack_require__(175);
+var enumBugKeys = __webpack_require__(121);
+
+// 19.1.2.14 / 15.2.3.14 Object.keys(O)
+module.exports = Object.keys || function keys(O) {
+  return internalObjectKeys(O, enumBugKeys);
 };
 
 /***/ }),
 /* 429 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var internalObjectKeys = __webpack_require__(175);
-var enumBugKeys = __webpack_require__(120);
+var global = __webpack_require__(26);
 
-// `Object.keys` method
-// https://tc39.github.io/ecma262/#sec-object.keys
-module.exports = Object.keys || function keys(O) {
-  return internalObjectKeys(O, enumBugKeys);
-};
+var document = global.document;
+
+module.exports = document && document.documentElement;
 
 /***/ }),
 /* 430 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var getBuiltIn = __webpack_require__(174);
-
-module.exports = getBuiltIn('document', 'documentElement');
-
-/***/ }),
-/* 431 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -44772,7 +44808,7 @@ module.exports = getBuiltIn('document', 'documentElement');
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(47);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(432);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(431);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3__material_dialog__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -44938,7 +44974,7 @@ var VDialog = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 432 */
+/* 431 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -48556,19 +48592,19 @@ var VDialog = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 433 */
+/* 432 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDateTime;
 /* unused harmony export VDateTime */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(434);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(433);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield__ = __webpack_require__(185);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__material_textfield__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__text_fields__ = __webpack_require__(186);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__config__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__config__ = __webpack_require__(65);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -48587,6 +48623,7 @@ function initDateTime(e) {
     console.debug('\tDateTime');
     Object(__WEBPACK_IMPORTED_MODULE_3__base_component__["b" /* hookupComponents */])(e, '.v-datetime', VDateTime, __WEBPACK_IMPORTED_MODULE_1__material_textfield__["MDCTextField"]);
 }
+
 var VDateTime = function (_VTextField) {
     _inherits(VDateTime, _VTextField);
 
@@ -48618,6 +48655,7 @@ var VDateTime = function (_VTextField) {
         element.addEventListener('click', function () {
             return _this.toggle();
         });
+        _this.originalValue = _this.fp.input.value;
         return _this;
     }
 
@@ -48633,7 +48671,7 @@ var VDateTime = function (_VTextField) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.fp.setDate(this.element.dataset.originalValue);
+            this.fp.setDate(this.originalValue);
         }
     }, {
         key: 'open',
@@ -48671,8 +48709,13 @@ var VDateTime = function (_VTextField) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
+            if (!this.dirtyable) {
+                return false;
+            }
+
             var currVal = new Date(this.fp.input.value);
-            var prevVal = new Date(this.element.dataset.originalValue);
+            var prevVal = new Date(this.originalValue);
+
             return currVal.getTime() !== prevVal.getTime();
         }
     }]);
@@ -48681,2202 +48724,2196 @@ var VDateTime = function (_VTextField) {
 }(__WEBPACK_IMPORTED_MODULE_2__text_fields__["a" /* VTextField */]);
 
 /***/ }),
-/* 434 */
+/* 433 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-/* flatpickr v4.6.2, @license MIT */
+/* flatpickr v4.5.2, @license MIT */
 (function (global, factory) {
-    ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = factory() :  true ? !(__WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = factory() :  true ? !(__WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) :
 				__WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : (global = global || self, global.flatpickr = factory());
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : global.flatpickr = factory();
 })(this, function () {
-    'use strict';
+  'use strict';
 
-    /*! *****************************************************************************
-    Copyright (c) Microsoft Corporation. All rights reserved.
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-    this file except in compliance with the License. You may obtain a copy of the
-    License at http://www.apache.org/licenses/LICENSE-2.0
-      THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-    WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-    MERCHANTABLITY OR NON-INFRINGEMENT.
-      See the Apache Version 2.0 License for specific language governing permissions
-    and limitations under the License.
-    ***************************************************************************** */
+  var pad = function pad(number) {
+    return ("0" + number).slice(-2);
+  };
+  var int = function int(bool) {
+    return bool === true ? 1 : 0;
+  };
+  function debounce(func, wait, immediate) {
+    if (immediate === void 0) {
+      immediate = false;
+    }
 
-    var _assign = function __assign() {
-        _assign = Object.assign || function __assign(t) {
-            for (var s, i = 1, n = arguments.length; i < n; i++) {
-                s = arguments[i];
-                for (var p in s) {
-                    if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
-                }
-            }
-            return t;
-        };
-        return _assign.apply(this, arguments);
+    var timeout;
+    return function () {
+      var context = this,
+          args = arguments;
+      timeout !== null && clearTimeout(timeout);
+      timeout = window.setTimeout(function () {
+        timeout = null;
+        if (!immediate) func.apply(context, args);
+      }, wait);
+      if (immediate && !timeout) func.apply(context, args);
     };
+  }
+  var arrayify = function arrayify(obj) {
+    return obj instanceof Array ? obj : [obj];
+  };
 
-    var HOOKS = ["onChange", "onClose", "onDayCreate", "onDestroy", "onKeyDown", "onMonthChange", "onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange", "onPreCalendarPosition"];
-    var defaults = {
-        _disable: [],
-        _enable: [],
-        allowInput: false,
-        altFormat: "F j, Y",
-        altInput: false,
-        altInputClass: "form-control input",
-        animate: (typeof window === 'undefined' ? 'undefined' : _typeof(window)) === "object" && window.navigator.userAgent.indexOf("MSIE") === -1,
-        ariaDateFormat: "F j, Y",
-        clickOpens: true,
-        closeOnSelect: true,
-        conjunction: ", ",
-        dateFormat: "Y-m-d",
-        defaultHour: 12,
-        defaultMinute: 0,
-        defaultSeconds: 0,
-        disable: [],
-        disableMobile: false,
-        enable: [],
-        enableSeconds: false,
-        enableTime: false,
-        errorHandler: function errorHandler(err) {
-            return typeof console !== "undefined" && console.warn(err);
-        },
-        getWeek: function getWeek(givenDate) {
-            var date = new Date(givenDate.getTime());
-            date.setHours(0, 0, 0, 0);
-            // Thursday in current week decides the year.
-            date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
-            // January 4 is always in week 1.
-            var week1 = new Date(date.getFullYear(), 0, 4);
-            // Adjust to Thursday in week 1 and count number of weeks from date to week1.
-            return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getDay() + 6) % 7) / 7);
-        },
-        hourIncrement: 1,
-        ignoredFocusElements: [],
-        inline: false,
-        locale: "default",
-        minuteIncrement: 5,
-        mode: "single",
-        monthSelectorType: "dropdown",
-        nextArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
-        noCalendar: false,
-        now: new Date(),
-        onChange: [],
-        onClose: [],
-        onDayCreate: [],
-        onDestroy: [],
-        onKeyDown: [],
-        onMonthChange: [],
-        onOpen: [],
-        onParseConfig: [],
-        onReady: [],
-        onValueUpdate: [],
-        onYearChange: [],
-        onPreCalendarPosition: [],
-        plugins: [],
-        position: "auto",
-        positionElement: undefined,
-        prevArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
-        shorthandCurrentMonth: false,
-        showMonths: 1,
-        static: false,
-        time_24hr: false,
-        weekNumbers: false,
-        wrap: false
-    };
+  var do_nothing = function do_nothing() {
+    return undefined;
+  };
 
-    var english = {
-        weekdays: {
-            shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-            longhand: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-        },
-        months: {
-            shorthand: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-            longhand: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-        },
-        daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-        firstDayOfWeek: 0,
-        ordinal: function ordinal(nth) {
-            var s = nth % 100;
-            if (s > 3 && s < 21) return "th";
-            switch (s % 10) {
-                case 1:
-                    return "st";
-                case 2:
-                    return "nd";
-                case 3:
-                    return "rd";
-                default:
-                    return "th";
-            }
-        },
-        rangeSeparator: " to ",
-        weekAbbreviation: "Wk",
-        scrollTitle: "Scroll to increment",
-        toggleTitle: "Click to toggle",
-        amPM: ["AM", "PM"],
-        yearAriaLabel: "Year",
-        hourAriaLabel: "Hour",
-        minuteAriaLabel: "Minute",
-        time_24hr: false
-    };
+  var monthToStr = function monthToStr(monthNumber, shorthand, locale) {
+    return locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
+  };
+  var revFormat = {
+    D: do_nothing,
+    F: function F(dateObj, monthName, locale) {
+      dateObj.setMonth(locale.months.longhand.indexOf(monthName));
+    },
+    G: function G(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    H: function H(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    J: function J(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    K: function K(dateObj, amPM, locale) {
+      dateObj.setHours(dateObj.getHours() % 12 + 12 * int(new RegExp(locale.amPM[1], "i").test(amPM)));
+    },
+    M: function M(dateObj, shortMonth, locale) {
+      dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
+    },
+    S: function S(dateObj, seconds) {
+      dateObj.setSeconds(parseFloat(seconds));
+    },
+    U: function U(_, unixSeconds) {
+      return new Date(parseFloat(unixSeconds) * 1000);
+    },
+    W: function W(dateObj, weekNum) {
+      var weekNumber = parseInt(weekNum);
+      return new Date(dateObj.getFullYear(), 0, 2 + (weekNumber - 1) * 7, 0, 0, 0, 0);
+    },
+    Y: function Y(dateObj, year) {
+      dateObj.setFullYear(parseFloat(year));
+    },
+    Z: function Z(_, ISODate) {
+      return new Date(ISODate);
+    },
+    d: function d(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    h: function h(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    i: function i(dateObj, minutes) {
+      dateObj.setMinutes(parseFloat(minutes));
+    },
+    j: function j(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    l: do_nothing,
+    m: function m(dateObj, month) {
+      dateObj.setMonth(parseFloat(month) - 1);
+    },
+    n: function n(dateObj, month) {
+      dateObj.setMonth(parseFloat(month) - 1);
+    },
+    s: function s(dateObj, seconds) {
+      dateObj.setSeconds(parseFloat(seconds));
+    },
+    w: do_nothing,
+    y: function y(dateObj, year) {
+      dateObj.setFullYear(2000 + parseFloat(year));
+    }
+  };
+  var tokenRegex = {
+    D: "(\\w+)",
+    F: "(\\w+)",
+    G: "(\\d\\d|\\d)",
+    H: "(\\d\\d|\\d)",
+    J: "(\\d\\d|\\d)\\w+",
+    K: "",
+    M: "(\\w+)",
+    S: "(\\d\\d|\\d)",
+    U: "(.+)",
+    W: "(\\d\\d|\\d)",
+    Y: "(\\d{4})",
+    Z: "(.+)",
+    d: "(\\d\\d|\\d)",
+    h: "(\\d\\d|\\d)",
+    i: "(\\d\\d|\\d)",
+    j: "(\\d\\d|\\d)",
+    l: "(\\w+)",
+    m: "(\\d\\d|\\d)",
+    n: "(\\d\\d|\\d)",
+    s: "(\\d\\d|\\d)",
+    w: "(\\d\\d|\\d)",
+    y: "(\\d{2})"
+  };
+  var formats = {
+    Z: function Z(date) {
+      return date.toISOString();
+    },
+    D: function D(date, locale, options) {
+      return locale.weekdays.shorthand[formats.w(date, locale, options)];
+    },
+    F: function F(date, locale, options) {
+      return monthToStr(formats.n(date, locale, options) - 1, false, locale);
+    },
+    G: function G(date, locale, options) {
+      return pad(formats.h(date, locale, options));
+    },
+    H: function H(date) {
+      return pad(date.getHours());
+    },
+    J: function J(date, locale) {
+      return locale.ordinal !== undefined ? date.getDate() + locale.ordinal(date.getDate()) : date.getDate();
+    },
+    K: function K(date, locale) {
+      return locale.amPM[int(date.getHours() > 11)];
+    },
+    M: function M(date, locale) {
+      return monthToStr(date.getMonth(), true, locale);
+    },
+    S: function S(date) {
+      return pad(date.getSeconds());
+    },
+    U: function U(date) {
+      return date.getTime() / 1000;
+    },
+    W: function W(date, _, options) {
+      return options.getWeek(date);
+    },
+    Y: function Y(date) {
+      return date.getFullYear();
+    },
+    d: function d(date) {
+      return pad(date.getDate());
+    },
+    h: function h(date) {
+      return date.getHours() % 12 ? date.getHours() % 12 : 12;
+    },
+    i: function i(date) {
+      return pad(date.getMinutes());
+    },
+    j: function j(date) {
+      return date.getDate();
+    },
+    l: function l(date, locale) {
+      return locale.weekdays.longhand[date.getDay()];
+    },
+    m: function m(date) {
+      return pad(date.getMonth() + 1);
+    },
+    n: function n(date) {
+      return date.getMonth() + 1;
+    },
+    s: function s(date) {
+      return date.getSeconds();
+    },
+    w: function w(date) {
+      return date.getDay();
+    },
+    y: function y(date) {
+      return String(date.getFullYear()).substring(2);
+    }
+  };
 
-    var pad = function pad(number) {
-        return ("0" + number).slice(-2);
+  var english = {
+    weekdays: {
+      shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+      longhand: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    },
+    months: {
+      shorthand: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+      longhand: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+    },
+    daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+    firstDayOfWeek: 0,
+    ordinal: function ordinal(nth) {
+      var s = nth % 100;
+      if (s > 3 && s < 21) return "th";
+
+      switch (s % 10) {
+        case 1:
+          return "st";
+
+        case 2:
+          return "nd";
+
+        case 3:
+          return "rd";
+
+        default:
+          return "th";
+      }
+    },
+    rangeSeparator: " to ",
+    weekAbbreviation: "Wk",
+    scrollTitle: "Scroll to increment",
+    toggleTitle: "Click to toggle",
+    amPM: ["AM", "PM"],
+    yearAriaLabel: "Year"
+  };
+
+  var createDateFormatter = function createDateFormatter(_ref) {
+    var _ref$config = _ref.config,
+        config = _ref$config === void 0 ? defaults : _ref$config,
+        _ref$l10n = _ref.l10n,
+        l10n = _ref$l10n === void 0 ? english : _ref$l10n;
+    return function (dateObj, frmt, overrideLocale) {
+      var locale = overrideLocale || l10n;
+
+      if (config.formatDate !== undefined) {
+        return config.formatDate(dateObj, frmt, locale);
+      }
+
+      return frmt.split("").map(function (c, i, arr) {
+        return formats[c] && arr[i - 1] !== "\\" ? formats[c](dateObj, locale, config) : c !== "\\" ? c : "";
+      }).join("");
     };
-    var int = function int(bool) {
-        return bool === true ? 1 : 0;
-    };
-    /* istanbul ignore next */
-    function debounce(func, wait, immediate) {
-        if (immediate === void 0) {
-            immediate = false;
+  };
+  var createDateParser = function createDateParser(_ref2) {
+    var _ref2$config = _ref2.config,
+        config = _ref2$config === void 0 ? defaults : _ref2$config,
+        _ref2$l10n = _ref2.l10n,
+        l10n = _ref2$l10n === void 0 ? english : _ref2$l10n;
+    return function (date, givenFormat, timeless, customLocale) {
+      if (date !== 0 && !date) return undefined;
+      var locale = customLocale || l10n;
+      var parsedDate;
+      var date_orig = date;
+      if (date instanceof Date) parsedDate = new Date(date.getTime());else if (typeof date !== "string" && date.toFixed !== undefined) parsedDate = new Date(date);else if (typeof date === "string") {
+        var format = givenFormat || (config || defaults).dateFormat;
+        var datestr = String(date).trim();
+
+        if (datestr === "today") {
+          parsedDate = new Date();
+          timeless = true;
+        } else if (/Z$/.test(datestr) || /GMT$/.test(datestr)) parsedDate = new Date(date);else if (config && config.parseDate) parsedDate = config.parseDate(date, format);else {
+          parsedDate = !config || !config.noCalendar ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0) : new Date(new Date().setHours(0, 0, 0, 0));
+          var matched,
+              ops = [];
+
+          for (var i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
+            var token = format[i];
+            var isBackSlash = token === "\\";
+            var escaped = format[i - 1] === "\\" || isBackSlash;
+
+            if (tokenRegex[token] && !escaped) {
+              regexStr += tokenRegex[token];
+              var match = new RegExp(regexStr).exec(date);
+
+              if (match && (matched = true)) {
+                ops[token !== "Y" ? "push" : "unshift"]({
+                  fn: revFormat[token],
+                  val: match[++matchIndex]
+                });
+              }
+            } else if (!isBackSlash) regexStr += ".";
+
+            ops.forEach(function (_ref3) {
+              var fn = _ref3.fn,
+                  val = _ref3.val;
+              return parsedDate = fn(parsedDate, val, locale) || parsedDate;
+            });
+          }
+
+          parsedDate = matched ? parsedDate : undefined;
         }
-        var timeout;
-        return function () {
-            var context = this,
-                args = arguments;
-            timeout !== null && clearTimeout(timeout);
-            timeout = window.setTimeout(function () {
-                timeout = null;
-                if (!immediate) func.apply(context, args);
-            }, wait);
-            if (immediate && !timeout) func.apply(context, args);
-        };
-    }
-    var arrayify = function arrayify(obj) {
-        return obj instanceof Array ? obj : [obj];
-    };
+      }
 
-    function toggleClass(elem, className, bool) {
-        if (bool === true) return elem.classList.add(className);
-        elem.classList.remove(className);
-    }
-    function createElement(tag, className, content) {
-        var e = window.document.createElement(tag);
-        className = className || "";
-        content = content || "";
-        e.className = className;
-        if (content !== undefined) e.textContent = content;
-        return e;
-    }
-    function clearNode(node) {
-        while (node.firstChild) {
-            node.removeChild(node.firstChild);
-        }
-    }
-    function findParent(node, condition) {
-        if (condition(node)) return node;else if (node.parentNode) return findParent(node.parentNode, condition);
-        return undefined; // nothing found
-    }
-    function createNumberInput(inputClassName, opts) {
-        var wrapper = createElement("div", "numInputWrapper"),
-            numInput = createElement("input", "numInput " + inputClassName),
-            arrowUp = createElement("span", "arrowUp"),
-            arrowDown = createElement("span", "arrowDown");
-        if (navigator.userAgent.indexOf("MSIE 9.0") === -1) {
-            numInput.type = "number";
-        } else {
-            numInput.type = "text";
-            numInput.pattern = "\\d*";
-        }
-        if (opts !== undefined) for (var key in opts) {
-            numInput.setAttribute(key, opts[key]);
-        }wrapper.appendChild(numInput);
-        wrapper.appendChild(arrowUp);
-        wrapper.appendChild(arrowDown);
-        return wrapper;
-    }
-    function getEventTarget(event) {
-        if (typeof event.composedPath === "function") {
-            var path = event.composedPath();
-            return path[0];
-        }
-        return event.target;
-    }
-
-    var doNothing = function doNothing() {
+      if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
+        config.errorHandler(new Error("Invalid date provided: " + date_orig));
         return undefined;
-    };
-    var monthToStr = function monthToStr(monthNumber, shorthand, locale) {
-        return locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
-    };
-    var revFormat = {
-        D: doNothing,
-        F: function F(dateObj, monthName, locale) {
-            dateObj.setMonth(locale.months.longhand.indexOf(monthName));
-        },
-        G: function G(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        H: function H(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        J: function J(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        K: function K(dateObj, amPM, locale) {
-            dateObj.setHours(dateObj.getHours() % 12 + 12 * int(new RegExp(locale.amPM[1], "i").test(amPM)));
-        },
-        M: function M(dateObj, shortMonth, locale) {
-            dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
-        },
-        S: function S(dateObj, seconds) {
-            dateObj.setSeconds(parseFloat(seconds));
-        },
-        U: function U(_, unixSeconds) {
-            return new Date(parseFloat(unixSeconds) * 1000);
-        },
-        W: function W(dateObj, weekNum, locale) {
-            var weekNumber = parseInt(weekNum);
-            var date = new Date(dateObj.getFullYear(), 0, 2 + (weekNumber - 1) * 7, 0, 0, 0, 0);
-            date.setDate(date.getDate() - date.getDay() + locale.firstDayOfWeek);
-            return date;
-        },
-        Y: function Y(dateObj, year) {
-            dateObj.setFullYear(parseFloat(year));
-        },
-        Z: function Z(_, ISODate) {
-            return new Date(ISODate);
-        },
-        d: function d(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        h: function h(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        i: function i(dateObj, minutes) {
-            dateObj.setMinutes(parseFloat(minutes));
-        },
-        j: function j(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        l: doNothing,
-        m: function m(dateObj, month) {
-            dateObj.setMonth(parseFloat(month) - 1);
-        },
-        n: function n(dateObj, month) {
-            dateObj.setMonth(parseFloat(month) - 1);
-        },
-        s: function s(dateObj, seconds) {
-            dateObj.setSeconds(parseFloat(seconds));
-        },
-        u: function u(_, unixMillSeconds) {
-            return new Date(parseFloat(unixMillSeconds));
-        },
-        w: doNothing,
-        y: function y(dateObj, year) {
-            dateObj.setFullYear(2000 + parseFloat(year));
-        }
-    };
-    var tokenRegex = {
-        D: "(\\w+)",
-        F: "(\\w+)",
-        G: "(\\d\\d|\\d)",
-        H: "(\\d\\d|\\d)",
-        J: "(\\d\\d|\\d)\\w+",
-        K: "",
-        M: "(\\w+)",
-        S: "(\\d\\d|\\d)",
-        U: "(.+)",
-        W: "(\\d\\d|\\d)",
-        Y: "(\\d{4})",
-        Z: "(.+)",
-        d: "(\\d\\d|\\d)",
-        h: "(\\d\\d|\\d)",
-        i: "(\\d\\d|\\d)",
-        j: "(\\d\\d|\\d)",
-        l: "(\\w+)",
-        m: "(\\d\\d|\\d)",
-        n: "(\\d\\d|\\d)",
-        s: "(\\d\\d|\\d)",
-        u: "(.+)",
-        w: "(\\d\\d|\\d)",
-        y: "(\\d{2})"
-    };
-    var formats = {
-        // get the date in UTC
-        Z: function Z(date) {
-            return date.toISOString();
-        },
-        // weekday name, short, e.g. Thu
-        D: function D(date, locale, options) {
-            return locale.weekdays.shorthand[formats.w(date, locale, options)];
-        },
-        // full month name e.g. January
-        F: function F(date, locale, options) {
-            return monthToStr(formats.n(date, locale, options) - 1, false, locale);
-        },
-        // padded hour 1-12
-        G: function G(date, locale, options) {
-            return pad(formats.h(date, locale, options));
-        },
-        // hours with leading zero e.g. 03
-        H: function H(date) {
-            return pad(date.getHours());
-        },
-        // day (1-30) with ordinal suffix e.g. 1st, 2nd
-        J: function J(date, locale) {
-            return locale.ordinal !== undefined ? date.getDate() + locale.ordinal(date.getDate()) : date.getDate();
-        },
-        // AM/PM
-        K: function K(date, locale) {
-            return locale.amPM[int(date.getHours() > 11)];
-        },
-        // shorthand month e.g. Jan, Sep, Oct, etc
-        M: function M(date, locale) {
-            return monthToStr(date.getMonth(), true, locale);
-        },
-        // seconds 00-59
-        S: function S(date) {
-            return pad(date.getSeconds());
-        },
-        // unix timestamp
-        U: function U(date) {
-            return date.getTime() / 1000;
-        },
-        W: function W(date, _, options) {
-            return options.getWeek(date);
-        },
-        // full year e.g. 2016
-        Y: function Y(date) {
-            return date.getFullYear();
-        },
-        // day in month, padded (01-30)
-        d: function d(date) {
-            return pad(date.getDate());
-        },
-        // hour from 1-12 (am/pm)
-        h: function h(date) {
-            return date.getHours() % 12 ? date.getHours() % 12 : 12;
-        },
-        // minutes, padded with leading zero e.g. 09
-        i: function i(date) {
-            return pad(date.getMinutes());
-        },
-        // day in month (1-30)
-        j: function j(date) {
-            return date.getDate();
-        },
-        // weekday name, full, e.g. Thursday
-        l: function l(date, locale) {
-            return locale.weekdays.longhand[date.getDay()];
-        },
-        // padded month number (01-12)
-        m: function m(date) {
-            return pad(date.getMonth() + 1);
-        },
-        // the month number (1-12)
-        n: function n(date) {
-            return date.getMonth() + 1;
-        },
-        // seconds 0-59
-        s: function s(date) {
-            return date.getSeconds();
-        },
-        // Unix Milliseconds
-        u: function u(date) {
-            return date.getTime();
-        },
-        // number of the day of the week
-        w: function w(date) {
-            return date.getDay();
-        },
-        // last two digits of year e.g. 16 for 2016
-        y: function y(date) {
-            return String(date.getFullYear()).substring(2);
-        }
-    };
+      }
 
-    var createDateFormatter = function createDateFormatter(_a) {
-        var _b = _a.config,
-            config = _b === void 0 ? defaults : _b,
-            _c = _a.l10n,
-            l10n = _c === void 0 ? english : _c;
-        return function (dateObj, frmt, overrideLocale) {
-            var locale = overrideLocale || l10n;
-            if (config.formatDate !== undefined) {
-                return config.formatDate(dateObj, frmt, locale);
-            }
-            return frmt.split("").map(function (c, i, arr) {
-                return formats[c] && arr[i - 1] !== "\\" ? formats[c](dateObj, locale, config) : c !== "\\" ? c : "";
-            }).join("");
-        };
+      if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
+      return parsedDate;
     };
-    var createDateParser = function createDateParser(_a) {
-        var _b = _a.config,
-            config = _b === void 0 ? defaults : _b,
-            _c = _a.l10n,
-            l10n = _c === void 0 ? english : _c;
-        return function (date, givenFormat, timeless, customLocale) {
-            if (date !== 0 && !date) return undefined;
-            var locale = customLocale || l10n;
-            var parsedDate;
-            var dateOrig = date;
-            if (date instanceof Date) parsedDate = new Date(date.getTime());else if (typeof date !== "string" && date.toFixed !== undefined // timestamp
-            )
-                // create a copy
-                parsedDate = new Date(date);else if (typeof date === "string") {
-                // date string
-                var format = givenFormat || (config || defaults).dateFormat;
-                var datestr = String(date).trim();
-                if (datestr === "today") {
-                    parsedDate = new Date();
-                    timeless = true;
-                } else if (/Z$/.test(datestr) || /GMT$/.test(datestr) // datestrings w/ timezone
-                ) parsedDate = new Date(date);else if (config && config.parseDate) parsedDate = config.parseDate(date, format);else {
-                    parsedDate = !config || !config.noCalendar ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0) : new Date(new Date().setHours(0, 0, 0, 0));
-                    var matched = void 0,
-                        ops = [];
-                    for (var i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
-                        var token_1 = format[i];
-                        var isBackSlash = token_1 === "\\";
-                        var escaped = format[i - 1] === "\\" || isBackSlash;
-                        if (tokenRegex[token_1] && !escaped) {
-                            regexStr += tokenRegex[token_1];
-                            var match = new RegExp(regexStr).exec(date);
-                            if (match && (matched = true)) {
-                                ops[token_1 !== "Y" ? "push" : "unshift"]({
-                                    fn: revFormat[token_1],
-                                    val: match[++matchIndex]
-                                });
-                            }
-                        } else if (!isBackSlash) regexStr += "."; // don't really care
-                        ops.forEach(function (_a) {
-                            var fn = _a.fn,
-                                val = _a.val;
-                            return parsedDate = fn(parsedDate, val, locale) || parsedDate;
-                        });
-                    }
-                    parsedDate = matched ? parsedDate : undefined;
-                }
-            }
-            /* istanbul ignore next */
-            if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
-                config.errorHandler(new Error("Invalid date provided: " + dateOrig));
-                return undefined;
-            }
-            if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
-            return parsedDate;
-        };
-    };
-    /**
-     * Compute the difference in dates, measured in ms
-     */
-    function compareDates(date1, date2, timeless) {
-        if (timeless === void 0) {
-            timeless = true;
-        }
-        if (timeless !== false) {
-            return new Date(date1.getTime()).setHours(0, 0, 0, 0) - new Date(date2.getTime()).setHours(0, 0, 0, 0);
-        }
-        return date1.getTime() - date2.getTime();
-    }
-    var isBetween = function isBetween(ts, ts1, ts2) {
-        return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
-    };
-    var duration = {
-        DAY: 86400000
-    };
-
-    if (typeof Object.assign !== "function") {
-        Object.assign = function (target) {
-            var args = [];
-            for (var _i = 1; _i < arguments.length; _i++) {
-                args[_i - 1] = arguments[_i];
-            }
-            if (!target) {
-                throw TypeError("Cannot convert undefined or null to object");
-            }
-            var _loop_1 = function _loop_1(source) {
-                if (source) {
-                    Object.keys(source).forEach(function (key) {
-                        return target[key] = source[key];
-                    });
-                }
-            };
-            for (var _a = 0, args_1 = args; _a < args_1.length; _a++) {
-                var source = args_1[_a];
-                _loop_1(source);
-            }
-            return target;
-        };
+  };
+  function compareDates(date1, date2, timeless) {
+    if (timeless === void 0) {
+      timeless = true;
     }
 
-    var DEBOUNCED_CHANGE_MS = 300;
-    function FlatpickrInstance(element, instanceConfig) {
-        var self = {
-            config: _assign({}, defaults, flatpickr.defaultConfig),
-            l10n: english
-        };
-        self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
-        self._handlers = [];
-        self.pluginElements = [];
-        self.loadedPlugins = [];
-        self._bind = bind;
-        self._setHoursFromDate = setHoursFromDate;
-        self._positionCalendar = positionCalendar;
-        self.changeMonth = changeMonth;
-        self.changeYear = changeYear;
-        self.clear = clear;
-        self.close = close;
-        self._createElement = createElement;
-        self.destroy = destroy;
-        self.isEnabled = isEnabled;
-        self.jumpToDate = jumpToDate;
-        self.open = open;
-        self.redraw = redraw;
-        self.set = set;
-        self.setDate = setDate;
-        self.toggle = toggle;
-        function setupHelperFunctions() {
-            self.utils = {
-                getDaysInMonth: function getDaysInMonth(month, yr) {
-                    if (month === void 0) {
-                        month = self.currentMonth;
-                    }
-                    if (yr === void 0) {
-                        yr = self.currentYear;
-                    }
-                    if (month === 1 && (yr % 4 === 0 && yr % 100 !== 0 || yr % 400 === 0)) return 29;
-                    return self.l10n.daysInMonth[month];
-                }
-            };
-        }
-        function init() {
-            self.element = self.input = element;
-            self.isOpen = false;
-            parseConfig();
-            setupLocale();
-            setupInputs();
-            setupDates();
-            setupHelperFunctions();
-            if (!self.isMobile) build();
-            bindEvents();
-            if (self.selectedDates.length || self.config.noCalendar) {
-                if (self.config.enableTime) {
-                    setHoursFromDate(self.config.noCalendar ? self.latestSelectedDateObj || self.config.minDate : undefined);
-                }
-                updateValue(false);
-            }
-            setCalendarWidth();
-            self.showTimeInput = self.selectedDates.length > 0 || self.config.noCalendar;
-            var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            /* TODO: investigate this further
-                       Currently, there is weird positioning behavior in safari causing pages
-              to scroll up. https://github.com/chmln/flatpickr/issues/563
-                       However, most browsers are not Safari and positioning is expensive when used
-              in scale. https://github.com/chmln/flatpickr/issues/1096
-            */
-            if (!self.isMobile && isSafari) {
-                positionCalendar();
-            }
-            triggerEvent("onReady");
-        }
-        function bindToInstance(fn) {
-            return fn.bind(self);
-        }
-        function setCalendarWidth() {
-            var config = self.config;
-            if (config.weekNumbers === false && config.showMonths === 1) return;else if (config.noCalendar !== true) {
-                window.requestAnimationFrame(function () {
-                    if (self.calendarContainer !== undefined) {
-                        self.calendarContainer.style.visibility = "hidden";
-                        self.calendarContainer.style.display = "block";
-                    }
-                    if (self.daysContainer !== undefined) {
-                        var daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
-                        self.daysContainer.style.width = daysWidth + "px";
-                        self.calendarContainer.style.width = daysWidth + (self.weekWrapper !== undefined ? self.weekWrapper.offsetWidth : 0) + "px";
-                        self.calendarContainer.style.removeProperty("visibility");
-                        self.calendarContainer.style.removeProperty("display");
-                    }
-                });
-            }
-        }
-        /**
-         * The handler for all events targeting the time inputs
-         */
-        function updateTime(e) {
-            if (self.selectedDates.length === 0) {
-                setDefaultTime();
-            }
-            if (e !== undefined && e.type !== "blur") {
-                timeWrapper(e);
-            }
-            var prevValue = self._input.value;
-            setHoursFromInputs();
-            updateValue();
-            if (self._input.value !== prevValue) {
-                self._debouncedChange();
-            }
-        }
-        function ampm2military(hour, amPM) {
-            return hour % 12 + 12 * int(amPM === self.l10n.amPM[1]);
-        }
-        function military2ampm(hour) {
-            switch (hour % 24) {
-                case 0:
-                case 12:
-                    return 12;
-                default:
-                    return hour % 12;
-            }
-        }
-        /**
-         * Syncs the selected date object time with user's time input
-         */
-        function setHoursFromInputs() {
-            if (self.hourElement === undefined || self.minuteElement === undefined) return;
-            var hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
-                minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
-                seconds = self.secondElement !== undefined ? (parseInt(self.secondElement.value, 10) || 0) % 60 : 0;
-            if (self.amPM !== undefined) {
-                hours = ampm2military(hours, self.amPM.textContent);
-            }
-            var limitMinHours = self.config.minTime !== undefined || self.config.minDate && self.minDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.minDate, true) === 0;
-            var limitMaxHours = self.config.maxTime !== undefined || self.config.maxDate && self.maxDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.maxDate, true) === 0;
-            if (limitMaxHours) {
-                var maxTime = self.config.maxTime !== undefined ? self.config.maxTime : self.config.maxDate;
-                hours = Math.min(hours, maxTime.getHours());
-                if (hours === maxTime.getHours()) minutes = Math.min(minutes, maxTime.getMinutes());
-                if (minutes === maxTime.getMinutes()) seconds = Math.min(seconds, maxTime.getSeconds());
-            }
-            if (limitMinHours) {
-                var minTime = self.config.minTime !== undefined ? self.config.minTime : self.config.minDate;
-                hours = Math.max(hours, minTime.getHours());
-                if (hours === minTime.getHours()) minutes = Math.max(minutes, minTime.getMinutes());
-                if (minutes === minTime.getMinutes()) seconds = Math.max(seconds, minTime.getSeconds());
-            }
-            setHours(hours, minutes, seconds);
-        }
-        /**
-         * Syncs time input values with a date
-         */
-        function setHoursFromDate(dateObj) {
-            var date = dateObj || self.latestSelectedDateObj;
-            if (date) setHours(date.getHours(), date.getMinutes(), date.getSeconds());
-        }
-        function setDefaultHours() {
-            var hours = self.config.defaultHour;
-            var minutes = self.config.defaultMinute;
-            var seconds = self.config.defaultSeconds;
-            if (self.config.minDate !== undefined) {
-                var minHr = self.config.minDate.getHours();
-                var minMinutes = self.config.minDate.getMinutes();
-                hours = Math.max(hours, minHr);
-                if (hours === minHr) minutes = Math.max(minMinutes, minutes);
-                if (hours === minHr && minutes === minMinutes) seconds = self.config.minDate.getSeconds();
-            }
-            if (self.config.maxDate !== undefined) {
-                var maxHr = self.config.maxDate.getHours();
-                var maxMinutes = self.config.maxDate.getMinutes();
-                hours = Math.min(hours, maxHr);
-                if (hours === maxHr) minutes = Math.min(maxMinutes, minutes);
-                if (hours === maxHr && minutes === maxMinutes) seconds = self.config.maxDate.getSeconds();
-            }
-            setHours(hours, minutes, seconds);
-        }
-        /**
-         * Sets the hours, minutes, and optionally seconds
-         * of the latest selected date object and the
-         * corresponding time inputs
-         * @param {Number} hours the hour. whether its military
-         *                 or am-pm gets inferred from config
-         * @param {Number} minutes the minutes
-         * @param {Number} seconds the seconds (optional)
-         */
-        function setHours(hours, minutes, seconds) {
-            if (self.latestSelectedDateObj !== undefined) {
-                self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
-            }
-            if (!self.hourElement || !self.minuteElement || self.isMobile) return;
-            self.hourElement.value = pad(!self.config.time_24hr ? (12 + hours) % 12 + 12 * int(hours % 12 === 0) : hours);
-            self.minuteElement.value = pad(minutes);
-            if (self.amPM !== undefined) self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
-            if (self.secondElement !== undefined) self.secondElement.value = pad(seconds);
-        }
-        /**
-         * Handles the year input and incrementing events
-         * @param {Event} event the keyup or increment event
-         */
-        function onYearInput(event) {
-            var year = parseInt(event.target.value) + (event.delta || 0);
-            if (year / 1000 > 1 || event.key === "Enter" && !/[^\d]/.test(year.toString())) {
-                changeYear(year);
-            }
-        }
-        /**
-         * Essentially addEventListener + tracking
-         * @param {Element} element the element to addEventListener to
-         * @param {String} event the event name
-         * @param {Function} handler the event handler
-         */
-        function bind(element, event, handler, options) {
-            if (event instanceof Array) return event.forEach(function (ev) {
-                return bind(element, ev, handler, options);
-            });
-            if (element instanceof Array) return element.forEach(function (el) {
-                return bind(el, event, handler, options);
-            });
-            element.addEventListener(event, handler, options);
-            self._handlers.push({
-                element: element,
-                event: event,
-                handler: handler,
-                options: options
-            });
-        }
-        /**
-         * A mousedown handler which mimics click.
-         * Minimizes latency, since we don't need to wait for mouseup in most cases.
-         * Also, avoids handling right clicks.
-         *
-         * @param {Function} handler the event handler
-         */
-        function onClick(handler) {
-            return function (evt) {
-                evt.which === 1 && handler(evt);
-            };
-        }
-        function triggerChange() {
-            triggerEvent("onChange");
-        }
-        /**
-         * Adds all the necessary event listeners
-         */
-        function bindEvents() {
-            if (self.config.wrap) {
-                ["open", "close", "toggle", "clear"].forEach(function (evt) {
-                    Array.prototype.forEach.call(self.element.querySelectorAll("[data-" + evt + "]"), function (el) {
-                        return bind(el, "click", self[evt]);
-                    });
-                });
-            }
-            if (self.isMobile) {
-                setupMobile();
-                return;
-            }
-            var debouncedResize = debounce(onResize, 50);
-            self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
-            if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent)) bind(self.daysContainer, "mouseover", function (e) {
-                if (self.config.mode === "range") onMouseOver(e.target);
-            });
-            bind(window.document.body, "keydown", onKeyDown);
-            if (!self.config.inline && !self.config.static) bind(window, "resize", debouncedResize);
-            if (window.ontouchstart !== undefined) bind(window.document, "touchstart", documentClick);else bind(window.document, "mousedown", onClick(documentClick));
-            bind(window.document, "focus", documentClick, { capture: true });
-            if (self.config.clickOpens === true) {
-                bind(self._input, "focus", self.open);
-                bind(self._input, "mousedown", onClick(self.open));
-            }
-            if (self.daysContainer !== undefined) {
-                bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
-                bind(self.monthNav, ["keyup", "increment"], onYearInput);
-                bind(self.daysContainer, "mousedown", onClick(selectDate));
-            }
-            if (self.timeContainer !== undefined && self.minuteElement !== undefined && self.hourElement !== undefined) {
-                var selText = function selText(e) {
-                    return e.target.select();
-                };
-                bind(self.timeContainer, ["increment"], updateTime);
-                bind(self.timeContainer, "blur", updateTime, { capture: true });
-                bind(self.timeContainer, "mousedown", onClick(timeIncrement));
-                bind([self.hourElement, self.minuteElement], ["focus", "click"], selText);
-                if (self.secondElement !== undefined) bind(self.secondElement, "focus", function () {
-                    return self.secondElement && self.secondElement.select();
-                });
-                if (self.amPM !== undefined) {
-                    bind(self.amPM, "mousedown", onClick(function (e) {
-                        updateTime(e);
-                        triggerChange();
-                    }));
-                }
-            }
-        }
-        /**
-         * Set the calendar view to a particular date.
-         * @param {Date} jumpDate the date to set the view to
-         * @param {boolean} triggerChange if change events should be triggered
-         */
-        function jumpToDate(jumpDate, triggerChange) {
-            var jumpTo = jumpDate !== undefined ? self.parseDate(jumpDate) : self.latestSelectedDateObj || (self.config.minDate && self.config.minDate > self.now ? self.config.minDate : self.config.maxDate && self.config.maxDate < self.now ? self.config.maxDate : self.now);
-            var oldYear = self.currentYear;
-            var oldMonth = self.currentMonth;
-            try {
-                if (jumpTo !== undefined) {
-                    self.currentYear = jumpTo.getFullYear();
-                    self.currentMonth = jumpTo.getMonth();
-                }
-            } catch (e) {
-                /* istanbul ignore next */
-                e.message = "Invalid date supplied: " + jumpTo;
-                self.config.errorHandler(e);
-            }
-            if (triggerChange && self.currentYear !== oldYear) {
-                triggerEvent("onYearChange");
-                buildMonthSwitch();
-            }
-            if (triggerChange && (self.currentYear !== oldYear || self.currentMonth !== oldMonth)) {
-                triggerEvent("onMonthChange");
-            }
-            self.redraw();
-        }
-        /**
-         * The up/down arrow handler for time inputs
-         * @param {Event} e the click event
-         */
-        function timeIncrement(e) {
-            if (~e.target.className.indexOf("arrow")) incrementNumInput(e, e.target.classList.contains("arrowUp") ? 1 : -1);
-        }
-        /**
-         * Increments/decrements the value of input associ-
-         * ated with the up/down arrow by dispatching an
-         * "increment" event on the input.
-         *
-         * @param {Event} e the click event
-         * @param {Number} delta the diff (usually 1 or -1)
-         * @param {Element} inputElem the input element
-         */
-        function incrementNumInput(e, delta, inputElem) {
-            var target = e && e.target;
-            var input = inputElem || target && target.parentNode && target.parentNode.firstChild;
-            var event = createEvent("increment");
-            event.delta = delta;
-            input && input.dispatchEvent(event);
-        }
-        function build() {
-            var fragment = window.document.createDocumentFragment();
-            self.calendarContainer = createElement("div", "flatpickr-calendar");
-            self.calendarContainer.tabIndex = -1;
-            if (!self.config.noCalendar) {
-                fragment.appendChild(buildMonthNav());
-                self.innerContainer = createElement("div", "flatpickr-innerContainer");
-                if (self.config.weekNumbers) {
-                    var _a = buildWeeks(),
-                        weekWrapper = _a.weekWrapper,
-                        weekNumbers = _a.weekNumbers;
-                    self.innerContainer.appendChild(weekWrapper);
-                    self.weekNumbers = weekNumbers;
-                    self.weekWrapper = weekWrapper;
-                }
-                self.rContainer = createElement("div", "flatpickr-rContainer");
-                self.rContainer.appendChild(buildWeekdays());
-                if (!self.daysContainer) {
-                    self.daysContainer = createElement("div", "flatpickr-days");
-                    self.daysContainer.tabIndex = -1;
-                }
-                buildDays();
-                self.rContainer.appendChild(self.daysContainer);
-                self.innerContainer.appendChild(self.rContainer);
-                fragment.appendChild(self.innerContainer);
-            }
-            if (self.config.enableTime) {
-                fragment.appendChild(buildTime());
-            }
-            toggleClass(self.calendarContainer, "rangeMode", self.config.mode === "range");
-            toggleClass(self.calendarContainer, "animate", self.config.animate === true);
-            toggleClass(self.calendarContainer, "multiMonth", self.config.showMonths > 1);
-            self.calendarContainer.appendChild(fragment);
-            var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType !== undefined;
-            if (self.config.inline || self.config.static) {
-                self.calendarContainer.classList.add(self.config.inline ? "inline" : "static");
-                if (self.config.inline) {
-                    if (!customAppend && self.element.parentNode) self.element.parentNode.insertBefore(self.calendarContainer, self._input.nextSibling);else if (self.config.appendTo !== undefined) self.config.appendTo.appendChild(self.calendarContainer);
-                }
-                if (self.config.static) {
-                    var wrapper = createElement("div", "flatpickr-wrapper");
-                    if (self.element.parentNode) self.element.parentNode.insertBefore(wrapper, self.element);
-                    wrapper.appendChild(self.element);
-                    if (self.altInput) wrapper.appendChild(self.altInput);
-                    wrapper.appendChild(self.calendarContainer);
-                }
-            }
-            if (!self.config.static && !self.config.inline) (self.config.appendTo !== undefined ? self.config.appendTo : window.document.body).appendChild(self.calendarContainer);
-        }
-        function createDay(className, date, dayNumber, i) {
-            var dateIsEnabled = isEnabled(date, true),
-                dayElement = createElement("span", "flatpickr-day " + className, date.getDate().toString());
-            dayElement.dateObj = date;
-            dayElement.$i = i;
-            dayElement.setAttribute("aria-label", self.formatDate(date, self.config.ariaDateFormat));
-            if (className.indexOf("hidden") === -1 && compareDates(date, self.now) === 0) {
-                self.todayDateElem = dayElement;
-                dayElement.classList.add("today");
-                dayElement.setAttribute("aria-current", "date");
-            }
-            if (dateIsEnabled) {
-                dayElement.tabIndex = -1;
-                if (isDateSelected(date)) {
-                    dayElement.classList.add("selected");
-                    self.selectedDateElem = dayElement;
-                    if (self.config.mode === "range") {
-                        toggleClass(dayElement, "startRange", self.selectedDates[0] && compareDates(date, self.selectedDates[0], true) === 0);
-                        toggleClass(dayElement, "endRange", self.selectedDates[1] && compareDates(date, self.selectedDates[1], true) === 0);
-                        if (className === "nextMonthDay") dayElement.classList.add("inRange");
-                    }
-                }
-            } else {
-                dayElement.classList.add("flatpickr-disabled");
-            }
-            if (self.config.mode === "range") {
-                if (isDateInRange(date) && !isDateSelected(date)) dayElement.classList.add("inRange");
-            }
-            if (self.weekNumbers && self.config.showMonths === 1 && className !== "prevMonthDay" && dayNumber % 7 === 1) {
-                self.weekNumbers.insertAdjacentHTML("beforeend", "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>");
-            }
-            triggerEvent("onDayCreate", dayElement);
-            return dayElement;
-        }
-        function focusOnDayElem(targetNode) {
-            targetNode.focus();
-            if (self.config.mode === "range") onMouseOver(targetNode);
-        }
-        function getFirstAvailableDay(delta) {
-            var startMonth = delta > 0 ? 0 : self.config.showMonths - 1;
-            var endMonth = delta > 0 ? self.config.showMonths : -1;
-            for (var m = startMonth; m != endMonth; m += delta) {
-                var month = self.daysContainer.children[m];
-                var startIndex = delta > 0 ? 0 : month.children.length - 1;
-                var endIndex = delta > 0 ? month.children.length : -1;
-                for (var i = startIndex; i != endIndex; i += delta) {
-                    var c = month.children[i];
-                    if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj)) return c;
-                }
-            }
-            return undefined;
-        }
-        function getNextAvailableDay(current, delta) {
-            var givenMonth = current.className.indexOf("Month") === -1 ? current.dateObj.getMonth() : self.currentMonth;
-            var endMonth = delta > 0 ? self.config.showMonths : -1;
-            var loopDelta = delta > 0 ? 1 : -1;
-            for (var m = givenMonth - self.currentMonth; m != endMonth; m += loopDelta) {
-                var month = self.daysContainer.children[m];
-                var startIndex = givenMonth - self.currentMonth === m ? current.$i + delta : delta < 0 ? month.children.length - 1 : 0;
-                var numMonthDays = month.children.length;
-                for (var i = startIndex; i >= 0 && i < numMonthDays && i != (delta > 0 ? numMonthDays : -1); i += loopDelta) {
-                    var c = month.children[i];
-                    if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj) && Math.abs(current.$i - i) >= Math.abs(delta)) return focusOnDayElem(c);
-                }
-            }
-            self.changeMonth(loopDelta);
-            focusOnDay(getFirstAvailableDay(loopDelta), 0);
-            return undefined;
-        }
-        function focusOnDay(current, offset) {
-            var dayFocused = isInView(document.activeElement || document.body);
-            var startElem = current !== undefined ? current : dayFocused ? document.activeElement : self.selectedDateElem !== undefined && isInView(self.selectedDateElem) ? self.selectedDateElem : self.todayDateElem !== undefined && isInView(self.todayDateElem) ? self.todayDateElem : getFirstAvailableDay(offset > 0 ? 1 : -1);
-            if (startElem === undefined) return self._input.focus();
-            if (!dayFocused) return focusOnDayElem(startElem);
-            getNextAvailableDay(startElem, offset);
-        }
-        function buildMonthDays(year, month) {
-            var firstOfMonth = (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
-            var prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12);
-            var daysInMonth = self.utils.getDaysInMonth(month),
-                days = window.document.createDocumentFragment(),
-                isMultiMonth = self.config.showMonths > 1,
-                prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
-                nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
-            var dayNumber = prevMonthDays + 1 - firstOfMonth,
-                dayIndex = 0;
-            // prepend days from the ending of previous month
-            for (; dayNumber <= prevMonthDays; dayNumber++, dayIndex++) {
-                days.appendChild(createDay(prevMonthDayClass, new Date(year, month - 1, dayNumber), dayNumber, dayIndex));
-            }
-            // Start at 1 since there is no 0th day
-            for (dayNumber = 1; dayNumber <= daysInMonth; dayNumber++, dayIndex++) {
-                days.appendChild(createDay("", new Date(year, month, dayNumber), dayNumber, dayIndex));
-            }
-            // append days from the next month
-            for (var dayNum = daysInMonth + 1; dayNum <= 42 - firstOfMonth && (self.config.showMonths === 1 || dayIndex % 7 !== 0); dayNum++, dayIndex++) {
-                days.appendChild(createDay(nextMonthDayClass, new Date(year, month + 1, dayNum % daysInMonth), dayNum, dayIndex));
-            }
-            //updateNavigationCurrentMonth();
-            var dayContainer = createElement("div", "dayContainer");
-            dayContainer.appendChild(days);
-            return dayContainer;
-        }
-        function buildDays() {
-            if (self.daysContainer === undefined) {
-                return;
-            }
-            clearNode(self.daysContainer);
-            // TODO: week numbers for each month
-            if (self.weekNumbers) clearNode(self.weekNumbers);
-            var frag = document.createDocumentFragment();
-            for (var i = 0; i < self.config.showMonths; i++) {
-                var d = new Date(self.currentYear, self.currentMonth, 1);
-                d.setMonth(self.currentMonth + i);
-                frag.appendChild(buildMonthDays(d.getFullYear(), d.getMonth()));
-            }
-            self.daysContainer.appendChild(frag);
-            self.days = self.daysContainer.firstChild;
-            if (self.config.mode === "range" && self.selectedDates.length === 1) {
-                onMouseOver();
-            }
-        }
-        function buildMonthSwitch() {
-            if (self.config.showMonths > 1 || self.config.monthSelectorType !== "dropdown") return;
-            var shouldBuildMonth = function shouldBuildMonth(month) {
-                if (self.config.minDate !== undefined && self.currentYear === self.config.minDate.getFullYear() && month < self.config.minDate.getMonth()) {
-                    return false;
-                }
-                return !(self.config.maxDate !== undefined && self.currentYear === self.config.maxDate.getFullYear() && month > self.config.maxDate.getMonth());
-            };
-            self.monthsDropdownContainer.tabIndex = -1;
-            self.monthsDropdownContainer.innerHTML = "";
-            for (var i = 0; i < 12; i++) {
-                if (!shouldBuildMonth(i)) continue;
-                var month = createElement("option", "flatpickr-monthDropdown-month");
-                month.value = new Date(self.currentYear, i).getMonth().toString();
-                month.textContent = monthToStr(i, self.config.shorthandCurrentMonth, self.l10n);
-                month.tabIndex = -1;
-                if (self.currentMonth === i) {
-                    month.selected = true;
-                }
-                self.monthsDropdownContainer.appendChild(month);
-            }
-        }
-        function buildMonth() {
-            var container = createElement("div", "flatpickr-month");
-            var monthNavFragment = window.document.createDocumentFragment();
-            var monthElement;
-            if (self.config.showMonths > 1 || self.config.monthSelectorType === "static") {
-                monthElement = createElement("span", "cur-month");
-            } else {
-                self.monthsDropdownContainer = createElement("select", "flatpickr-monthDropdown-months");
-                bind(self.monthsDropdownContainer, "change", function (e) {
-                    var target = e.target;
-                    var selectedMonth = parseInt(target.value, 10);
-                    self.changeMonth(selectedMonth - self.currentMonth);
-                    triggerEvent("onMonthChange");
-                });
-                buildMonthSwitch();
-                monthElement = self.monthsDropdownContainer;
-            }
-            var yearInput = createNumberInput("cur-year", { tabindex: "-1" });
-            var yearElement = yearInput.getElementsByTagName("input")[0];
-            yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
-            if (self.config.minDate) {
-                yearElement.setAttribute("min", self.config.minDate.getFullYear().toString());
-            }
-            if (self.config.maxDate) {
-                yearElement.setAttribute("max", self.config.maxDate.getFullYear().toString());
-                yearElement.disabled = !!self.config.minDate && self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
-            }
-            var currentMonth = createElement("div", "flatpickr-current-month");
-            currentMonth.appendChild(monthElement);
-            currentMonth.appendChild(yearInput);
-            monthNavFragment.appendChild(currentMonth);
-            container.appendChild(monthNavFragment);
-            return {
-                container: container,
-                yearElement: yearElement,
-                monthElement: monthElement
-            };
-        }
-        function buildMonths() {
-            clearNode(self.monthNav);
-            self.monthNav.appendChild(self.prevMonthNav);
-            if (self.config.showMonths) {
-                self.yearElements = [];
-                self.monthElements = [];
-            }
-            for (var m = self.config.showMonths; m--;) {
-                var month = buildMonth();
-                self.yearElements.push(month.yearElement);
-                self.monthElements.push(month.monthElement);
-                self.monthNav.appendChild(month.container);
-            }
-            self.monthNav.appendChild(self.nextMonthNav);
-        }
-        function buildMonthNav() {
-            self.monthNav = createElement("div", "flatpickr-months");
-            self.yearElements = [];
-            self.monthElements = [];
-            self.prevMonthNav = createElement("span", "flatpickr-prev-month");
-            self.prevMonthNav.innerHTML = self.config.prevArrow;
-            self.nextMonthNav = createElement("span", "flatpickr-next-month");
-            self.nextMonthNav.innerHTML = self.config.nextArrow;
-            buildMonths();
-            Object.defineProperty(self, "_hidePrevMonthArrow", {
-                get: function get() {
-                    return self.__hidePrevMonthArrow;
-                },
-                set: function set(bool) {
-                    if (self.__hidePrevMonthArrow !== bool) {
-                        toggleClass(self.prevMonthNav, "flatpickr-disabled", bool);
-                        self.__hidePrevMonthArrow = bool;
-                    }
-                }
-            });
-            Object.defineProperty(self, "_hideNextMonthArrow", {
-                get: function get() {
-                    return self.__hideNextMonthArrow;
-                },
-                set: function set(bool) {
-                    if (self.__hideNextMonthArrow !== bool) {
-                        toggleClass(self.nextMonthNav, "flatpickr-disabled", bool);
-                        self.__hideNextMonthArrow = bool;
-                    }
-                }
-            });
-            self.currentYearElement = self.yearElements[0];
-            updateNavigationCurrentMonth();
-            return self.monthNav;
-        }
-        function buildTime() {
-            self.calendarContainer.classList.add("hasTime");
-            if (self.config.noCalendar) self.calendarContainer.classList.add("noCalendar");
-            self.timeContainer = createElement("div", "flatpickr-time");
-            self.timeContainer.tabIndex = -1;
-            var separator = createElement("span", "flatpickr-time-separator", ":");
-            var hourInput = createNumberInput("flatpickr-hour", {
-                "aria-label": self.l10n.hourAriaLabel
-            });
-            self.hourElement = hourInput.getElementsByTagName("input")[0];
-            var minuteInput = createNumberInput("flatpickr-minute", {
-                "aria-label": self.l10n.minuteAriaLabel
-            });
-            self.minuteElement = minuteInput.getElementsByTagName("input")[0];
-            self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
-            self.hourElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getHours() : self.config.time_24hr ? self.config.defaultHour : military2ampm(self.config.defaultHour));
-            self.minuteElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getMinutes() : self.config.defaultMinute);
-            self.hourElement.setAttribute("step", self.config.hourIncrement.toString());
-            self.minuteElement.setAttribute("step", self.config.minuteIncrement.toString());
-            self.hourElement.setAttribute("min", self.config.time_24hr ? "0" : "1");
-            self.hourElement.setAttribute("max", self.config.time_24hr ? "23" : "12");
-            self.minuteElement.setAttribute("min", "0");
-            self.minuteElement.setAttribute("max", "59");
-            self.timeContainer.appendChild(hourInput);
-            self.timeContainer.appendChild(separator);
-            self.timeContainer.appendChild(minuteInput);
-            if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
-            if (self.config.enableSeconds) {
-                self.timeContainer.classList.add("hasSeconds");
-                var secondInput = createNumberInput("flatpickr-second");
-                self.secondElement = secondInput.getElementsByTagName("input")[0];
-                self.secondElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getSeconds() : self.config.defaultSeconds);
-                self.secondElement.setAttribute("step", self.minuteElement.getAttribute("step"));
-                self.secondElement.setAttribute("min", "0");
-                self.secondElement.setAttribute("max", "59");
-                self.timeContainer.appendChild(createElement("span", "flatpickr-time-separator", ":"));
-                self.timeContainer.appendChild(secondInput);
-            }
-            if (!self.config.time_24hr) {
-                // add self.amPM if appropriate
-                self.amPM = createElement("span", "flatpickr-am-pm", self.l10n.amPM[int((self.latestSelectedDateObj ? self.hourElement.value : self.config.defaultHour) > 11)]);
-                self.amPM.title = self.l10n.toggleTitle;
-                self.amPM.tabIndex = -1;
-                self.timeContainer.appendChild(self.amPM);
-            }
-            return self.timeContainer;
-        }
-        function buildWeekdays() {
-            if (!self.weekdayContainer) self.weekdayContainer = createElement("div", "flatpickr-weekdays");else clearNode(self.weekdayContainer);
-            for (var i = self.config.showMonths; i--;) {
-                var container = createElement("div", "flatpickr-weekdaycontainer");
-                self.weekdayContainer.appendChild(container);
-            }
-            updateWeekdays();
-            return self.weekdayContainer;
-        }
-        function updateWeekdays() {
-            var firstDayOfWeek = self.l10n.firstDayOfWeek;
-            var weekdays = self.l10n.weekdays.shorthand.slice();
-            if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {
-                weekdays = weekdays.splice(firstDayOfWeek, weekdays.length).concat(weekdays.splice(0, firstDayOfWeek));
-            }
-            for (var i = self.config.showMonths; i--;) {
-                self.weekdayContainer.children[i].innerHTML = "\n      <span class='flatpickr-weekday'>\n        " + weekdays.join("</span><span class='flatpickr-weekday'>") + "\n      </span>\n      ";
-            }
-        }
-        /* istanbul ignore next */
-        function buildWeeks() {
-            self.calendarContainer.classList.add("hasWeeks");
-            var weekWrapper = createElement("div", "flatpickr-weekwrapper");
-            weekWrapper.appendChild(createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation));
-            var weekNumbers = createElement("div", "flatpickr-weeks");
-            weekWrapper.appendChild(weekNumbers);
-            return {
-                weekWrapper: weekWrapper,
-                weekNumbers: weekNumbers
-            };
-        }
-        function changeMonth(value, isOffset) {
-            if (isOffset === void 0) {
-                isOffset = true;
-            }
-            var delta = isOffset ? value : value - self.currentMonth;
-            if (delta < 0 && self._hidePrevMonthArrow === true || delta > 0 && self._hideNextMonthArrow === true) return;
-            self.currentMonth += delta;
-            if (self.currentMonth < 0 || self.currentMonth > 11) {
-                self.currentYear += self.currentMonth > 11 ? 1 : -1;
-                self.currentMonth = (self.currentMonth + 12) % 12;
-                triggerEvent("onYearChange");
-                buildMonthSwitch();
-            }
-            buildDays();
-            triggerEvent("onMonthChange");
-            updateNavigationCurrentMonth();
-        }
-        function clear(triggerChangeEvent, toInitial) {
-            if (triggerChangeEvent === void 0) {
-                triggerChangeEvent = true;
-            }
-            if (toInitial === void 0) {
-                toInitial = true;
-            }
-            self.input.value = "";
-            if (self.altInput !== undefined) self.altInput.value = "";
-            if (self.mobileInput !== undefined) self.mobileInput.value = "";
-            self.selectedDates = [];
-            self.latestSelectedDateObj = undefined;
-            if (toInitial === true) {
-                self.currentYear = self._initialDate.getFullYear();
-                self.currentMonth = self._initialDate.getMonth();
-            }
-            self.showTimeInput = false;
-            if (self.config.enableTime === true) {
-                setDefaultHours();
-            }
-            self.redraw();
-            if (triggerChangeEvent)
-                // triggerChangeEvent is true (default) or an Event
-                triggerEvent("onChange");
-        }
-        function close() {
-            self.isOpen = false;
-            if (!self.isMobile) {
-                if (self.calendarContainer !== undefined) {
-                    self.calendarContainer.classList.remove("open");
-                }
-                if (self._input !== undefined) {
-                    self._input.classList.remove("active");
-                }
-            }
-            triggerEvent("onClose");
-        }
-        function destroy() {
-            if (self.config !== undefined) triggerEvent("onDestroy");
-            for (var i = self._handlers.length; i--;) {
-                var h = self._handlers[i];
-                h.element.removeEventListener(h.event, h.handler, h.options);
-            }
-            self._handlers = [];
-            if (self.mobileInput) {
-                if (self.mobileInput.parentNode) self.mobileInput.parentNode.removeChild(self.mobileInput);
-                self.mobileInput = undefined;
-            } else if (self.calendarContainer && self.calendarContainer.parentNode) {
-                if (self.config.static && self.calendarContainer.parentNode) {
-                    var wrapper = self.calendarContainer.parentNode;
-                    wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
-                    if (wrapper.parentNode) {
-                        while (wrapper.firstChild) {
-                            wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
-                        }wrapper.parentNode.removeChild(wrapper);
-                    }
-                } else self.calendarContainer.parentNode.removeChild(self.calendarContainer);
-            }
-            if (self.altInput) {
-                self.input.type = "text";
-                if (self.altInput.parentNode) self.altInput.parentNode.removeChild(self.altInput);
-                delete self.altInput;
-            }
-            if (self.input) {
-                self.input.type = self.input._type;
-                self.input.classList.remove("flatpickr-input");
-                self.input.removeAttribute("readonly");
-                self.input.value = "";
-            }
-            ["_showTimeInput", "latestSelectedDateObj", "_hideNextMonthArrow", "_hidePrevMonthArrow", "__hideNextMonthArrow", "__hidePrevMonthArrow", "isMobile", "isOpen", "selectedDateElem", "minDateHasTime", "maxDateHasTime", "days", "daysContainer", "_input", "_positionElement", "innerContainer", "rContainer", "monthNav", "todayDateElem", "calendarContainer", "weekdayContainer", "prevMonthNav", "nextMonthNav", "monthsDropdownContainer", "currentMonthElement", "currentYearElement", "navigationCurrentMonth", "selectedDateElem", "config"].forEach(function (k) {
-                try {
-                    delete self[k];
-                } catch (_) {}
-            });
-        }
-        function isCalendarElem(elem) {
-            if (self.config.appendTo && self.config.appendTo.contains(elem)) return true;
-            return self.calendarContainer.contains(elem);
-        }
-        function documentClick(e) {
-            if (self.isOpen && !self.config.inline) {
-                var eventTarget_1 = getEventTarget(e);
-                var isCalendarElement = isCalendarElem(eventTarget_1);
-                var isInput = eventTarget_1 === self.input || eventTarget_1 === self.altInput || self.element.contains(eventTarget_1) ||
-                // web components
-                // e.path is not present in all browsers. circumventing typechecks
-                e.path && e.path.indexOf && (~e.path.indexOf(self.input) || ~e.path.indexOf(self.altInput));
-                var lostFocus = e.type === "blur" ? isInput && e.relatedTarget && !isCalendarElem(e.relatedTarget) : !isInput && !isCalendarElement && !isCalendarElem(e.relatedTarget);
-                var isIgnored = !self.config.ignoredFocusElements.some(function (elem) {
-                    return elem.contains(eventTarget_1);
-                });
-                if (lostFocus && isIgnored) {
-                    self.close();
-                    if (self.config.mode === "range" && self.selectedDates.length === 1) {
-                        self.clear(false);
-                        self.redraw();
-                    }
-                }
-            }
-        }
-        function changeYear(newYear) {
-            if (!newYear || self.config.minDate && newYear < self.config.minDate.getFullYear() || self.config.maxDate && newYear > self.config.maxDate.getFullYear()) return;
-            var newYearNum = newYear,
-                isNewYear = self.currentYear !== newYearNum;
-            self.currentYear = newYearNum || self.currentYear;
-            if (self.config.maxDate && self.currentYear === self.config.maxDate.getFullYear()) {
-                self.currentMonth = Math.min(self.config.maxDate.getMonth(), self.currentMonth);
-            } else if (self.config.minDate && self.currentYear === self.config.minDate.getFullYear()) {
-                self.currentMonth = Math.max(self.config.minDate.getMonth(), self.currentMonth);
-            }
-            if (isNewYear) {
-                self.redraw();
-                triggerEvent("onYearChange");
-                buildMonthSwitch();
-            }
-        }
-        function isEnabled(date, timeless) {
-            if (timeless === void 0) {
-                timeless = true;
-            }
-            var dateToCheck = self.parseDate(date, undefined, timeless); // timeless
-            if (self.config.minDate && dateToCheck && compareDates(dateToCheck, self.config.minDate, timeless !== undefined ? timeless : !self.minDateHasTime) < 0 || self.config.maxDate && dateToCheck && compareDates(dateToCheck, self.config.maxDate, timeless !== undefined ? timeless : !self.maxDateHasTime) > 0) return false;
-            if (self.config.enable.length === 0 && self.config.disable.length === 0) return true;
-            if (dateToCheck === undefined) return false;
-            var bool = self.config.enable.length > 0,
-                array = bool ? self.config.enable : self.config.disable;
-            for (var i = 0, d = void 0; i < array.length; i++) {
-                d = array[i];
-                if (typeof d === "function" && d(dateToCheck) // disabled by function
-                ) return bool;else if (d instanceof Date && dateToCheck !== undefined && d.getTime() === dateToCheck.getTime())
-                    // disabled by date
-                    return bool;else if (typeof d === "string" && dateToCheck !== undefined) {
-                    // disabled by date string
-                    var parsed = self.parseDate(d, undefined, true);
-                    return parsed && parsed.getTime() === dateToCheck.getTime() ? bool : !bool;
-                } else if (
-                // disabled by range
-                (typeof d === 'undefined' ? 'undefined' : _typeof(d)) === "object" && dateToCheck !== undefined && d.from && d.to && dateToCheck.getTime() >= d.from.getTime() && dateToCheck.getTime() <= d.to.getTime()) return bool;
-            }
-            return !bool;
-        }
-        function isInView(elem) {
-            if (self.daysContainer !== undefined) return elem.className.indexOf("hidden") === -1 && self.daysContainer.contains(elem);
-            return false;
-        }
-        function onKeyDown(e) {
-            // e.key                      e.keyCode
-            // "Backspace"                        8
-            // "Tab"                              9
-            // "Enter"                           13
-            // "Escape"     (IE "Esc")           27
-            // "ArrowLeft"  (IE "Left")          37
-            // "ArrowUp"    (IE "Up")            38
-            // "ArrowRight" (IE "Right")         39
-            // "ArrowDown"  (IE "Down")          40
-            // "Delete"     (IE "Del")           46
-            var isInput = e.target === self._input;
-            var allowInput = self.config.allowInput;
-            var allowKeydown = self.isOpen && (!allowInput || !isInput);
-            var allowInlineKeydown = self.config.inline && isInput && !allowInput;
-            if (e.keyCode === 13 && isInput) {
-                if (allowInput) {
-                    self.setDate(self._input.value, true, e.target === self.altInput ? self.config.altFormat : self.config.dateFormat);
-                    return e.target.blur();
-                } else {
-                    self.open();
-                }
-            } else if (isCalendarElem(e.target) || allowKeydown || allowInlineKeydown) {
-                var isTimeObj = !!self.timeContainer && self.timeContainer.contains(e.target);
-                switch (e.keyCode) {
-                    case 13:
-                        if (isTimeObj) {
-                            e.preventDefault();
-                            updateTime();
-                            focusAndClose();
-                        } else selectDate(e);
-                        break;
-                    case 27:
-                        // escape
-                        e.preventDefault();
-                        focusAndClose();
-                        break;
-                    case 8:
-                    case 46:
-                        if (isInput && !self.config.allowInput) {
-                            e.preventDefault();
-                            self.clear();
-                        }
-                        break;
-                    case 37:
-                    case 39:
-                        if (!isTimeObj && !isInput) {
-                            e.preventDefault();
-                            if (self.daysContainer !== undefined && (allowInput === false || document.activeElement && isInView(document.activeElement))) {
-                                var delta_1 = e.keyCode === 39 ? 1 : -1;
-                                if (!e.ctrlKey) focusOnDay(undefined, delta_1);else {
-                                    e.stopPropagation();
-                                    changeMonth(delta_1);
-                                    focusOnDay(getFirstAvailableDay(1), 0);
-                                }
-                            }
-                        } else if (self.hourElement) self.hourElement.focus();
-                        break;
-                    case 38:
-                    case 40:
-                        e.preventDefault();
-                        var delta = e.keyCode === 40 ? 1 : -1;
-                        if (self.daysContainer && e.target.$i !== undefined || e.target === self.input) {
-                            if (e.ctrlKey) {
-                                e.stopPropagation();
-                                changeYear(self.currentYear - delta);
-                                focusOnDay(getFirstAvailableDay(1), 0);
-                            } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
-                        } else if (e.target === self.currentYearElement) {
-                            changeYear(self.currentYear - delta);
-                        } else if (self.config.enableTime) {
-                            if (!isTimeObj && self.hourElement) self.hourElement.focus();
-                            updateTime(e);
-                            self._debouncedChange();
-                        }
-                        break;
-                    case 9:
-                        if (isTimeObj) {
-                            var elems = [self.hourElement, self.minuteElement, self.secondElement, self.amPM].concat(self.pluginElements).filter(function (x) {
-                                return x;
-                            });
-                            var i = elems.indexOf(e.target);
-                            if (i !== -1) {
-                                var target = elems[i + (e.shiftKey ? -1 : 1)];
-                                e.preventDefault();
-                                (target || self._input).focus();
-                            }
-                        } else if (!self.config.noCalendar && self.daysContainer && self.daysContainer.contains(e.target) && e.shiftKey) {
-                            e.preventDefault();
-                            self._input.focus();
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            if (self.amPM !== undefined && e.target === self.amPM) {
-                switch (e.key) {
-                    case self.l10n.amPM[0].charAt(0):
-                    case self.l10n.amPM[0].charAt(0).toLowerCase():
-                        self.amPM.textContent = self.l10n.amPM[0];
-                        setHoursFromInputs();
-                        updateValue();
-                        break;
-                    case self.l10n.amPM[1].charAt(0):
-                    case self.l10n.amPM[1].charAt(0).toLowerCase():
-                        self.amPM.textContent = self.l10n.amPM[1];
-                        setHoursFromInputs();
-                        updateValue();
-                        break;
-                }
-            }
-            if (isInput || isCalendarElem(e.target)) {
-                triggerEvent("onKeyDown", e);
-            }
-        }
-        function onMouseOver(elem) {
-            if (self.selectedDates.length !== 1 || elem && (!elem.classList.contains("flatpickr-day") || elem.classList.contains("flatpickr-disabled"))) return;
-            var hoverDate = elem ? elem.dateObj.getTime() : self.days.firstElementChild.dateObj.getTime(),
-                initialDate = self.parseDate(self.selectedDates[0], undefined, true).getTime(),
-                rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
-                rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime());
-            var containsDisabled = false;
-            var minRange = 0,
-                maxRange = 0;
-            for (var t = rangeStartDate; t < rangeEndDate; t += duration.DAY) {
-                if (!isEnabled(new Date(t), true)) {
-                    containsDisabled = containsDisabled || t > rangeStartDate && t < rangeEndDate;
-                    if (t < initialDate && (!minRange || t > minRange)) minRange = t;else if (t > initialDate && (!maxRange || t < maxRange)) maxRange = t;
-                }
-            }
-            for (var m = 0; m < self.config.showMonths; m++) {
-                var month = self.daysContainer.children[m];
-                var _loop_1 = function _loop_1(i, l) {
-                    var dayElem = month.children[i],
-                        date = dayElem.dateObj;
-                    var timestamp = date.getTime();
-                    var outOfRange = minRange > 0 && timestamp < minRange || maxRange > 0 && timestamp > maxRange;
-                    if (outOfRange) {
-                        dayElem.classList.add("notAllowed");
-                        ["inRange", "startRange", "endRange"].forEach(function (c) {
-                            dayElem.classList.remove(c);
-                        });
-                        return "continue";
-                    } else if (containsDisabled && !outOfRange) return "continue";
-                    ["startRange", "inRange", "endRange", "notAllowed"].forEach(function (c) {
-                        dayElem.classList.remove(c);
-                    });
-                    if (elem !== undefined) {
-                        elem.classList.add(hoverDate <= self.selectedDates[0].getTime() ? "startRange" : "endRange");
-                        if (initialDate < hoverDate && timestamp === initialDate) dayElem.classList.add("startRange");else if (initialDate > hoverDate && timestamp === initialDate) dayElem.classList.add("endRange");
-                        if (timestamp >= minRange && (maxRange === 0 || timestamp <= maxRange) && isBetween(timestamp, initialDate, hoverDate)) dayElem.classList.add("inRange");
-                    }
-                };
-                for (var i = 0, l = month.children.length; i < l; i++) {
-                    _loop_1(i, l);
-                }
-            }
-        }
-        function onResize() {
-            if (self.isOpen && !self.config.static && !self.config.inline) positionCalendar();
-        }
-        function setDefaultTime() {
-            self.setDate(self.config.minDate !== undefined ? new Date(self.config.minDate.getTime()) : new Date(), true);
-            setDefaultHours();
-            updateValue();
-        }
-        function open(e, positionElement) {
-            if (positionElement === void 0) {
-                positionElement = self._positionElement;
-            }
-            if (self.isMobile === true) {
-                if (e) {
-                    e.preventDefault();
-                    e.target && e.target.blur();
-                }
-                if (self.mobileInput !== undefined) {
-                    self.mobileInput.focus();
-                    self.mobileInput.click();
-                }
-                triggerEvent("onOpen");
-                return;
-            }
-            if (self._input.disabled || self.config.inline) return;
-            var wasOpen = self.isOpen;
-            self.isOpen = true;
-            if (!wasOpen) {
-                self.calendarContainer.classList.add("open");
-                self._input.classList.add("active");
-                triggerEvent("onOpen");
-                positionCalendar(positionElement);
-            }
-            if (self.config.enableTime === true && self.config.noCalendar === true) {
-                if (self.selectedDates.length === 0) {
-                    setDefaultTime();
-                }
-                if (self.config.allowInput === false && (e === undefined || !self.timeContainer.contains(e.relatedTarget))) {
-                    setTimeout(function () {
-                        return self.hourElement.select();
-                    }, 50);
-                }
-            }
-        }
-        function minMaxDateSetter(type) {
-            return function (date) {
-                var dateObj = self.config["_" + type + "Date"] = self.parseDate(date, self.config.dateFormat);
-                var inverseDateObj = self.config["_" + (type === "min" ? "max" : "min") + "Date"];
-                if (dateObj !== undefined) {
-                    self[type === "min" ? "minDateHasTime" : "maxDateHasTime"] = dateObj.getHours() > 0 || dateObj.getMinutes() > 0 || dateObj.getSeconds() > 0;
-                }
-                if (self.selectedDates) {
-                    self.selectedDates = self.selectedDates.filter(function (d) {
-                        return isEnabled(d);
-                    });
-                    if (!self.selectedDates.length && type === "min") setHoursFromDate(dateObj);
-                    updateValue();
-                }
-                if (self.daysContainer) {
-                    redraw();
-                    if (dateObj !== undefined) self.currentYearElement[type] = dateObj.getFullYear().toString();else self.currentYearElement.removeAttribute(type);
-                    self.currentYearElement.disabled = !!inverseDateObj && dateObj !== undefined && inverseDateObj.getFullYear() === dateObj.getFullYear();
-                }
-            };
-        }
-        function parseConfig() {
-            var boolOpts = ["wrap", "weekNumbers", "allowInput", "clickOpens", "time_24hr", "enableTime", "noCalendar", "altInput", "shorthandCurrentMonth", "inline", "static", "enableSeconds", "disableMobile"];
-            var userConfig = _assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
-            var formats = {};
-            self.config.parseDate = userConfig.parseDate;
-            self.config.formatDate = userConfig.formatDate;
-            Object.defineProperty(self.config, "enable", {
-                get: function get() {
-                    return self.config._enable;
-                },
-                set: function set(dates) {
-                    self.config._enable = parseDateRules(dates);
-                }
-            });
-            Object.defineProperty(self.config, "disable", {
-                get: function get() {
-                    return self.config._disable;
-                },
-                set: function set(dates) {
-                    self.config._disable = parseDateRules(dates);
-                }
-            });
-            var timeMode = userConfig.mode === "time";
-            if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
-                var defaultDateFormat = flatpickr.defaultConfig.dateFormat || defaults.dateFormat;
-                formats.dateFormat = userConfig.noCalendar || timeMode ? "H:i" + (userConfig.enableSeconds ? ":S" : "") : defaultDateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
-            }
-            if (userConfig.altInput && (userConfig.enableTime || timeMode) && !userConfig.altFormat) {
-                var defaultAltFormat = flatpickr.defaultConfig.altFormat || defaults.altFormat;
-                formats.altFormat = userConfig.noCalendar || timeMode ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K") : defaultAltFormat + (" h:i" + (userConfig.enableSeconds ? ":S" : "") + " K");
-            }
-            if (!userConfig.altInputClass) {
-                self.config.altInputClass = self.input.className + " " + self.config.altInputClass;
-            }
-            Object.defineProperty(self.config, "minDate", {
-                get: function get() {
-                    return self.config._minDate;
-                },
-                set: minMaxDateSetter("min")
-            });
-            Object.defineProperty(self.config, "maxDate", {
-                get: function get() {
-                    return self.config._maxDate;
-                },
-                set: minMaxDateSetter("max")
-            });
-            var minMaxTimeSetter = function minMaxTimeSetter(type) {
-                return function (val) {
-                    self.config[type === "min" ? "_minTime" : "_maxTime"] = self.parseDate(val, "H:i");
-                };
-            };
-            Object.defineProperty(self.config, "minTime", {
-                get: function get() {
-                    return self.config._minTime;
-                },
-                set: minMaxTimeSetter("min")
-            });
-            Object.defineProperty(self.config, "maxTime", {
-                get: function get() {
-                    return self.config._maxTime;
-                },
-                set: minMaxTimeSetter("max")
-            });
-            if (userConfig.mode === "time") {
-                self.config.noCalendar = true;
-                self.config.enableTime = true;
-            }
-            Object.assign(self.config, formats, userConfig);
-            for (var i = 0; i < boolOpts.length; i++) {
-                self.config[boolOpts[i]] = self.config[boolOpts[i]] === true || self.config[boolOpts[i]] === "true";
-            }HOOKS.filter(function (hook) {
-                return self.config[hook] !== undefined;
-            }).forEach(function (hook) {
-                self.config[hook] = arrayify(self.config[hook] || []).map(bindToInstance);
-            });
-            self.isMobile = !self.config.disableMobile && !self.config.inline && self.config.mode === "single" && !self.config.disable.length && !self.config.enable.length && !self.config.weekNumbers && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-            for (var i = 0; i < self.config.plugins.length; i++) {
-                var pluginConf = self.config.plugins[i](self) || {};
-                for (var key in pluginConf) {
-                    if (HOOKS.indexOf(key) > -1) {
-                        self.config[key] = arrayify(pluginConf[key]).map(bindToInstance).concat(self.config[key]);
-                    } else if (typeof userConfig[key] === "undefined") self.config[key] = pluginConf[key];
-                }
-            }
-            triggerEvent("onParseConfig");
-        }
-        function setupLocale() {
-            if (_typeof(self.config.locale) !== "object" && typeof flatpickr.l10ns[self.config.locale] === "undefined") self.config.errorHandler(new Error("flatpickr: invalid locale " + self.config.locale));
-            self.l10n = _assign({}, flatpickr.l10ns["default"], _typeof(self.config.locale) === "object" ? self.config.locale : self.config.locale !== "default" ? flatpickr.l10ns[self.config.locale] : undefined);
-            tokenRegex.K = "(" + self.l10n.amPM[0] + "|" + self.l10n.amPM[1] + "|" + self.l10n.amPM[0].toLowerCase() + "|" + self.l10n.amPM[1].toLowerCase() + ")";
-            var userConfig = _assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
-            if (userConfig.time_24hr === undefined && flatpickr.defaultConfig.time_24hr === undefined) {
-                self.config.time_24hr = self.l10n.time_24hr;
-            }
-            self.formatDate = createDateFormatter(self);
-            self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
-        }
-        function positionCalendar(customPositionElement) {
-            if (self.calendarContainer === undefined) return;
-            triggerEvent("onPreCalendarPosition");
-            var positionElement = customPositionElement || self._positionElement;
-            var calendarHeight = Array.prototype.reduce.call(self.calendarContainer.children, function (acc, child) {
-                return acc + child.offsetHeight;
-            }, 0),
-                calendarWidth = self.calendarContainer.offsetWidth,
-                configPos = self.config.position.split(" "),
-                configPosVertical = configPos[0],
-                configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
-                inputBounds = positionElement.getBoundingClientRect(),
-                distanceFromBottom = window.innerHeight - inputBounds.bottom,
-                showOnTop = configPosVertical === "above" || configPosVertical !== "below" && distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
-            var top = window.pageYOffset + inputBounds.top + (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
-            toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
-            toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
-            if (self.config.inline) return;
-            var left = window.pageXOffset + inputBounds.left - (configPosHorizontal != null && configPosHorizontal === "center" ? (calendarWidth - inputBounds.width) / 2 : 0);
-            var right = window.document.body.offsetWidth - inputBounds.right;
-            var rightMost = left + calendarWidth > window.document.body.offsetWidth;
-            var centerMost = right + calendarWidth > window.document.body.offsetWidth;
-            toggleClass(self.calendarContainer, "rightMost", rightMost);
-            if (self.config.static) return;
-            self.calendarContainer.style.top = top + "px";
-            if (!rightMost) {
-                self.calendarContainer.style.left = left + "px";
-                self.calendarContainer.style.right = "auto";
-            } else if (!centerMost) {
-                self.calendarContainer.style.left = "auto";
-                self.calendarContainer.style.right = right + "px";
-            } else {
-                var doc = document.styleSheets[0];
-                // some testing environments don't have css support
-                if (doc === undefined) return;
-                var bodyWidth = window.document.body.offsetWidth;
-                var centerLeft = Math.max(0, bodyWidth / 2 - calendarWidth / 2);
-                var centerBefore = ".flatpickr-calendar.centerMost:before";
-                var centerAfter = ".flatpickr-calendar.centerMost:after";
-                var centerIndex = doc.cssRules.length;
-                var centerStyle = "{left:" + inputBounds.left + "px;right:auto;}";
-                toggleClass(self.calendarContainer, "rightMost", false);
-                toggleClass(self.calendarContainer, "centerMost", true);
-                doc.insertRule(centerBefore + "," + centerAfter + centerStyle, centerIndex);
-                self.calendarContainer.style.left = centerLeft + "px";
-                self.calendarContainer.style.right = "auto";
-            }
-        }
-        function redraw() {
-            if (self.config.noCalendar || self.isMobile) return;
-            updateNavigationCurrentMonth();
-            buildDays();
-        }
-        function focusAndClose() {
-            self._input.focus();
-            if (window.navigator.userAgent.indexOf("MSIE") !== -1 || navigator.msMaxTouchPoints !== undefined) {
-                // hack - bugs in the way IE handles focus keeps the calendar open
-                setTimeout(self.close, 0);
-            } else {
-                self.close();
-            }
-        }
-        function selectDate(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            var isSelectable = function isSelectable(day) {
-                return day.classList && day.classList.contains("flatpickr-day") && !day.classList.contains("flatpickr-disabled") && !day.classList.contains("notAllowed");
-            };
-            var t = findParent(e.target, isSelectable);
-            if (t === undefined) return;
-            var target = t;
-            var selectedDate = self.latestSelectedDateObj = new Date(target.dateObj.getTime());
-            var shouldChangeMonth = (selectedDate.getMonth() < self.currentMonth || selectedDate.getMonth() > self.currentMonth + self.config.showMonths - 1) && self.config.mode !== "range";
-            self.selectedDateElem = target;
-            if (self.config.mode === "single") self.selectedDates = [selectedDate];else if (self.config.mode === "multiple") {
-                var selectedIndex = isDateSelected(selectedDate);
-                if (selectedIndex) self.selectedDates.splice(parseInt(selectedIndex), 1);else self.selectedDates.push(selectedDate);
-            } else if (self.config.mode === "range") {
-                if (self.selectedDates.length === 2) {
-                    self.clear(false, false);
-                }
-                self.latestSelectedDateObj = selectedDate;
-                self.selectedDates.push(selectedDate);
-                // unless selecting same date twice, sort ascendingly
-                if (compareDates(selectedDate, self.selectedDates[0], true) !== 0) self.selectedDates.sort(function (a, b) {
-                    return a.getTime() - b.getTime();
-                });
-            }
-            setHoursFromInputs();
-            if (shouldChangeMonth) {
-                var isNewYear = self.currentYear !== selectedDate.getFullYear();
-                self.currentYear = selectedDate.getFullYear();
-                self.currentMonth = selectedDate.getMonth();
-                if (isNewYear) {
-                    triggerEvent("onYearChange");
-                    buildMonthSwitch();
-                }
-                triggerEvent("onMonthChange");
-            }
-            updateNavigationCurrentMonth();
-            buildDays();
-            updateValue();
-            if (self.config.enableTime) setTimeout(function () {
-                return self.showTimeInput = true;
-            }, 50);
-            // maintain focus
-            if (!shouldChangeMonth && self.config.mode !== "range" && self.config.showMonths === 1) focusOnDayElem(target);else if (self.selectedDateElem !== undefined && self.hourElement === undefined) {
-                self.selectedDateElem && self.selectedDateElem.focus();
-            }
-            if (self.hourElement !== undefined) self.hourElement !== undefined && self.hourElement.focus();
-            if (self.config.closeOnSelect) {
-                var single = self.config.mode === "single" && !self.config.enableTime;
-                var range = self.config.mode === "range" && self.selectedDates.length === 2 && !self.config.enableTime;
-                if (single || range) {
-                    focusAndClose();
-                }
-            }
-            triggerChange();
-        }
-        var CALLBACKS = {
-            locale: [setupLocale, updateWeekdays],
-            showMonths: [buildMonths, setCalendarWidth, buildWeekdays],
-            minDate: [jumpToDate],
-            maxDate: [jumpToDate]
-        };
-        function set(option, value) {
-            if (option !== null && (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === "object") {
-                Object.assign(self.config, option);
-                for (var key in option) {
-                    if (CALLBACKS[key] !== undefined) CALLBACKS[key].forEach(function (x) {
-                        return x();
-                    });
-                }
-            } else {
-                self.config[option] = value;
-                if (CALLBACKS[option] !== undefined) CALLBACKS[option].forEach(function (x) {
-                    return x();
-                });else if (HOOKS.indexOf(option) > -1) self.config[option] = arrayify(value);
-            }
-            self.redraw();
-            updateValue(false);
-        }
-        function setSelectedDate(inputDate, format) {
-            var dates = [];
-            if (inputDate instanceof Array) dates = inputDate.map(function (d) {
-                return self.parseDate(d, format);
-            });else if (inputDate instanceof Date || typeof inputDate === "number") dates = [self.parseDate(inputDate, format)];else if (typeof inputDate === "string") {
-                switch (self.config.mode) {
-                    case "single":
-                    case "time":
-                        dates = [self.parseDate(inputDate, format)];
-                        break;
-                    case "multiple":
-                        dates = inputDate.split(self.config.conjunction).map(function (date) {
-                            return self.parseDate(date, format);
-                        });
-                        break;
-                    case "range":
-                        dates = inputDate.split(self.l10n.rangeSeparator).map(function (date) {
-                            return self.parseDate(date, format);
-                        });
-                        break;
-                    default:
-                        break;
-                }
-            } else self.config.errorHandler(new Error("Invalid date supplied: " + JSON.stringify(inputDate)));
-            self.selectedDates = dates.filter(function (d) {
-                return d instanceof Date && isEnabled(d, false);
-            });
-            if (self.config.mode === "range") self.selectedDates.sort(function (a, b) {
-                return a.getTime() - b.getTime();
-            });
-        }
-        function setDate(date, triggerChange, format) {
-            if (triggerChange === void 0) {
-                triggerChange = false;
-            }
-            if (format === void 0) {
-                format = self.config.dateFormat;
-            }
-            if (date !== 0 && !date || date instanceof Array && date.length === 0) return self.clear(triggerChange);
-            setSelectedDate(date, format);
-            self.showTimeInput = self.selectedDates.length > 0;
-            self.latestSelectedDateObj = self.selectedDates[self.selectedDates.length - 1];
-            self.redraw();
-            jumpToDate();
-            setHoursFromDate();
-            if (self.selectedDates.length === 0) {
-                self.clear(false);
-            }
-            updateValue(triggerChange);
-            if (triggerChange) triggerEvent("onChange");
-        }
-        function parseDateRules(arr) {
-            return arr.slice().map(function (rule) {
-                if (typeof rule === "string" || typeof rule === "number" || rule instanceof Date) {
-                    return self.parseDate(rule, undefined, true);
-                } else if (rule && (typeof rule === 'undefined' ? 'undefined' : _typeof(rule)) === "object" && rule.from && rule.to) return {
-                    from: self.parseDate(rule.from, undefined),
-                    to: self.parseDate(rule.to, undefined)
-                };
-                return rule;
-            }).filter(function (x) {
-                return x;
-            }); // remove falsy values
-        }
-        function setupDates() {
-            self.selectedDates = [];
-            self.now = self.parseDate(self.config.now) || new Date();
-            // Workaround IE11 setting placeholder as the input's value
-            var preloadedDate = self.config.defaultDate || ((self.input.nodeName === "INPUT" || self.input.nodeName === "TEXTAREA") && self.input.placeholder && self.input.value === self.input.placeholder ? null : self.input.value);
-            if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
-            self._initialDate = self.selectedDates.length > 0 ? self.selectedDates[0] : self.config.minDate && self.config.minDate.getTime() > self.now.getTime() ? self.config.minDate : self.config.maxDate && self.config.maxDate.getTime() < self.now.getTime() ? self.config.maxDate : self.now;
-            self.currentYear = self._initialDate.getFullYear();
-            self.currentMonth = self._initialDate.getMonth();
-            if (self.selectedDates.length > 0) self.latestSelectedDateObj = self.selectedDates[0];
-            if (self.config.minTime !== undefined) self.config.minTime = self.parseDate(self.config.minTime, "H:i");
-            if (self.config.maxTime !== undefined) self.config.maxTime = self.parseDate(self.config.maxTime, "H:i");
-            self.minDateHasTime = !!self.config.minDate && (self.config.minDate.getHours() > 0 || self.config.minDate.getMinutes() > 0 || self.config.minDate.getSeconds() > 0);
-            self.maxDateHasTime = !!self.config.maxDate && (self.config.maxDate.getHours() > 0 || self.config.maxDate.getMinutes() > 0 || self.config.maxDate.getSeconds() > 0);
-            Object.defineProperty(self, "showTimeInput", {
-                get: function get() {
-                    return self._showTimeInput;
-                },
-                set: function set(bool) {
-                    self._showTimeInput = bool;
-                    if (self.calendarContainer) toggleClass(self.calendarContainer, "showTimeInput", bool);
-                    self.isOpen && positionCalendar();
-                }
-            });
-        }
-        function setupInputs() {
-            self.input = self.config.wrap ? element.querySelector("[data-input]") : element;
-            /* istanbul ignore next */
-            if (!self.input) {
-                self.config.errorHandler(new Error("Invalid input element specified"));
-                return;
-            }
-            // hack: store previous type to restore it after destroy()
-            self.input._type = self.input.type;
-            self.input.type = "text";
-            self.input.classList.add("flatpickr-input");
-            self._input = self.input;
-            if (self.config.altInput) {
-                // replicate self.element
-                self.altInput = createElement(self.input.nodeName, self.config.altInputClass);
-                self._input = self.altInput;
-                self.altInput.placeholder = self.input.placeholder;
-                self.altInput.disabled = self.input.disabled;
-                self.altInput.required = self.input.required;
-                self.altInput.tabIndex = self.input.tabIndex;
-                self.altInput.type = "text";
-                self.input.setAttribute("type", "hidden");
-                if (!self.config.static && self.input.parentNode) self.input.parentNode.insertBefore(self.altInput, self.input.nextSibling);
-            }
-            if (!self.config.allowInput) self._input.setAttribute("readonly", "readonly");
-            self._positionElement = self.config.positionElement || self._input;
-        }
-        function setupMobile() {
-            var inputType = self.config.enableTime ? self.config.noCalendar ? "time" : "datetime-local" : "date";
-            self.mobileInput = createElement("input", self.input.className + " flatpickr-mobile");
-            self.mobileInput.step = self.input.getAttribute("step") || "any";
-            self.mobileInput.tabIndex = 1;
-            self.mobileInput.type = inputType;
-            self.mobileInput.disabled = self.input.disabled;
-            self.mobileInput.required = self.input.required;
-            self.mobileInput.placeholder = self.input.placeholder;
-            self.mobileFormatStr = inputType === "datetime-local" ? "Y-m-d\\TH:i:S" : inputType === "date" ? "Y-m-d" : "H:i:S";
-            if (self.selectedDates.length > 0) {
-                self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(self.selectedDates[0], self.mobileFormatStr);
-            }
-            if (self.config.minDate) self.mobileInput.min = self.formatDate(self.config.minDate, "Y-m-d");
-            if (self.config.maxDate) self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
-            self.input.type = "hidden";
-            if (self.altInput !== undefined) self.altInput.type = "hidden";
-            try {
-                if (self.input.parentNode) self.input.parentNode.insertBefore(self.mobileInput, self.input.nextSibling);
-            } catch (_a) {}
-            bind(self.mobileInput, "change", function (e) {
-                self.setDate(e.target.value, false, self.mobileFormatStr);
-                triggerEvent("onChange");
-                triggerEvent("onClose");
-            });
-        }
-        function toggle(e) {
-            if (self.isOpen === true) return self.close();
-            self.open(e);
-        }
-        function triggerEvent(event, data) {
-            // If the instance has been destroyed already, all hooks have been removed
-            if (self.config === undefined) return;
-            var hooks = self.config[event];
-            if (hooks !== undefined && hooks.length > 0) {
-                for (var i = 0; hooks[i] && i < hooks.length; i++) {
-                    hooks[i](self.selectedDates, self.input.value, self, data);
-                }
-            }
-            if (event === "onChange") {
-                self.input.dispatchEvent(createEvent("change"));
-                // many front-end frameworks bind to the input event
-                self.input.dispatchEvent(createEvent("input"));
-            }
-        }
-        function createEvent(name) {
-            var e = document.createEvent("Event");
-            e.initEvent(name, true, true);
-            return e;
-        }
-        function isDateSelected(date) {
-            for (var i = 0; i < self.selectedDates.length; i++) {
-                if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
-            }
-            return false;
-        }
-        function isDateInRange(date) {
-            if (self.config.mode !== "range" || self.selectedDates.length < 2) return false;
-            return compareDates(date, self.selectedDates[0]) >= 0 && compareDates(date, self.selectedDates[1]) <= 0;
-        }
-        function updateNavigationCurrentMonth() {
-            if (self.config.noCalendar || self.isMobile || !self.monthNav) return;
-            self.yearElements.forEach(function (yearElement, i) {
-                var d = new Date(self.currentYear, self.currentMonth, 1);
-                d.setMonth(self.currentMonth + i);
-                if (self.config.showMonths > 1 || self.config.monthSelectorType === "static") {
-                    self.monthElements[i].textContent = monthToStr(d.getMonth(), self.config.shorthandCurrentMonth, self.l10n) + " ";
-                } else {
-                    self.monthsDropdownContainer.value = d.getMonth().toString();
-                }
-                yearElement.value = d.getFullYear().toString();
-            });
-            self._hidePrevMonthArrow = self.config.minDate !== undefined && (self.currentYear === self.config.minDate.getFullYear() ? self.currentMonth <= self.config.minDate.getMonth() : self.currentYear < self.config.minDate.getFullYear());
-            self._hideNextMonthArrow = self.config.maxDate !== undefined && (self.currentYear === self.config.maxDate.getFullYear() ? self.currentMonth + 1 > self.config.maxDate.getMonth() : self.currentYear > self.config.maxDate.getFullYear());
-        }
-        function getDateStr(format) {
-            return self.selectedDates.map(function (dObj) {
-                return self.formatDate(dObj, format);
-            }).filter(function (d, i, arr) {
-                return self.config.mode !== "range" || self.config.enableTime || arr.indexOf(d) === i;
-            }).join(self.config.mode !== "range" ? self.config.conjunction : self.l10n.rangeSeparator);
-        }
-        /**
-         * Updates the values of inputs associated with the calendar
-         */
-        function updateValue(triggerChange) {
-            if (triggerChange === void 0) {
-                triggerChange = true;
-            }
-            if (self.mobileInput !== undefined && self.mobileFormatStr) {
-                self.mobileInput.value = self.latestSelectedDateObj !== undefined ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr) : "";
-            }
-            self.input.value = getDateStr(self.config.dateFormat);
-            if (self.altInput !== undefined) {
-                self.altInput.value = getDateStr(self.config.altFormat);
-            }
-            if (triggerChange !== false) triggerEvent("onValueUpdate");
-        }
-        function onMonthNavClick(e) {
-            var isPrevMonth = self.prevMonthNav.contains(e.target);
-            var isNextMonth = self.nextMonthNav.contains(e.target);
-            if (isPrevMonth || isNextMonth) {
-                changeMonth(isPrevMonth ? -1 : 1);
-            } else if (self.yearElements.indexOf(e.target) >= 0) {
-                e.target.select();
-            } else if (e.target.classList.contains("arrowUp")) {
-                self.changeYear(self.currentYear + 1);
-            } else if (e.target.classList.contains("arrowDown")) {
-                self.changeYear(self.currentYear - 1);
-            }
-        }
-        function timeWrapper(e) {
-            e.preventDefault();
-            var isKeyDown = e.type === "keydown",
-                input = e.target;
-            if (self.amPM !== undefined && e.target === self.amPM) {
-                self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
-            }
-            var min = parseFloat(input.getAttribute("min")),
-                max = parseFloat(input.getAttribute("max")),
-                step = parseFloat(input.getAttribute("step")),
-                curValue = parseInt(input.value, 10),
-                delta = e.delta || (isKeyDown ? e.which === 38 ? 1 : -1 : 0);
-            var newValue = curValue + step * delta;
-            if (typeof input.value !== "undefined" && input.value.length === 2) {
-                var isHourElem = input === self.hourElement,
-                    isMinuteElem = input === self.minuteElement;
-                if (newValue < min) {
-                    newValue = max + newValue + int(!isHourElem) + (int(isHourElem) && int(!self.amPM));
-                    if (isMinuteElem) incrementNumInput(undefined, -1, self.hourElement);
-                } else if (newValue > max) {
-                    newValue = input === self.hourElement ? newValue - max - int(!self.amPM) : min;
-                    if (isMinuteElem) incrementNumInput(undefined, 1, self.hourElement);
-                }
-                if (self.amPM && isHourElem && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) {
-                    self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
-                }
-                input.value = pad(newValue);
-            }
-        }
-        init();
-        return self;
+    if (timeless !== false) {
+      return new Date(date1.getTime()).setHours(0, 0, 0, 0) - new Date(date2.getTime()).setHours(0, 0, 0, 0);
     }
-    /* istanbul ignore next */
-    function _flatpickr(nodeList, config) {
-        // static list
-        var nodes = Array.prototype.slice.call(nodeList).filter(function (x) {
-            return x instanceof HTMLElement;
+
+    return date1.getTime() - date2.getTime();
+  }
+  var getWeek = function getWeek(givenDate) {
+    var date = new Date(givenDate.getTime());
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
+    var week1 = new Date(date.getFullYear(), 0, 4);
+    return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getDay() + 6) % 7) / 7);
+  };
+  var isBetween = function isBetween(ts, ts1, ts2) {
+    return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
+  };
+  var duration = {
+    DAY: 86400000
+  };
+
+  var HOOKS = ["onChange", "onClose", "onDayCreate", "onDestroy", "onKeyDown", "onMonthChange", "onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange", "onPreCalendarPosition"];
+  var defaults = {
+    _disable: [],
+    _enable: [],
+    allowInput: false,
+    altFormat: "F j, Y",
+    altInput: false,
+    altInputClass: "form-control input",
+    animate: (typeof window === 'undefined' ? 'undefined' : _typeof(window)) === "object" && window.navigator.userAgent.indexOf("MSIE") === -1,
+    ariaDateFormat: "F j, Y",
+    clickOpens: true,
+    closeOnSelect: true,
+    conjunction: ", ",
+    dateFormat: "Y-m-d",
+    defaultHour: 12,
+    defaultMinute: 0,
+    defaultSeconds: 0,
+    disable: [],
+    disableMobile: false,
+    enable: [],
+    enableSeconds: false,
+    enableTime: false,
+    errorHandler: function errorHandler(err) {
+      return typeof console !== "undefined" && console.warn(err);
+    },
+    getWeek: getWeek,
+    hourIncrement: 1,
+    ignoredFocusElements: [],
+    inline: false,
+    locale: "default",
+    minuteIncrement: 5,
+    mode: "single",
+    nextArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
+    noCalendar: false,
+    now: new Date(),
+    onChange: [],
+    onClose: [],
+    onDayCreate: [],
+    onDestroy: [],
+    onKeyDown: [],
+    onMonthChange: [],
+    onOpen: [],
+    onParseConfig: [],
+    onReady: [],
+    onValueUpdate: [],
+    onYearChange: [],
+    onPreCalendarPosition: [],
+    plugins: [],
+    position: "auto",
+    positionElement: undefined,
+    prevArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
+    shorthandCurrentMonth: false,
+    showMonths: 1,
+    static: false,
+    time_24hr: false,
+    weekNumbers: false,
+    wrap: false
+  };
+
+  function toggleClass(elem, className, bool) {
+    if (bool === true) return elem.classList.add(className);
+    elem.classList.remove(className);
+  }
+  function createElement(tag, className, content) {
+    var e = window.document.createElement(tag);
+    className = className || "";
+    content = content || "";
+    e.className = className;
+    if (content !== undefined) e.textContent = content;
+    return e;
+  }
+  function clearNode(node) {
+    while (node.firstChild) {
+      node.removeChild(node.firstChild);
+    }
+  }
+  function findParent(node, condition) {
+    if (condition(node)) return node;else if (node.parentNode) return findParent(node.parentNode, condition);
+    return undefined;
+  }
+  function createNumberInput(inputClassName, opts) {
+    var wrapper = createElement("div", "numInputWrapper"),
+        numInput = createElement("input", "numInput " + inputClassName),
+        arrowUp = createElement("span", "arrowUp"),
+        arrowDown = createElement("span", "arrowDown");
+    numInput.type = "text";
+    numInput.pattern = "\\d*";
+    if (opts !== undefined) for (var key in opts) {
+      numInput.setAttribute(key, opts[key]);
+    }
+    wrapper.appendChild(numInput);
+    wrapper.appendChild(arrowUp);
+    wrapper.appendChild(arrowDown);
+    return wrapper;
+  }
+
+  if (typeof Object.assign !== "function") {
+    Object.assign = function (target) {
+      if (!target) {
+        throw TypeError("Cannot convert undefined or null to object");
+      }
+
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      var _loop = function _loop() {
+        var source = args[_i];
+
+        if (source) {
+          Object.keys(source).forEach(function (key) {
+            return target[key] = source[key];
+          });
+        }
+      };
+
+      for (var _i = 0; _i < args.length; _i++) {
+        _loop();
+      }
+
+      return target;
+    };
+  }
+
+  var DEBOUNCED_CHANGE_MS = 300;
+
+  function FlatpickrInstance(element, instanceConfig) {
+    var self = {
+      config: Object.assign({}, flatpickr.defaultConfig),
+      l10n: english
+    };
+    self.parseDate = createDateParser({
+      config: self.config,
+      l10n: self.l10n
+    });
+    self._handlers = [];
+    self._bind = bind;
+    self._setHoursFromDate = setHoursFromDate;
+    self._positionCalendar = positionCalendar;
+    self.changeMonth = changeMonth;
+    self.changeYear = changeYear;
+    self.clear = clear;
+    self.close = close;
+    self._createElement = createElement;
+    self.destroy = destroy;
+    self.isEnabled = isEnabled;
+    self.jumpToDate = jumpToDate;
+    self.open = open;
+    self.redraw = redraw;
+    self.set = set;
+    self.setDate = setDate;
+    self.toggle = toggle;
+
+    function setupHelperFunctions() {
+      self.utils = {
+        getDaysInMonth: function getDaysInMonth(month, yr) {
+          if (month === void 0) {
+            month = self.currentMonth;
+          }
+
+          if (yr === void 0) {
+            yr = self.currentYear;
+          }
+
+          if (month === 1 && (yr % 4 === 0 && yr % 100 !== 0 || yr % 400 === 0)) return 29;
+          return self.l10n.daysInMonth[month];
+        }
+      };
+    }
+
+    function init() {
+      self.element = self.input = element;
+      self.isOpen = false;
+      parseConfig();
+      setupLocale();
+      setupInputs();
+      setupDates();
+      setupHelperFunctions();
+      if (!self.isMobile) build();
+      bindEvents();
+
+      if (self.selectedDates.length || self.config.noCalendar) {
+        if (self.config.enableTime) {
+          setHoursFromDate(self.config.noCalendar ? self.latestSelectedDateObj || self.config.minDate : undefined);
+        }
+
+        updateValue(false);
+      }
+
+      setCalendarWidth();
+      self.showTimeInput = self.selectedDates.length > 0 || self.config.noCalendar;
+      var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+      if (!self.isMobile && isSafari) {
+        positionCalendar();
+      }
+
+      triggerEvent("onReady");
+    }
+
+    function bindToInstance(fn) {
+      return fn.bind(self);
+    }
+
+    function setCalendarWidth() {
+      var config = self.config;
+      if (config.weekNumbers === false && config.showMonths === 1) return;else if (config.noCalendar !== true) {
+        window.requestAnimationFrame(function () {
+          self.calendarContainer.style.visibility = "hidden";
+          self.calendarContainer.style.display = "block";
+
+          if (self.daysContainer !== undefined) {
+            var daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
+            self.daysContainer.style.width = daysWidth + "px";
+            self.calendarContainer.style.width = daysWidth + (self.weekWrapper !== undefined ? self.weekWrapper.offsetWidth : 0) + "px";
+            self.calendarContainer.style.removeProperty("visibility");
+            self.calendarContainer.style.removeProperty("display");
+          }
         });
-        var instances = [];
-        for (var i = 0; i < nodes.length; i++) {
-            var node = nodes[i];
-            try {
-                if (node.getAttribute("data-fp-omit") !== null) continue;
-                if (node._flatpickr !== undefined) {
-                    node._flatpickr.destroy();
-                    node._flatpickr = undefined;
-                }
-                node._flatpickr = FlatpickrInstance(node, config || {});
-                instances.push(node._flatpickr);
-            } catch (e) {
-                console.error(e);
-            }
-        }
-        return instances.length === 1 ? instances[0] : instances;
-    }
-    /* istanbul ignore next */
-    if (typeof HTMLElement !== "undefined" && typeof HTMLCollection !== "undefined" && typeof NodeList !== "undefined") {
-        // browser env
-        HTMLCollection.prototype.flatpickr = NodeList.prototype.flatpickr = function (config) {
-            return _flatpickr(this, config);
-        };
-        HTMLElement.prototype.flatpickr = function (config) {
-            return _flatpickr([this], config);
-        };
-    }
-    /* istanbul ignore next */
-    var flatpickr = function flatpickr(selector, config) {
-        if (typeof selector === "string") {
-            return _flatpickr(window.document.querySelectorAll(selector), config);
-        } else if (selector instanceof Node) {
-            return _flatpickr([selector], config);
-        } else {
-            return _flatpickr(selector, config);
-        }
-    };
-    /* istanbul ignore next */
-    flatpickr.defaultConfig = {};
-    flatpickr.l10ns = {
-        en: _assign({}, english),
-        "default": _assign({}, english)
-    };
-    flatpickr.localize = function (l10n) {
-        flatpickr.l10ns["default"] = _assign({}, flatpickr.l10ns["default"], l10n);
-    };
-    flatpickr.setDefaults = function (config) {
-        flatpickr.defaultConfig = _assign({}, flatpickr.defaultConfig, config);
-    };
-    flatpickr.parseDate = createDateParser({});
-    flatpickr.formatDate = createDateFormatter({});
-    flatpickr.compareDates = compareDates;
-    /* istanbul ignore next */
-    if (typeof jQuery !== "undefined" && typeof jQuery.fn !== "undefined") {
-        jQuery.fn.flatpickr = function (config) {
-            return _flatpickr(this, config);
-        };
-    }
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    Date.prototype.fp_incr = function (days) {
-        return new Date(this.getFullYear(), this.getMonth(), this.getDate() + (typeof days === "string" ? parseInt(days, 10) : days));
-    };
-    if (typeof window !== "undefined") {
-        window.flatpickr = flatpickr;
+      }
     }
 
-    return flatpickr;
+    function updateTime(e) {
+      if (self.selectedDates.length === 0) return;
+
+      if (e !== undefined && e.type !== "blur") {
+        timeWrapper(e);
+      }
+
+      var prevValue = self._input.value;
+      setHoursFromInputs();
+      updateValue();
+
+      if (self._input.value !== prevValue) {
+        self._debouncedChange();
+      }
+    }
+
+    function ampm2military(hour, amPM) {
+      return hour % 12 + 12 * int(amPM === self.l10n.amPM[1]);
+    }
+
+    function military2ampm(hour) {
+      switch (hour % 24) {
+        case 0:
+        case 12:
+          return 12;
+
+        default:
+          return hour % 12;
+      }
+    }
+
+    function setHoursFromInputs() {
+      if (self.hourElement === undefined || self.minuteElement === undefined) return;
+      var hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
+          minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
+          seconds = self.secondElement !== undefined ? (parseInt(self.secondElement.value, 10) || 0) % 60 : 0;
+
+      if (self.amPM !== undefined) {
+        hours = ampm2military(hours, self.amPM.textContent);
+      }
+
+      var limitMinHours = self.config.minTime !== undefined || self.config.minDate && self.minDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.minDate, true) === 0;
+      var limitMaxHours = self.config.maxTime !== undefined || self.config.maxDate && self.maxDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.maxDate, true) === 0;
+
+      if (limitMaxHours) {
+        var maxTime = self.config.maxTime !== undefined ? self.config.maxTime : self.config.maxDate;
+        hours = Math.min(hours, maxTime.getHours());
+        if (hours === maxTime.getHours()) minutes = Math.min(minutes, maxTime.getMinutes());
+        if (minutes === maxTime.getMinutes()) seconds = Math.min(seconds, maxTime.getSeconds());
+      }
+
+      if (limitMinHours) {
+        var minTime = self.config.minTime !== undefined ? self.config.minTime : self.config.minDate;
+        hours = Math.max(hours, minTime.getHours());
+        if (hours === minTime.getHours()) minutes = Math.max(minutes, minTime.getMinutes());
+        if (minutes === minTime.getMinutes()) seconds = Math.max(seconds, minTime.getSeconds());
+      }
+
+      setHours(hours, minutes, seconds);
+    }
+
+    function setHoursFromDate(dateObj) {
+      var date = dateObj || self.latestSelectedDateObj;
+      if (date) setHours(date.getHours(), date.getMinutes(), date.getSeconds());
+    }
+
+    function setDefaultHours() {
+      var hours = self.config.defaultHour;
+      var minutes = self.config.defaultMinute;
+      var seconds = self.config.defaultSeconds;
+
+      if (self.config.minDate !== undefined) {
+        var min_hr = self.config.minDate.getHours();
+        var min_minutes = self.config.minDate.getMinutes();
+        hours = Math.max(hours, min_hr);
+        if (hours === min_hr) minutes = Math.max(min_minutes, minutes);
+        if (hours === min_hr && minutes === min_minutes) seconds = self.config.minDate.getSeconds();
+      }
+
+      if (self.config.maxDate !== undefined) {
+        var max_hr = self.config.maxDate.getHours();
+        var max_minutes = self.config.maxDate.getMinutes();
+        hours = Math.min(hours, max_hr);
+        if (hours === max_hr) minutes = Math.min(max_minutes, minutes);
+        if (hours === max_hr && minutes === max_minutes) seconds = self.config.maxDate.getSeconds();
+      }
+
+      setHours(hours, minutes, seconds);
+    }
+
+    function setHours(hours, minutes, seconds) {
+      if (self.latestSelectedDateObj !== undefined) {
+        self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
+      }
+
+      if (!self.hourElement || !self.minuteElement || self.isMobile) return;
+      self.hourElement.value = pad(!self.config.time_24hr ? (12 + hours) % 12 + 12 * int(hours % 12 === 0) : hours);
+      self.minuteElement.value = pad(minutes);
+      if (self.amPM !== undefined) self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
+      if (self.secondElement !== undefined) self.secondElement.value = pad(seconds);
+    }
+
+    function onYearInput(event) {
+      var year = parseInt(event.target.value) + (event.delta || 0);
+
+      if (year / 1000 > 1 || event.key === "Enter" && !/[^\d]/.test(year.toString())) {
+        changeYear(year);
+      }
+    }
+
+    function bind(element, event, handler, options) {
+      if (event instanceof Array) return event.forEach(function (ev) {
+        return bind(element, ev, handler, options);
+      });
+      if (element instanceof Array) return element.forEach(function (el) {
+        return bind(el, event, handler, options);
+      });
+      element.addEventListener(event, handler, options);
+
+      self._handlers.push({
+        element: element,
+        event: event,
+        handler: handler,
+        options: options
+      });
+    }
+
+    function onClick(handler) {
+      return function (evt) {
+        evt.which === 1 && handler(evt);
+      };
+    }
+
+    function triggerChange() {
+      triggerEvent("onChange");
+    }
+
+    function bindEvents() {
+      if (self.config.wrap) {
+        ["open", "close", "toggle", "clear"].forEach(function (evt) {
+          Array.prototype.forEach.call(self.element.querySelectorAll("[data-" + evt + "]"), function (el) {
+            return bind(el, "click", self[evt]);
+          });
+        });
+      }
+
+      if (self.isMobile) {
+        setupMobile();
+        return;
+      }
+
+      var debouncedResize = debounce(onResize, 50);
+      self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
+      if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent)) bind(self.daysContainer, "mouseover", function (e) {
+        if (self.config.mode === "range") onMouseOver(e.target);
+      });
+      bind(window.document.body, "keydown", onKeyDown);
+      if (!self.config.static) bind(self._input, "keydown", onKeyDown);
+      if (!self.config.inline && !self.config.static) bind(window, "resize", debouncedResize);
+      if (window.ontouchstart !== undefined) bind(window.document, "click", documentClick);else bind(window.document, "mousedown", onClick(documentClick));
+      bind(window.document, "focus", documentClick, {
+        capture: true
+      });
+
+      if (self.config.clickOpens === true) {
+        bind(self._input, "focus", self.open);
+        bind(self._input, "mousedown", onClick(self.open));
+      }
+
+      if (self.daysContainer !== undefined) {
+        bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
+        bind(self.monthNav, ["keyup", "increment"], onYearInput);
+        bind(self.daysContainer, "mousedown", onClick(selectDate));
+      }
+
+      if (self.timeContainer !== undefined && self.minuteElement !== undefined && self.hourElement !== undefined) {
+        var selText = function selText(e) {
+          return e.target.select();
+        };
+
+        bind(self.timeContainer, ["increment"], updateTime);
+        bind(self.timeContainer, "blur", updateTime, {
+          capture: true
+        });
+        bind(self.timeContainer, "mousedown", onClick(timeIncrement));
+        bind([self.hourElement, self.minuteElement], ["focus", "click"], selText);
+        if (self.secondElement !== undefined) bind(self.secondElement, "focus", function () {
+          return self.secondElement && self.secondElement.select();
+        });
+
+        if (self.amPM !== undefined) {
+          bind(self.amPM, "mousedown", onClick(function (e) {
+            updateTime(e);
+            triggerChange();
+          }));
+        }
+      }
+    }
+
+    function jumpToDate(jumpDate) {
+      var jumpTo = jumpDate !== undefined ? self.parseDate(jumpDate) : self.latestSelectedDateObj || (self.config.minDate && self.config.minDate > self.now ? self.config.minDate : self.config.maxDate && self.config.maxDate < self.now ? self.config.maxDate : self.now);
+
+      try {
+        if (jumpTo !== undefined) {
+          self.currentYear = jumpTo.getFullYear();
+          self.currentMonth = jumpTo.getMonth();
+        }
+      } catch (e) {
+        e.message = "Invalid date supplied: " + jumpTo;
+        self.config.errorHandler(e);
+      }
+
+      self.redraw();
+    }
+
+    function timeIncrement(e) {
+      if (~e.target.className.indexOf("arrow")) incrementNumInput(e, e.target.classList.contains("arrowUp") ? 1 : -1);
+    }
+
+    function incrementNumInput(e, delta, inputElem) {
+      var target = e && e.target;
+      var input = inputElem || target && target.parentNode && target.parentNode.firstChild;
+      var event = createEvent("increment");
+      event.delta = delta;
+      input && input.dispatchEvent(event);
+    }
+
+    function build() {
+      var fragment = window.document.createDocumentFragment();
+      self.calendarContainer = createElement("div", "flatpickr-calendar");
+      self.calendarContainer.tabIndex = -1;
+
+      if (!self.config.noCalendar) {
+        fragment.appendChild(buildMonthNav());
+        self.innerContainer = createElement("div", "flatpickr-innerContainer");
+
+        if (self.config.weekNumbers) {
+          var _buildWeeks = buildWeeks(),
+              weekWrapper = _buildWeeks.weekWrapper,
+              weekNumbers = _buildWeeks.weekNumbers;
+
+          self.innerContainer.appendChild(weekWrapper);
+          self.weekNumbers = weekNumbers;
+          self.weekWrapper = weekWrapper;
+        }
+
+        self.rContainer = createElement("div", "flatpickr-rContainer");
+        self.rContainer.appendChild(buildWeekdays());
+
+        if (!self.daysContainer) {
+          self.daysContainer = createElement("div", "flatpickr-days");
+          self.daysContainer.tabIndex = -1;
+        }
+
+        buildDays();
+        self.rContainer.appendChild(self.daysContainer);
+        self.innerContainer.appendChild(self.rContainer);
+        fragment.appendChild(self.innerContainer);
+      }
+
+      if (self.config.enableTime) {
+        fragment.appendChild(buildTime());
+      }
+
+      toggleClass(self.calendarContainer, "rangeMode", self.config.mode === "range");
+      toggleClass(self.calendarContainer, "animate", self.config.animate === true);
+      toggleClass(self.calendarContainer, "multiMonth", self.config.showMonths > 1);
+      self.calendarContainer.appendChild(fragment);
+      var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType !== undefined;
+
+      if (self.config.inline || self.config.static) {
+        self.calendarContainer.classList.add(self.config.inline ? "inline" : "static");
+
+        if (self.config.inline) {
+          if (!customAppend && self.element.parentNode) self.element.parentNode.insertBefore(self.calendarContainer, self._input.nextSibling);else if (self.config.appendTo !== undefined) self.config.appendTo.appendChild(self.calendarContainer);
+        }
+
+        if (self.config.static) {
+          var wrapper = createElement("div", "flatpickr-wrapper");
+          if (self.element.parentNode) self.element.parentNode.insertBefore(wrapper, self.element);
+          wrapper.appendChild(self.element);
+          if (self.altInput) wrapper.appendChild(self.altInput);
+          wrapper.appendChild(self.calendarContainer);
+        }
+      }
+
+      if (!self.config.static && !self.config.inline) (self.config.appendTo !== undefined ? self.config.appendTo : window.document.body).appendChild(self.calendarContainer);
+    }
+
+    function createDay(className, date, dayNumber, i) {
+      var dateIsEnabled = isEnabled(date, true),
+          dayElement = createElement("span", "flatpickr-day " + className, date.getDate().toString());
+      dayElement.dateObj = date;
+      dayElement.$i = i;
+      dayElement.setAttribute("aria-label", self.formatDate(date, self.config.ariaDateFormat));
+
+      if (className.indexOf("hidden") === -1 && compareDates(date, self.now) === 0) {
+        self.todayDateElem = dayElement;
+        dayElement.classList.add("today");
+        dayElement.setAttribute("aria-current", "date");
+      }
+
+      if (dateIsEnabled) {
+        dayElement.tabIndex = -1;
+
+        if (isDateSelected(date)) {
+          dayElement.classList.add("selected");
+          self.selectedDateElem = dayElement;
+
+          if (self.config.mode === "range") {
+            toggleClass(dayElement, "startRange", self.selectedDates[0] && compareDates(date, self.selectedDates[0], true) === 0);
+            toggleClass(dayElement, "endRange", self.selectedDates[1] && compareDates(date, self.selectedDates[1], true) === 0);
+            if (className === "nextMonthDay") dayElement.classList.add("inRange");
+          }
+        }
+      } else {
+        dayElement.classList.add("disabled");
+      }
+
+      if (self.config.mode === "range") {
+        if (isDateInRange(date) && !isDateSelected(date)) dayElement.classList.add("inRange");
+      }
+
+      if (self.weekNumbers && self.config.showMonths === 1 && className !== "prevMonthDay" && dayNumber % 7 === 1) {
+        self.weekNumbers.insertAdjacentHTML("beforeend", "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>");
+      }
+
+      triggerEvent("onDayCreate", dayElement);
+      return dayElement;
+    }
+
+    function focusOnDayElem(targetNode) {
+      targetNode.focus();
+      if (self.config.mode === "range") onMouseOver(targetNode);
+    }
+
+    function getFirstAvailableDay(delta) {
+      var startMonth = delta > 0 ? 0 : self.config.showMonths - 1;
+      var endMonth = delta > 0 ? self.config.showMonths : -1;
+
+      for (var m = startMonth; m != endMonth; m += delta) {
+        var month = self.daysContainer.children[m];
+        var startIndex = delta > 0 ? 0 : month.children.length - 1;
+        var endIndex = delta > 0 ? month.children.length : -1;
+
+        for (var i = startIndex; i != endIndex; i += delta) {
+          var c = month.children[i];
+          if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj)) return c;
+        }
+      }
+
+      return undefined;
+    }
+
+    function getNextAvailableDay(current, delta) {
+      var givenMonth = current.className.indexOf("Month") === -1 ? current.dateObj.getMonth() : self.currentMonth;
+      var endMonth = delta > 0 ? self.config.showMonths : -1;
+      var loopDelta = delta > 0 ? 1 : -1;
+
+      for (var m = givenMonth - self.currentMonth; m != endMonth; m += loopDelta) {
+        var month = self.daysContainer.children[m];
+        var startIndex = givenMonth - self.currentMonth === m ? current.$i + delta : delta < 0 ? month.children.length - 1 : 0;
+        var numMonthDays = month.children.length;
+
+        for (var i = startIndex; i >= 0 && i < numMonthDays && i != (delta > 0 ? numMonthDays : -1); i += loopDelta) {
+          var c = month.children[i];
+          if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj) && Math.abs(current.$i - i) >= Math.abs(delta)) return focusOnDayElem(c);
+        }
+      }
+
+      self.changeMonth(loopDelta);
+      focusOnDay(getFirstAvailableDay(loopDelta), 0);
+      return undefined;
+    }
+
+    function focusOnDay(current, offset) {
+      var dayFocused = isInView(document.activeElement || document.body);
+      var startElem = current !== undefined ? current : dayFocused ? document.activeElement : self.selectedDateElem !== undefined && isInView(self.selectedDateElem) ? self.selectedDateElem : self.todayDateElem !== undefined && isInView(self.todayDateElem) ? self.todayDateElem : getFirstAvailableDay(offset > 0 ? 1 : -1);
+      if (startElem === undefined) return self._input.focus();
+      if (!dayFocused) return focusOnDayElem(startElem);
+      getNextAvailableDay(startElem, offset);
+    }
+
+    function buildMonthDays(year, month) {
+      var firstOfMonth = (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
+      var prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12);
+      var daysInMonth = self.utils.getDaysInMonth(month),
+          days = window.document.createDocumentFragment(),
+          isMultiMonth = self.config.showMonths > 1,
+          prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
+          nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
+      var dayNumber = prevMonthDays + 1 - firstOfMonth,
+          dayIndex = 0;
+
+      for (; dayNumber <= prevMonthDays; dayNumber++, dayIndex++) {
+        days.appendChild(createDay(prevMonthDayClass, new Date(year, month - 1, dayNumber), dayNumber, dayIndex));
+      }
+
+      for (dayNumber = 1; dayNumber <= daysInMonth; dayNumber++, dayIndex++) {
+        days.appendChild(createDay("", new Date(year, month, dayNumber), dayNumber, dayIndex));
+      }
+
+      for (var dayNum = daysInMonth + 1; dayNum <= 42 - firstOfMonth && (self.config.showMonths === 1 || dayIndex % 7 !== 0); dayNum++, dayIndex++) {
+        days.appendChild(createDay(nextMonthDayClass, new Date(year, month + 1, dayNum % daysInMonth), dayNum, dayIndex));
+      }
+
+      var dayContainer = createElement("div", "dayContainer");
+      dayContainer.appendChild(days);
+      return dayContainer;
+    }
+
+    function buildDays() {
+      if (self.daysContainer === undefined) {
+        return;
+      }
+
+      clearNode(self.daysContainer);
+      if (self.weekNumbers) clearNode(self.weekNumbers);
+      var frag = document.createDocumentFragment();
+
+      for (var i = 0; i < self.config.showMonths; i++) {
+        var d = new Date(self.currentYear, self.currentMonth, 1);
+        d.setMonth(self.currentMonth + i);
+        frag.appendChild(buildMonthDays(d.getFullYear(), d.getMonth()));
+      }
+
+      self.daysContainer.appendChild(frag);
+      self.days = self.daysContainer.firstChild;
+
+      if (self.config.mode === "range" && self.selectedDates.length === 1) {
+        onMouseOver();
+      }
+    }
+
+    function buildMonth() {
+      var container = createElement("div", "flatpickr-month");
+      var monthNavFragment = window.document.createDocumentFragment();
+      var monthElement = createElement("span", "cur-month");
+      var yearInput = createNumberInput("cur-year", {
+        tabindex: "-1"
+      });
+      var yearElement = yearInput.getElementsByTagName("input")[0];
+      yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
+      if (self.config.minDate) yearElement.setAttribute("data-min", self.config.minDate.getFullYear().toString());
+
+      if (self.config.maxDate) {
+        yearElement.setAttribute("data-max", self.config.maxDate.getFullYear().toString());
+        yearElement.disabled = !!self.config.minDate && self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
+      }
+
+      var currentMonth = createElement("div", "flatpickr-current-month");
+      currentMonth.appendChild(monthElement);
+      currentMonth.appendChild(yearInput);
+      monthNavFragment.appendChild(currentMonth);
+      container.appendChild(monthNavFragment);
+      return {
+        container: container,
+        yearElement: yearElement,
+        monthElement: monthElement
+      };
+    }
+
+    function buildMonths() {
+      clearNode(self.monthNav);
+      self.monthNav.appendChild(self.prevMonthNav);
+
+      for (var m = self.config.showMonths; m--;) {
+        var month = buildMonth();
+        self.yearElements.push(month.yearElement);
+        self.monthElements.push(month.monthElement);
+        self.monthNav.appendChild(month.container);
+      }
+
+      self.monthNav.appendChild(self.nextMonthNav);
+    }
+
+    function buildMonthNav() {
+      self.monthNav = createElement("div", "flatpickr-months");
+      self.yearElements = [];
+      self.monthElements = [];
+      self.prevMonthNav = createElement("span", "flatpickr-prev-month");
+      self.prevMonthNav.innerHTML = self.config.prevArrow;
+      self.nextMonthNav = createElement("span", "flatpickr-next-month");
+      self.nextMonthNav.innerHTML = self.config.nextArrow;
+      buildMonths();
+      Object.defineProperty(self, "_hidePrevMonthArrow", {
+        get: function get() {
+          return self.__hidePrevMonthArrow;
+        },
+        set: function set(bool) {
+          if (self.__hidePrevMonthArrow !== bool) {
+            toggleClass(self.prevMonthNav, "disabled", bool);
+            self.__hidePrevMonthArrow = bool;
+          }
+        }
+      });
+      Object.defineProperty(self, "_hideNextMonthArrow", {
+        get: function get() {
+          return self.__hideNextMonthArrow;
+        },
+        set: function set(bool) {
+          if (self.__hideNextMonthArrow !== bool) {
+            toggleClass(self.nextMonthNav, "disabled", bool);
+            self.__hideNextMonthArrow = bool;
+          }
+        }
+      });
+      self.currentYearElement = self.yearElements[0];
+      updateNavigationCurrentMonth();
+      return self.monthNav;
+    }
+
+    function buildTime() {
+      self.calendarContainer.classList.add("hasTime");
+      if (self.config.noCalendar) self.calendarContainer.classList.add("noCalendar");
+      self.timeContainer = createElement("div", "flatpickr-time");
+      self.timeContainer.tabIndex = -1;
+      var separator = createElement("span", "flatpickr-time-separator", ":");
+      var hourInput = createNumberInput("flatpickr-hour");
+      self.hourElement = hourInput.getElementsByTagName("input")[0];
+      var minuteInput = createNumberInput("flatpickr-minute");
+      self.minuteElement = minuteInput.getElementsByTagName("input")[0];
+      self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
+      self.hourElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getHours() : self.config.time_24hr ? self.config.defaultHour : military2ampm(self.config.defaultHour));
+      self.minuteElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getMinutes() : self.config.defaultMinute);
+      self.hourElement.setAttribute("data-step", self.config.hourIncrement.toString());
+      self.minuteElement.setAttribute("data-step", self.config.minuteIncrement.toString());
+      self.hourElement.setAttribute("data-min", self.config.time_24hr ? "0" : "1");
+      self.hourElement.setAttribute("data-max", self.config.time_24hr ? "23" : "12");
+      self.minuteElement.setAttribute("data-min", "0");
+      self.minuteElement.setAttribute("data-max", "59");
+      self.timeContainer.appendChild(hourInput);
+      self.timeContainer.appendChild(separator);
+      self.timeContainer.appendChild(minuteInput);
+      if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
+
+      if (self.config.enableSeconds) {
+        self.timeContainer.classList.add("hasSeconds");
+        var secondInput = createNumberInput("flatpickr-second");
+        self.secondElement = secondInput.getElementsByTagName("input")[0];
+        self.secondElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getSeconds() : self.config.defaultSeconds);
+        self.secondElement.setAttribute("data-step", self.minuteElement.getAttribute("data-step"));
+        self.secondElement.setAttribute("data-min", self.minuteElement.getAttribute("data-min"));
+        self.secondElement.setAttribute("data-max", self.minuteElement.getAttribute("data-max"));
+        self.timeContainer.appendChild(createElement("span", "flatpickr-time-separator", ":"));
+        self.timeContainer.appendChild(secondInput);
+      }
+
+      if (!self.config.time_24hr) {
+        self.amPM = createElement("span", "flatpickr-am-pm", self.l10n.amPM[int((self.latestSelectedDateObj ? self.hourElement.value : self.config.defaultHour) > 11)]);
+        self.amPM.title = self.l10n.toggleTitle;
+        self.amPM.tabIndex = -1;
+        self.timeContainer.appendChild(self.amPM);
+      }
+
+      return self.timeContainer;
+    }
+
+    function buildWeekdays() {
+      if (!self.weekdayContainer) self.weekdayContainer = createElement("div", "flatpickr-weekdays");else clearNode(self.weekdayContainer);
+
+      for (var i = self.config.showMonths; i--;) {
+        var container = createElement("div", "flatpickr-weekdaycontainer");
+        self.weekdayContainer.appendChild(container);
+      }
+
+      updateWeekdays();
+      return self.weekdayContainer;
+    }
+
+    function updateWeekdays() {
+      var firstDayOfWeek = self.l10n.firstDayOfWeek;
+      var weekdays = self.l10n.weekdays.shorthand.concat();
+
+      if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {
+        weekdays = weekdays.splice(firstDayOfWeek, weekdays.length).concat(weekdays.splice(0, firstDayOfWeek));
+      }
+
+      for (var i = self.config.showMonths; i--;) {
+        self.weekdayContainer.children[i].innerHTML = "\n      <span class=flatpickr-weekday>\n        " + weekdays.join("</span><span class=flatpickr-weekday>") + "\n      </span>\n      ";
+      }
+    }
+
+    function buildWeeks() {
+      self.calendarContainer.classList.add("hasWeeks");
+      var weekWrapper = createElement("div", "flatpickr-weekwrapper");
+      weekWrapper.appendChild(createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation));
+      var weekNumbers = createElement("div", "flatpickr-weeks");
+      weekWrapper.appendChild(weekNumbers);
+      return {
+        weekWrapper: weekWrapper,
+        weekNumbers: weekNumbers
+      };
+    }
+
+    function changeMonth(value, is_offset) {
+      if (is_offset === void 0) {
+        is_offset = true;
+      }
+
+      var delta = is_offset ? value : value - self.currentMonth;
+      if (delta < 0 && self._hidePrevMonthArrow === true || delta > 0 && self._hideNextMonthArrow === true) return;
+      self.currentMonth += delta;
+
+      if (self.currentMonth < 0 || self.currentMonth > 11) {
+        self.currentYear += self.currentMonth > 11 ? 1 : -1;
+        self.currentMonth = (self.currentMonth + 12) % 12;
+        triggerEvent("onYearChange");
+      }
+
+      buildDays();
+      triggerEvent("onMonthChange");
+      updateNavigationCurrentMonth();
+    }
+
+    function clear(triggerChangeEvent) {
+      if (triggerChangeEvent === void 0) {
+        triggerChangeEvent = true;
+      }
+
+      self.input.value = "";
+      if (self.altInput !== undefined) self.altInput.value = "";
+      if (self.mobileInput !== undefined) self.mobileInput.value = "";
+      self.selectedDates = [];
+      self.latestSelectedDateObj = undefined;
+      self.showTimeInput = false;
+
+      if (self.config.enableTime === true) {
+        setDefaultHours();
+      }
+
+      self.redraw();
+      if (triggerChangeEvent) triggerEvent("onChange");
+    }
+
+    function close() {
+      self.isOpen = false;
+
+      if (!self.isMobile) {
+        self.calendarContainer.classList.remove("open");
+
+        self._input.classList.remove("active");
+      }
+
+      triggerEvent("onClose");
+    }
+
+    function destroy() {
+      if (self.config !== undefined) triggerEvent("onDestroy");
+
+      for (var i = self._handlers.length; i--;) {
+        var h = self._handlers[i];
+        h.element.removeEventListener(h.event, h.handler, h.options);
+      }
+
+      self._handlers = [];
+
+      if (self.mobileInput) {
+        if (self.mobileInput.parentNode) self.mobileInput.parentNode.removeChild(self.mobileInput);
+        self.mobileInput = undefined;
+      } else if (self.calendarContainer && self.calendarContainer.parentNode) {
+        if (self.config.static && self.calendarContainer.parentNode) {
+          var wrapper = self.calendarContainer.parentNode;
+          wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
+
+          if (wrapper.parentNode) {
+            while (wrapper.firstChild) {
+              wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
+            }
+
+            wrapper.parentNode.removeChild(wrapper);
+          }
+        } else self.calendarContainer.parentNode.removeChild(self.calendarContainer);
+      }
+
+      if (self.altInput) {
+        self.input.type = "text";
+        if (self.altInput.parentNode) self.altInput.parentNode.removeChild(self.altInput);
+        delete self.altInput;
+      }
+
+      if (self.input) {
+        self.input.type = self.input._type;
+        self.input.classList.remove("flatpickr-input");
+        self.input.removeAttribute("readonly");
+        self.input.value = "";
+      }
+
+      ["_showTimeInput", "latestSelectedDateObj", "_hideNextMonthArrow", "_hidePrevMonthArrow", "__hideNextMonthArrow", "__hidePrevMonthArrow", "isMobile", "isOpen", "selectedDateElem", "minDateHasTime", "maxDateHasTime", "days", "daysContainer", "_input", "_positionElement", "innerContainer", "rContainer", "monthNav", "todayDateElem", "calendarContainer", "weekdayContainer", "prevMonthNav", "nextMonthNav", "currentMonthElement", "currentYearElement", "navigationCurrentMonth", "selectedDateElem", "config"].forEach(function (k) {
+        try {
+          delete self[k];
+        } catch (_) {}
+      });
+    }
+
+    function isCalendarElem(elem) {
+      if (self.config.appendTo && self.config.appendTo.contains(elem)) return true;
+      return self.calendarContainer.contains(elem);
+    }
+
+    function documentClick(e) {
+      if (self.isOpen && !self.config.inline) {
+        var isCalendarElement = isCalendarElem(e.target);
+        var isInput = e.target === self.input || e.target === self.altInput || self.element.contains(e.target) || e.path && e.path.indexOf && (~e.path.indexOf(self.input) || ~e.path.indexOf(self.altInput));
+        var lostFocus = e.type === "blur" ? isInput && e.relatedTarget && !isCalendarElem(e.relatedTarget) : !isInput && !isCalendarElement;
+        var isIgnored = !self.config.ignoredFocusElements.some(function (elem) {
+          return elem.contains(e.target);
+        });
+
+        if (lostFocus && isIgnored) {
+          self.close();
+
+          if (self.config.mode === "range" && self.selectedDates.length === 1) {
+            self.clear(false);
+            self.redraw();
+          }
+        }
+      }
+    }
+
+    function changeYear(newYear) {
+      if (!newYear || self.config.minDate && newYear < self.config.minDate.getFullYear() || self.config.maxDate && newYear > self.config.maxDate.getFullYear()) return;
+      var newYearNum = newYear,
+          isNewYear = self.currentYear !== newYearNum;
+      self.currentYear = newYearNum || self.currentYear;
+
+      if (self.config.maxDate && self.currentYear === self.config.maxDate.getFullYear()) {
+        self.currentMonth = Math.min(self.config.maxDate.getMonth(), self.currentMonth);
+      } else if (self.config.minDate && self.currentYear === self.config.minDate.getFullYear()) {
+        self.currentMonth = Math.max(self.config.minDate.getMonth(), self.currentMonth);
+      }
+
+      if (isNewYear) {
+        self.redraw();
+        triggerEvent("onYearChange");
+      }
+    }
+
+    function isEnabled(date, timeless) {
+      if (timeless === void 0) {
+        timeless = true;
+      }
+
+      var dateToCheck = self.parseDate(date, undefined, timeless);
+      if (self.config.minDate && dateToCheck && compareDates(dateToCheck, self.config.minDate, timeless !== undefined ? timeless : !self.minDateHasTime) < 0 || self.config.maxDate && dateToCheck && compareDates(dateToCheck, self.config.maxDate, timeless !== undefined ? timeless : !self.maxDateHasTime) > 0) return false;
+      if (self.config.enable.length === 0 && self.config.disable.length === 0) return true;
+      if (dateToCheck === undefined) return false;
+      var bool = self.config.enable.length > 0,
+          array = bool ? self.config.enable : self.config.disable;
+
+      for (var i = 0, d; i < array.length; i++) {
+        d = array[i];
+        if (typeof d === "function" && d(dateToCheck)) return bool;else if (d instanceof Date && dateToCheck !== undefined && d.getTime() === dateToCheck.getTime()) return bool;else if (typeof d === "string" && dateToCheck !== undefined) {
+          var parsed = self.parseDate(d, undefined, true);
+          return parsed && parsed.getTime() === dateToCheck.getTime() ? bool : !bool;
+        } else if ((typeof d === 'undefined' ? 'undefined' : _typeof(d)) === "object" && dateToCheck !== undefined && d.from && d.to && dateToCheck.getTime() >= d.from.getTime() && dateToCheck.getTime() <= d.to.getTime()) return bool;
+      }
+
+      return !bool;
+    }
+
+    function isInView(elem) {
+      if (self.daysContainer !== undefined) return elem.className.indexOf("hidden") === -1 && self.daysContainer.contains(elem);
+      return false;
+    }
+
+    function onKeyDown(e) {
+      var isInput = e.target === self._input;
+      var allowInput = self.config.allowInput;
+      var allowKeydown = self.isOpen && (!allowInput || !isInput);
+      var allowInlineKeydown = self.config.inline && isInput && !allowInput;
+
+      if (e.keyCode === 13 && isInput) {
+        if (allowInput) {
+          self.setDate(self._input.value, true, e.target === self.altInput ? self.config.altFormat : self.config.dateFormat);
+          return e.target.blur();
+        } else self.open();
+      } else if (isCalendarElem(e.target) || allowKeydown || allowInlineKeydown) {
+        var isTimeObj = !!self.timeContainer && self.timeContainer.contains(e.target);
+
+        switch (e.keyCode) {
+          case 13:
+            if (isTimeObj) updateTime();else selectDate(e);
+            break;
+
+          case 27:
+            e.preventDefault();
+            focusAndClose();
+            break;
+
+          case 8:
+          case 46:
+            if (isInput && !self.config.allowInput) {
+              e.preventDefault();
+              self.clear();
+            }
+
+            break;
+
+          case 37:
+          case 39:
+            if (!isTimeObj) {
+              e.preventDefault();
+
+              if (self.daysContainer !== undefined && (allowInput === false || isInView(document.activeElement))) {
+                var _delta = e.keyCode === 39 ? 1 : -1;
+
+                if (!e.ctrlKey) focusOnDay(undefined, _delta);else {
+                  changeMonth(_delta);
+                  focusOnDay(getFirstAvailableDay(1), 0);
+                }
+              }
+            } else if (self.hourElement) self.hourElement.focus();
+
+            break;
+
+          case 38:
+          case 40:
+            e.preventDefault();
+            var delta = e.keyCode === 40 ? 1 : -1;
+
+            if (self.daysContainer && e.target.$i !== undefined) {
+              if (e.ctrlKey) {
+                changeYear(self.currentYear - delta);
+                focusOnDay(getFirstAvailableDay(1), 0);
+              } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
+            } else if (self.config.enableTime) {
+              if (!isTimeObj && self.hourElement) self.hourElement.focus();
+              updateTime(e);
+
+              self._debouncedChange();
+            }
+
+            break;
+
+          case 9:
+            if (!isTimeObj) {
+              self.element.focus();
+              break;
+            }
+
+            var elems = [self.hourElement, self.minuteElement, self.secondElement, self.amPM].filter(function (x) {
+              return x;
+            });
+            var i = elems.indexOf(e.target);
+
+            if (i !== -1) {
+              var target = elems[i + (e.shiftKey ? -1 : 1)];
+
+              if (target !== undefined) {
+                e.preventDefault();
+                target.focus();
+              } else {
+                self.element.focus();
+              }
+            }
+
+            break;
+
+          default:
+            break;
+        }
+      }
+
+      if (self.amPM !== undefined && e.target === self.amPM) {
+        switch (e.key) {
+          case self.l10n.amPM[0].charAt(0):
+          case self.l10n.amPM[0].charAt(0).toLowerCase():
+            self.amPM.textContent = self.l10n.amPM[0];
+            setHoursFromInputs();
+            updateValue();
+            break;
+
+          case self.l10n.amPM[1].charAt(0):
+          case self.l10n.amPM[1].charAt(0).toLowerCase():
+            self.amPM.textContent = self.l10n.amPM[1];
+            setHoursFromInputs();
+            updateValue();
+            break;
+        }
+      }
+
+      triggerEvent("onKeyDown", e);
+    }
+
+    function onMouseOver(elem) {
+      if (self.selectedDates.length !== 1 || elem && (!elem.classList.contains("flatpickr-day") || elem.classList.contains("disabled"))) return;
+      var hoverDate = elem ? elem.dateObj.getTime() : self.days.firstElementChild.dateObj.getTime(),
+          initialDate = self.parseDate(self.selectedDates[0], undefined, true).getTime(),
+          rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
+          rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime()),
+          lastDate = self.daysContainer.lastChild.lastChild.dateObj.getTime();
+      var containsDisabled = false;
+      var minRange = 0,
+          maxRange = 0;
+
+      for (var t = rangeStartDate; t < lastDate; t += duration.DAY) {
+        if (!isEnabled(new Date(t), true)) {
+          containsDisabled = containsDisabled || t > rangeStartDate && t < rangeEndDate;
+          if (t < initialDate && (!minRange || t > minRange)) minRange = t;else if (t > initialDate && (!maxRange || t < maxRange)) maxRange = t;
+        }
+      }
+
+      for (var m = 0; m < self.config.showMonths; m++) {
+        var month = self.daysContainer.children[m];
+        var prevMonth = self.daysContainer.children[m - 1];
+
+        var _loop = function _loop(i, l) {
+          var dayElem = month.children[i],
+              date = dayElem.dateObj;
+          var timestamp = date.getTime();
+          var outOfRange = minRange > 0 && timestamp < minRange || maxRange > 0 && timestamp > maxRange;
+
+          if (outOfRange) {
+            dayElem.classList.add("notAllowed");
+            ["inRange", "startRange", "endRange"].forEach(function (c) {
+              dayElem.classList.remove(c);
+            });
+            return "continue";
+          } else if (containsDisabled && !outOfRange) return "continue";
+
+          ["startRange", "inRange", "endRange", "notAllowed"].forEach(function (c) {
+            dayElem.classList.remove(c);
+          });
+
+          if (elem !== undefined) {
+            elem.classList.add(hoverDate < self.selectedDates[0].getTime() ? "startRange" : "endRange");
+
+            if (month.contains(elem) || !(m > 0 && prevMonth && prevMonth.lastChild.dateObj.getTime() >= timestamp)) {
+              if (initialDate < hoverDate && timestamp === initialDate) dayElem.classList.add("startRange");else if (initialDate > hoverDate && timestamp === initialDate) dayElem.classList.add("endRange");
+              if (timestamp >= minRange && (maxRange === 0 || timestamp <= maxRange) && isBetween(timestamp, initialDate, hoverDate)) dayElem.classList.add("inRange");
+            }
+          }
+        };
+
+        for (var i = 0, l = month.children.length; i < l; i++) {
+          var _ret = _loop(i, l);
+
+          if (_ret === "continue") continue;
+        }
+      }
+    }
+
+    function onResize() {
+      if (self.isOpen && !self.config.static && !self.config.inline) positionCalendar();
+    }
+
+    function open(e, positionElement) {
+      if (positionElement === void 0) {
+        positionElement = self._positionElement;
+      }
+
+      if (self.isMobile === true) {
+        if (e) {
+          e.preventDefault();
+          e.target && e.target.blur();
+        }
+
+        if (self.mobileInput !== undefined) {
+          self.mobileInput.focus();
+          self.mobileInput.click();
+        }
+
+        triggerEvent("onOpen");
+        return;
+      }
+
+      if (self._input.disabled || self.config.inline) return;
+      var wasOpen = self.isOpen;
+      self.isOpen = true;
+
+      if (!wasOpen) {
+        self.calendarContainer.classList.add("open");
+
+        self._input.classList.add("active");
+
+        triggerEvent("onOpen");
+        positionCalendar(positionElement);
+      }
+
+      if (self.config.enableTime === true && self.config.noCalendar === true) {
+        if (self.selectedDates.length === 0) {
+          self.setDate(self.config.minDate !== undefined ? new Date(self.config.minDate.getTime()) : new Date(), false);
+          setDefaultHours();
+          updateValue();
+        }
+
+        if (self.config.allowInput === false && (e === undefined || !self.timeContainer.contains(e.relatedTarget))) {
+          setTimeout(function () {
+            return self.hourElement.select();
+          }, 50);
+        }
+      }
+    }
+
+    function minMaxDateSetter(type) {
+      return function (date) {
+        var dateObj = self.config["_" + type + "Date"] = self.parseDate(date, self.config.dateFormat);
+        var inverseDateObj = self.config["_" + (type === "min" ? "max" : "min") + "Date"];
+
+        if (dateObj !== undefined) {
+          self[type === "min" ? "minDateHasTime" : "maxDateHasTime"] = dateObj.getHours() > 0 || dateObj.getMinutes() > 0 || dateObj.getSeconds() > 0;
+        }
+
+        if (self.selectedDates) {
+          self.selectedDates = self.selectedDates.filter(function (d) {
+            return isEnabled(d);
+          });
+          if (!self.selectedDates.length && type === "min") setHoursFromDate(dateObj);
+          updateValue();
+        }
+
+        if (self.daysContainer) {
+          redraw();
+          if (dateObj !== undefined) self.currentYearElement[type] = dateObj.getFullYear().toString();else self.currentYearElement.removeAttribute(type);
+          self.currentYearElement.disabled = !!inverseDateObj && dateObj !== undefined && inverseDateObj.getFullYear() === dateObj.getFullYear();
+        }
+      };
+    }
+
+    function parseConfig() {
+      var boolOpts = ["wrap", "weekNumbers", "allowInput", "clickOpens", "time_24hr", "enableTime", "noCalendar", "altInput", "shorthandCurrentMonth", "inline", "static", "enableSeconds", "disableMobile"];
+      var userConfig = Object.assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
+      var formats$$1 = {};
+      self.config.parseDate = userConfig.parseDate;
+      self.config.formatDate = userConfig.formatDate;
+      Object.defineProperty(self.config, "enable", {
+        get: function get() {
+          return self.config._enable;
+        },
+        set: function set(dates) {
+          self.config._enable = parseDateRules(dates);
+        }
+      });
+      Object.defineProperty(self.config, "disable", {
+        get: function get() {
+          return self.config._disable;
+        },
+        set: function set(dates) {
+          self.config._disable = parseDateRules(dates);
+        }
+      });
+      var timeMode = userConfig.mode === "time";
+
+      if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
+        formats$$1.dateFormat = userConfig.noCalendar || timeMode ? "H:i" + (userConfig.enableSeconds ? ":S" : "") : flatpickr.defaultConfig.dateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
+      }
+
+      if (userConfig.altInput && (userConfig.enableTime || timeMode) && !userConfig.altFormat) {
+        formats$$1.altFormat = userConfig.noCalendar || timeMode ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K") : flatpickr.defaultConfig.altFormat + (" h:i" + (userConfig.enableSeconds ? ":S" : "") + " K");
+      }
+
+      Object.defineProperty(self.config, "minDate", {
+        get: function get() {
+          return self.config._minDate;
+        },
+        set: minMaxDateSetter("min")
+      });
+      Object.defineProperty(self.config, "maxDate", {
+        get: function get() {
+          return self.config._maxDate;
+        },
+        set: minMaxDateSetter("max")
+      });
+
+      var minMaxTimeSetter = function minMaxTimeSetter(type) {
+        return function (val) {
+          self.config[type === "min" ? "_minTime" : "_maxTime"] = self.parseDate(val, "H:i");
+        };
+      };
+
+      Object.defineProperty(self.config, "minTime", {
+        get: function get() {
+          return self.config._minTime;
+        },
+        set: minMaxTimeSetter("min")
+      });
+      Object.defineProperty(self.config, "maxTime", {
+        get: function get() {
+          return self.config._maxTime;
+        },
+        set: minMaxTimeSetter("max")
+      });
+
+      if (userConfig.mode === "time") {
+        self.config.noCalendar = true;
+        self.config.enableTime = true;
+      }
+
+      Object.assign(self.config, formats$$1, userConfig);
+
+      for (var i = 0; i < boolOpts.length; i++) {
+        self.config[boolOpts[i]] = self.config[boolOpts[i]] === true || self.config[boolOpts[i]] === "true";
+      }
+
+      HOOKS.filter(function (hook) {
+        return self.config[hook] !== undefined;
+      }).forEach(function (hook) {
+        self.config[hook] = arrayify(self.config[hook] || []).map(bindToInstance);
+      });
+      self.isMobile = !self.config.disableMobile && !self.config.inline && self.config.mode === "single" && !self.config.disable.length && !self.config.enable.length && !self.config.weekNumbers && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+
+      for (var _i = 0; _i < self.config.plugins.length; _i++) {
+        var pluginConf = self.config.plugins[_i](self) || {};
+
+        for (var key in pluginConf) {
+          if (HOOKS.indexOf(key) > -1) {
+            self.config[key] = arrayify(pluginConf[key]).map(bindToInstance).concat(self.config[key]);
+          } else if (typeof userConfig[key] === "undefined") self.config[key] = pluginConf[key];
+        }
+      }
+
+      triggerEvent("onParseConfig");
+    }
+
+    function setupLocale() {
+      if (_typeof(self.config.locale) !== "object" && typeof flatpickr.l10ns[self.config.locale] === "undefined") self.config.errorHandler(new Error("flatpickr: invalid locale " + self.config.locale));
+      self.l10n = Object.assign({}, flatpickr.l10ns.default, _typeof(self.config.locale) === "object" ? self.config.locale : self.config.locale !== "default" ? flatpickr.l10ns[self.config.locale] : undefined);
+      tokenRegex.K = "(" + self.l10n.amPM[0] + "|" + self.l10n.amPM[1] + "|" + self.l10n.amPM[0].toLowerCase() + "|" + self.l10n.amPM[1].toLowerCase() + ")";
+      self.formatDate = createDateFormatter(self);
+      self.parseDate = createDateParser({
+        config: self.config,
+        l10n: self.l10n
+      });
+    }
+
+    function positionCalendar(customPositionElement) {
+      if (self.calendarContainer === undefined) return;
+      triggerEvent("onPreCalendarPosition");
+      var positionElement = customPositionElement || self._positionElement;
+      var calendarHeight = Array.prototype.reduce.call(self.calendarContainer.children, function (acc, child) {
+        return acc + child.offsetHeight;
+      }, 0),
+          calendarWidth = self.calendarContainer.offsetWidth,
+          configPos = self.config.position.split(" "),
+          configPosVertical = configPos[0],
+          configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
+          inputBounds = positionElement.getBoundingClientRect(),
+          distanceFromBottom = window.innerHeight - inputBounds.bottom,
+          showOnTop = configPosVertical === "above" || configPosVertical !== "below" && distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
+      var top = window.pageYOffset + inputBounds.top + (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
+      toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
+      toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
+      if (self.config.inline) return;
+      var left = window.pageXOffset + inputBounds.left - (configPosHorizontal != null && configPosHorizontal === "center" ? (calendarWidth - inputBounds.width) / 2 : 0);
+      var right = window.document.body.offsetWidth - inputBounds.right;
+      var rightMost = left + calendarWidth > window.document.body.offsetWidth;
+      toggleClass(self.calendarContainer, "rightMost", rightMost);
+      if (self.config.static) return;
+      self.calendarContainer.style.top = top + "px";
+
+      if (!rightMost) {
+        self.calendarContainer.style.left = left + "px";
+        self.calendarContainer.style.right = "auto";
+      } else {
+        self.calendarContainer.style.left = "auto";
+        self.calendarContainer.style.right = right + "px";
+      }
+    }
+
+    function redraw() {
+      if (self.config.noCalendar || self.isMobile) return;
+      updateNavigationCurrentMonth();
+      buildDays();
+    }
+
+    function focusAndClose() {
+      self._input.focus();
+
+      if (window.navigator.userAgent.indexOf("MSIE") !== -1 || navigator.msMaxTouchPoints !== undefined) {
+        setTimeout(self.close, 0);
+      } else {
+        self.close();
+      }
+    }
+
+    function selectDate(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      var isSelectable = function isSelectable(day) {
+        return day.classList && day.classList.contains("flatpickr-day") && !day.classList.contains("disabled") && !day.classList.contains("notAllowed");
+      };
+
+      var t = findParent(e.target, isSelectable);
+      if (t === undefined) return;
+      var target = t;
+      var selectedDate = self.latestSelectedDateObj = new Date(target.dateObj.getTime());
+      var shouldChangeMonth = (selectedDate.getMonth() < self.currentMonth || selectedDate.getMonth() > self.currentMonth + self.config.showMonths - 1) && self.config.mode !== "range";
+      self.selectedDateElem = target;
+      if (self.config.mode === "single") self.selectedDates = [selectedDate];else if (self.config.mode === "multiple") {
+        var selectedIndex = isDateSelected(selectedDate);
+        if (selectedIndex) self.selectedDates.splice(parseInt(selectedIndex), 1);else self.selectedDates.push(selectedDate);
+      } else if (self.config.mode === "range") {
+        if (self.selectedDates.length === 2) self.clear(false);
+        self.selectedDates.push(selectedDate);
+        if (compareDates(selectedDate, self.selectedDates[0], true) !== 0) self.selectedDates.sort(function (a, b) {
+          return a.getTime() - b.getTime();
+        });
+      }
+      setHoursFromInputs();
+
+      if (shouldChangeMonth) {
+        var isNewYear = self.currentYear !== selectedDate.getFullYear();
+        self.currentYear = selectedDate.getFullYear();
+        self.currentMonth = selectedDate.getMonth();
+        if (isNewYear) triggerEvent("onYearChange");
+        triggerEvent("onMonthChange");
+      }
+
+      updateNavigationCurrentMonth();
+      buildDays();
+      updateValue();
+      if (self.config.enableTime) setTimeout(function () {
+        return self.showTimeInput = true;
+      }, 50);
+      if (!shouldChangeMonth && self.config.mode !== "range" && self.config.showMonths === 1) focusOnDayElem(target);else self.selectedDateElem && self.selectedDateElem.focus();
+      if (self.hourElement !== undefined) setTimeout(function () {
+        return self.hourElement !== undefined && self.hourElement.select();
+      }, 451);
+
+      if (self.config.closeOnSelect) {
+        var single = self.config.mode === "single" && !self.config.enableTime;
+        var range = self.config.mode === "range" && self.selectedDates.length === 2 && !self.config.enableTime;
+
+        if (single || range) {
+          focusAndClose();
+        }
+      }
+
+      triggerChange();
+    }
+
+    var CALLBACKS = {
+      locale: [setupLocale, updateWeekdays],
+      showMonths: [buildMonths, setCalendarWidth, buildWeekdays]
+    };
+
+    function set(option, value) {
+      if (option !== null && (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === "object") Object.assign(self.config, option);else {
+        self.config[option] = value;
+        if (CALLBACKS[option] !== undefined) CALLBACKS[option].forEach(function (x) {
+          return x();
+        });else if (HOOKS.indexOf(option) > -1) self.config[option] = arrayify(value);
+      }
+      self.redraw();
+      jumpToDate();
+      updateValue(false);
+    }
+
+    function setSelectedDate(inputDate, format) {
+      var dates = [];
+      if (inputDate instanceof Array) dates = inputDate.map(function (d) {
+        return self.parseDate(d, format);
+      });else if (inputDate instanceof Date || typeof inputDate === "number") dates = [self.parseDate(inputDate, format)];else if (typeof inputDate === "string") {
+        switch (self.config.mode) {
+          case "single":
+          case "time":
+            dates = [self.parseDate(inputDate, format)];
+            break;
+
+          case "multiple":
+            dates = inputDate.split(self.config.conjunction).map(function (date) {
+              return self.parseDate(date, format);
+            });
+            break;
+
+          case "range":
+            dates = inputDate.split(self.l10n.rangeSeparator).map(function (date) {
+              return self.parseDate(date, format);
+            });
+            break;
+
+          default:
+            break;
+        }
+      } else self.config.errorHandler(new Error("Invalid date supplied: " + JSON.stringify(inputDate)));
+      self.selectedDates = dates.filter(function (d) {
+        return d instanceof Date && isEnabled(d, false);
+      });
+      if (self.config.mode === "range") self.selectedDates.sort(function (a, b) {
+        return a.getTime() - b.getTime();
+      });
+    }
+
+    function setDate(date, triggerChange, format) {
+      if (triggerChange === void 0) {
+        triggerChange = false;
+      }
+
+      if (format === void 0) {
+        format = self.config.dateFormat;
+      }
+
+      if (date !== 0 && !date || date instanceof Array && date.length === 0) return self.clear(triggerChange);
+      setSelectedDate(date, format);
+      self.showTimeInput = self.selectedDates.length > 0;
+      self.latestSelectedDateObj = self.selectedDates[0];
+      self.redraw();
+      jumpToDate();
+      setHoursFromDate();
+      updateValue(triggerChange);
+      if (triggerChange) triggerEvent("onChange");
+    }
+
+    function parseDateRules(arr) {
+      return arr.slice().map(function (rule) {
+        if (typeof rule === "string" || typeof rule === "number" || rule instanceof Date) {
+          return self.parseDate(rule, undefined, true);
+        } else if (rule && (typeof rule === 'undefined' ? 'undefined' : _typeof(rule)) === "object" && rule.from && rule.to) return {
+          from: self.parseDate(rule.from, undefined),
+          to: self.parseDate(rule.to, undefined)
+        };
+
+        return rule;
+      }).filter(function (x) {
+        return x;
+      });
+    }
+
+    function setupDates() {
+      self.selectedDates = [];
+      self.now = self.parseDate(self.config.now) || new Date();
+      var preloadedDate = self.config.defaultDate || ((self.input.nodeName === "INPUT" || self.input.nodeName === "TEXTAREA") && self.input.placeholder && self.input.value === self.input.placeholder ? null : self.input.value);
+      if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
+      var initialDate = self.selectedDates.length > 0 ? self.selectedDates[0] : self.config.minDate && self.config.minDate.getTime() > self.now.getTime() ? self.config.minDate : self.config.maxDate && self.config.maxDate.getTime() < self.now.getTime() ? self.config.maxDate : self.now;
+      self.currentYear = initialDate.getFullYear();
+      self.currentMonth = initialDate.getMonth();
+      if (self.selectedDates.length > 0) self.latestSelectedDateObj = self.selectedDates[0];
+      if (self.config.minTime !== undefined) self.config.minTime = self.parseDate(self.config.minTime, "H:i");
+      if (self.config.maxTime !== undefined) self.config.maxTime = self.parseDate(self.config.maxTime, "H:i");
+      self.minDateHasTime = !!self.config.minDate && (self.config.minDate.getHours() > 0 || self.config.minDate.getMinutes() > 0 || self.config.minDate.getSeconds() > 0);
+      self.maxDateHasTime = !!self.config.maxDate && (self.config.maxDate.getHours() > 0 || self.config.maxDate.getMinutes() > 0 || self.config.maxDate.getSeconds() > 0);
+      Object.defineProperty(self, "showTimeInput", {
+        get: function get() {
+          return self._showTimeInput;
+        },
+        set: function set(bool) {
+          self._showTimeInput = bool;
+          if (self.calendarContainer) toggleClass(self.calendarContainer, "showTimeInput", bool);
+          self.isOpen && positionCalendar();
+        }
+      });
+    }
+
+    function setupInputs() {
+      self.input = self.config.wrap ? element.querySelector("[data-input]") : element;
+
+      if (!self.input) {
+        self.config.errorHandler(new Error("Invalid input element specified"));
+        return;
+      }
+
+      self.input._type = self.input.type;
+      self.input.type = "text";
+      self.input.classList.add("flatpickr-input");
+      self._input = self.input;
+
+      if (self.config.altInput) {
+        self.altInput = createElement(self.input.nodeName, self.input.className + " " + self.config.altInputClass);
+        self._input = self.altInput;
+        self.altInput.placeholder = self.input.placeholder;
+        self.altInput.disabled = self.input.disabled;
+        self.altInput.required = self.input.required;
+        self.altInput.tabIndex = self.input.tabIndex;
+        self.altInput.type = "text";
+        self.input.setAttribute("type", "hidden");
+        if (!self.config.static && self.input.parentNode) self.input.parentNode.insertBefore(self.altInput, self.input.nextSibling);
+      }
+
+      if (!self.config.allowInput) self._input.setAttribute("readonly", "readonly");
+      self._positionElement = self.config.positionElement || self._input;
+    }
+
+    function setupMobile() {
+      var inputType = self.config.enableTime ? self.config.noCalendar ? "time" : "datetime-local" : "date";
+      self.mobileInput = createElement("input", self.input.className + " flatpickr-mobile");
+      self.mobileInput.step = self.input.getAttribute("step") || "any";
+      self.mobileInput.tabIndex = 1;
+      self.mobileInput.type = inputType;
+      self.mobileInput.disabled = self.input.disabled;
+      self.mobileInput.required = self.input.required;
+      self.mobileInput.placeholder = self.input.placeholder;
+      self.mobileFormatStr = inputType === "datetime-local" ? "Y-m-d\\TH:i:S" : inputType === "date" ? "Y-m-d" : "H:i:S";
+
+      if (self.selectedDates.length > 0) {
+        self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(self.selectedDates[0], self.mobileFormatStr);
+      }
+
+      if (self.config.minDate) self.mobileInput.min = self.formatDate(self.config.minDate, "Y-m-d");
+      if (self.config.maxDate) self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
+      self.input.type = "hidden";
+      if (self.altInput !== undefined) self.altInput.type = "hidden";
+
+      try {
+        if (self.input.parentNode) self.input.parentNode.insertBefore(self.mobileInput, self.input.nextSibling);
+      } catch (_a) {}
+
+      bind(self.mobileInput, "change", function (e) {
+        self.setDate(e.target.value, false, self.mobileFormatStr);
+        triggerEvent("onChange");
+        triggerEvent("onClose");
+      });
+    }
+
+    function toggle(e) {
+      if (self.isOpen === true) return self.close();
+      self.open(e);
+    }
+
+    function triggerEvent(event, data) {
+      if (self.config === undefined) return;
+      var hooks = self.config[event];
+
+      if (hooks !== undefined && hooks.length > 0) {
+        for (var i = 0; hooks[i] && i < hooks.length; i++) {
+          hooks[i](self.selectedDates, self.input.value, self, data);
+        }
+      }
+
+      if (event === "onChange") {
+        self.input.dispatchEvent(createEvent("change"));
+        self.input.dispatchEvent(createEvent("input"));
+      }
+    }
+
+    function createEvent(name) {
+      var e = document.createEvent("Event");
+      e.initEvent(name, true, true);
+      return e;
+    }
+
+    function isDateSelected(date) {
+      for (var i = 0; i < self.selectedDates.length; i++) {
+        if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
+      }
+
+      return false;
+    }
+
+    function isDateInRange(date) {
+      if (self.config.mode !== "range" || self.selectedDates.length < 2) return false;
+      return compareDates(date, self.selectedDates[0]) >= 0 && compareDates(date, self.selectedDates[1]) <= 0;
+    }
+
+    function updateNavigationCurrentMonth() {
+      if (self.config.noCalendar || self.isMobile || !self.monthNav) return;
+      self.yearElements.forEach(function (yearElement, i) {
+        var d = new Date(self.currentYear, self.currentMonth, 1);
+        d.setMonth(self.currentMonth + i);
+        self.monthElements[i].textContent = monthToStr(d.getMonth(), self.config.shorthandCurrentMonth, self.l10n) + " ";
+        yearElement.value = d.getFullYear().toString();
+      });
+      self._hidePrevMonthArrow = self.config.minDate !== undefined && (self.currentYear === self.config.minDate.getFullYear() ? self.currentMonth <= self.config.minDate.getMonth() : self.currentYear < self.config.minDate.getFullYear());
+      self._hideNextMonthArrow = self.config.maxDate !== undefined && (self.currentYear === self.config.maxDate.getFullYear() ? self.currentMonth + 1 > self.config.maxDate.getMonth() : self.currentYear > self.config.maxDate.getFullYear());
+    }
+
+    function getDateStr(format) {
+      return self.selectedDates.map(function (dObj) {
+        return self.formatDate(dObj, format);
+      }).filter(function (d, i, arr) {
+        return self.config.mode !== "range" || self.config.enableTime || arr.indexOf(d) === i;
+      }).join(self.config.mode !== "range" ? self.config.conjunction : self.l10n.rangeSeparator);
+    }
+
+    function updateValue(triggerChange) {
+      if (triggerChange === void 0) {
+        triggerChange = true;
+      }
+
+      if (self.selectedDates.length === 0) return self.clear(triggerChange);
+
+      if (self.mobileInput !== undefined && self.mobileFormatStr) {
+        self.mobileInput.value = self.latestSelectedDateObj !== undefined ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr) : "";
+      }
+
+      self.input.value = getDateStr(self.config.dateFormat);
+
+      if (self.altInput !== undefined) {
+        self.altInput.value = getDateStr(self.config.altFormat);
+      }
+
+      if (triggerChange !== false) triggerEvent("onValueUpdate");
+    }
+
+    function onMonthNavClick(e) {
+      e.preventDefault();
+      var isPrevMonth = self.prevMonthNav.contains(e.target);
+      var isNextMonth = self.nextMonthNav.contains(e.target);
+
+      if (isPrevMonth || isNextMonth) {
+        changeMonth(isPrevMonth ? -1 : 1);
+      } else if (self.yearElements.indexOf(e.target) >= 0) {
+        e.target.select();
+      } else if (e.target.classList.contains("arrowUp")) {
+        self.changeYear(self.currentYear + 1);
+      } else if (e.target.classList.contains("arrowDown")) {
+        self.changeYear(self.currentYear - 1);
+      }
+    }
+
+    function timeWrapper(e) {
+      e.preventDefault();
+      var isKeyDown = e.type === "keydown",
+          input = e.target;
+
+      if (self.amPM !== undefined && e.target === self.amPM) {
+        self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
+      }
+
+      var min = parseFloat(input.getAttribute("data-min")),
+          max = parseFloat(input.getAttribute("data-max")),
+          step = parseFloat(input.getAttribute("data-step")),
+          curValue = parseInt(input.value, 10),
+          delta = e.delta || (isKeyDown ? e.which === 38 ? 1 : -1 : 0);
+      var newValue = curValue + step * delta;
+
+      if (typeof input.value !== "undefined" && input.value.length === 2) {
+        var isHourElem = input === self.hourElement,
+            isMinuteElem = input === self.minuteElement;
+
+        if (newValue < min) {
+          newValue = max + newValue + int(!isHourElem) + (int(isHourElem) && int(!self.amPM));
+          if (isMinuteElem) incrementNumInput(undefined, -1, self.hourElement);
+        } else if (newValue > max) {
+          newValue = input === self.hourElement ? newValue - max - int(!self.amPM) : min;
+          if (isMinuteElem) incrementNumInput(undefined, 1, self.hourElement);
+        }
+
+        if (self.amPM && isHourElem && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) {
+          self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
+        }
+
+        input.value = pad(newValue);
+      }
+    }
+
+    init();
+    return self;
+  }
+
+  function _flatpickr(nodeList, config) {
+    var nodes = Array.prototype.slice.call(nodeList);
+    var instances = [];
+
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+
+      try {
+        if (node.getAttribute("data-fp-omit") !== null) continue;
+
+        if (node._flatpickr !== undefined) {
+          node._flatpickr.destroy();
+
+          node._flatpickr = undefined;
+        }
+
+        node._flatpickr = FlatpickrInstance(node, config || {});
+        instances.push(node._flatpickr);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    return instances.length === 1 ? instances[0] : instances;
+  }
+
+  if (typeof HTMLElement !== "undefined") {
+    HTMLCollection.prototype.flatpickr = NodeList.prototype.flatpickr = function (config) {
+      return _flatpickr(this, config);
+    };
+
+    HTMLElement.prototype.flatpickr = function (config) {
+      return _flatpickr([this], config);
+    };
+  }
+
+  var flatpickr = function flatpickr(selector, config) {
+    if (selector instanceof NodeList) return _flatpickr(selector, config);else if (typeof selector === "string") return _flatpickr(window.document.querySelectorAll(selector), config);
+    return _flatpickr([selector], config);
+  };
+
+  flatpickr.defaultConfig = defaults;
+  flatpickr.l10ns = {
+    en: Object.assign({}, english),
+    default: Object.assign({}, english)
+  };
+
+  flatpickr.localize = function (l10n) {
+    flatpickr.l10ns.default = Object.assign({}, flatpickr.l10ns.default, l10n);
+  };
+
+  flatpickr.setDefaults = function (config) {
+    flatpickr.defaultConfig = Object.assign({}, flatpickr.defaultConfig, config);
+  };
+
+  flatpickr.parseDate = createDateParser({});
+  flatpickr.formatDate = createDateFormatter({});
+  flatpickr.compareDates = compareDates;
+
+  if (typeof jQuery !== "undefined") {
+    jQuery.fn.flatpickr = function (config) {
+      return _flatpickr(this, config);
+    };
+  }
+
+  Date.prototype.fp_incr = function (days) {
+    return new Date(this.getFullYear(), this.getMonth(), this.getDate() + (typeof days === "string" ? parseInt(days, 10) : days));
+  };
+
+  if (typeof window !== "undefined") {
+    window.flatpickr = flatpickr;
+  }
+
+  return flatpickr;
 });
 
 /***/ }),
-/* 435 */
+/* 434 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VLoads; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_urls__ = __webpack_require__(187);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__action_parameter__ = __webpack_require__(83);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__action_parameter__ = __webpack_require__(84);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -50923,15 +50960,15 @@ var VLoads = function (_VUrls) {
 }(__WEBPACK_IMPORTED_MODULE_0__utils_urls__["a" /* VUrls */]);
 
 /***/ }),
-/* 436 */
+/* 435 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPosts; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(84);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(64);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(83);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(441);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(85);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(65);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(84);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(440);
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -51267,32 +51304,32 @@ var VPosts = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
+/* 436 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(437);
+
+/***/ }),
 /* 437 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(438);
-
-/***/ }),
-/* 438 */
-/***/ (function(module, exports, __webpack_require__) {
-
+__webpack_require__(438);
 __webpack_require__(439);
-__webpack_require__(440);
 var entryUnbind = __webpack_require__(184);
 
 module.exports = entryUnbind('Array', 'flatMap');
 
 /***/ }),
-/* 439 */
+/* 438 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var $ = __webpack_require__(163);
+var $ = __webpack_require__(164);
 var flattenIntoArray = __webpack_require__(176);
 var toObject = __webpack_require__(180);
-var toLength = __webpack_require__(82);
+var toLength = __webpack_require__(83);
 var aFunction = __webpack_require__(179);
 var arraySpeciesCreate = __webpack_require__(181);
 
@@ -51305,13 +51342,13 @@ $({ target: 'Array', proto: true }, {
     var A;
     aFunction(callbackfn);
     A = arraySpeciesCreate(O, 0);
-    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments[1]);
     return A;
   }
 });
 
 /***/ }),
-/* 440 */
+/* 439 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -51321,7 +51358,7 @@ var addToUnscopables = __webpack_require__(183);
 addToUnscopables('flatMap');
 
 /***/ }),
-/* 441 */
+/* 440 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -51335,15 +51372,15 @@ function encode(value) {
 }
 
 /***/ }),
-/* 442 */
+/* 441 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VReplaces; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(83);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base__ = __webpack_require__(84);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__initialize__ = __webpack_require__(161);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__uninitialize__ = __webpack_require__(443);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(84);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base__ = __webpack_require__(85);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__initialize__ = __webpack_require__(162);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__uninitialize__ = __webpack_require__(442);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
@@ -51510,7 +51547,7 @@ var VReplaces = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */]);
 
 /***/ }),
-/* 443 */
+/* 442 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -51525,7 +51562,7 @@ function uninitialize(root) {
 }
 
 /***/ }),
-/* 444 */
+/* 443 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -55880,7 +55917,7 @@ function uninitialize(root) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 445 */
+/* 444 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -55962,12 +55999,12 @@ var VToggleVisibility = function () {
 }();
 
 /***/ }),
-/* 446 */
+/* 445 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPromptIfDirty; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(84);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(85);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialog__ = __webpack_require__(189);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -56082,12 +56119,12 @@ var VPromptIfDirty = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 447 */
+/* 446 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VSnackbarEvent; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(83);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(84);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -56124,7 +56161,7 @@ var VSnackbarEvent = function () {
 }();
 
 /***/ }),
-/* 448 */
+/* 447 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56190,7 +56227,7 @@ var VClears = function () {
 }();
 
 /***/ }),
-/* 449 */
+/* 448 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56251,12 +56288,12 @@ var VRemoves = function () {
 }();
 
 /***/ }),
-/* 450 */
+/* 449 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VStepperEvent; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(84);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(85);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -56299,7 +56336,7 @@ var VStepperEvent = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 451 */
+/* 450 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56336,7 +56373,7 @@ var VNavigates = function () {
 }();
 
 /***/ }),
-/* 452 */
+/* 451 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56371,7 +56408,7 @@ var VPluginEventAction = function () {
 }();
 
 /***/ }),
-/* 453 */
+/* 452 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56386,7 +56423,7 @@ function getRoot(element) {
 }
 
 /***/ }),
-/* 454 */
+/* 453 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56597,14 +56634,14 @@ function initLists(e) {
 }
 
 /***/ }),
-/* 455 */
+/* 454 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDrawer;
 /* unused harmony export VModalDrawer */
 /* unused harmony export VDismissibleDrawer */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(456);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(455);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_drawer__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
@@ -56684,7 +56721,7 @@ var VDismissibleDrawer = function (_VDrawer2) {
 }(VDrawer);
 
 /***/ }),
-/* 456 */
+/* 455 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -60011,13 +60048,13 @@ var VDismissibleDrawer = function (_VDrawer2) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 457 */
+/* 456 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initHeader;
 /* unused harmony export VHeader */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(458);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(457);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -60056,19 +60093,19 @@ var VHeader = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 458 */
+/* 457 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCTopAppBar; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(62);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(63);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(190);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(459);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(63);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(85);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(462);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(463);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(464);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(458);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(86);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(461);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(462);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(463);
 /* unused harmony reexport MDCTopAppBarBaseFoundation */
 /* unused harmony reexport MDCTopAppBarFoundation */
 /* unused harmony reexport MDCFixedTopAppBarFoundation */
@@ -60275,7 +60312,7 @@ var MDCTopAppBar = function (_MDCComponent) {
 
 
 /***/ }),
-/* 459 */
+/* 458 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -60283,7 +60320,7 @@ var MDCTopAppBar = function (_MDCComponent) {
 /* unused harmony export RippleCapableSurface */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(190);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(191);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(460);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(459);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(192);
 /* unused harmony reexport MDCRippleFoundation */
 /* unused harmony reexport util */
@@ -60532,13 +60569,13 @@ RippleCapableSurface.prototype.disabled;
 
 
 /***/ }),
-/* 460 */
+/* 459 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(124);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(191);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(461);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(460);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(192);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -61319,7 +61356,7 @@ var MDCRippleFoundation = function (_MDCFoundation) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCRippleFoundation);
 
 /***/ }),
-/* 461 */
+/* 460 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -61380,13 +61417,13 @@ var numbers = {
 
 
 /***/ }),
-/* 462 */
+/* 461 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(63);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(62);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(85);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(86);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -61492,13 +61529,13 @@ var MDCFixedTopAppBarFoundation = function (_MDCTopAppBarFoundati) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCFixedTopAppBarFoundation);
 
 /***/ }),
-/* 463 */
+/* 462 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(62);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(85);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(86);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(64);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -61614,13 +61651,13 @@ var MDCShortTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCShortTopAppBarFoundation);
 
 /***/ }),
-/* 464 */
+/* 463 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(62);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(85);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(86);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(64);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -61887,15 +61924,15 @@ var MDCTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCTopAppBarFoundation);
 
 /***/ }),
-/* 465 */
+/* 464 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initIconToggles;
 /* unused harmony export VIconToggle */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(86);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(466);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(87);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(465);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -61925,7 +61962,7 @@ var VIconToggle = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 466 */
+/* 465 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -64711,16 +64748,17 @@ var VIconToggle = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 467 */
+/* 466 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSelects;
 /* unused harmony export VSelect */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(468);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(467);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_select__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__ = __webpack_require__(121);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__ = __webpack_require__(122);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_dirtyable__ = __webpack_require__(48);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -64733,13 +64771,14 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+
 function initSelects(e) {
     console.debug('\tSelects');
     Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-select', VSelect, __WEBPACK_IMPORTED_MODULE_0__material_select__["MDCSelect"]);
 }
 
-var VSelect = function (_visibilityObserverMi) {
-    _inherits(VSelect, _visibilityObserverMi);
+var VSelect = function (_dirtyableMixin) {
+    _inherits(VSelect, _dirtyableMixin);
 
     function VSelect(element, mdcComponent) {
         _classCallCheck(this, VSelect);
@@ -64749,6 +64788,7 @@ var VSelect = function (_visibilityObserverMi) {
         _this.select = element.querySelector('select');
         _this.select.vComponent = _this;
         _this.recalcWhenVisible(_this);
+        _this.originalValue = _this.value();
         return _this;
     }
 
@@ -64784,7 +64824,7 @@ var VSelect = function (_visibilityObserverMi) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.select.value = this.element.dataset.originalValue;
+            this.select.value = this.originalValue;
         }
     }, {
         key: 'setValue',
@@ -64794,15 +64834,15 @@ var VSelect = function (_visibilityObserverMi) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.value() != this.element.dataset.originalValue;
+            return this.dirtyable && this.value() !== this.originalValue;
         }
     }]);
 
     return VSelect;
-}(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
+}(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 468 */
+/* 467 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -75034,7 +75074,7 @@ var VSelect = function (_visibilityObserverMi) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 469 */
+/* 468 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75121,7 +75161,7 @@ var VChipSet = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 470 */
+/* 469 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75156,7 +75196,7 @@ var VCard = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 471 */
+/* 470 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75193,13 +75233,13 @@ var VForm = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 472 */
+/* 471 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSnackbar;
 /* unused harmony export VSnackbar */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(473);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(472);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_snackbar__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -75248,7 +75288,7 @@ var VSnackbar = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 473 */
+/* 472 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -76782,18 +76822,16 @@ var VSnackbar = function (_VBaseComponent) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 474 */
+/* 473 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initCheckboxes;
 /* unused harmony export VCheckbox */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(86);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(475);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(87);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(474);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_checkbox__);
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -76821,23 +76859,11 @@ var VCheckbox = function (_VBaseToggle) {
         return _this;
     }
 
-    _createClass(VCheckbox, [{
-        key: 'isDirty',
-        value: function isDirty() {
-            // If the checkbox is cannot be dirtied, it is never dirty.
-            if (!this.element.hasAttribute('data-original-value')) {
-                return false;
-            }
-
-            return String(this.input.checked) != this.element.dataset.originalValue;
-        }
-    }]);
-
     return VCheckbox;
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 475 */
+/* 474 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -79953,18 +79979,16 @@ var VCheckbox = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 476 */
+/* 475 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSwitches;
 /* unused harmony export VSwitch */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(86);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(477);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(87);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(476);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_switch__);
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -79989,18 +80013,11 @@ var VSwitch = function (_VBaseToggle) {
         return _possibleConstructorReturn(this, (VSwitch.__proto__ || Object.getPrototypeOf(VSwitch)).call(this, element, mdcComponent));
     }
 
-    _createClass(VSwitch, [{
-        key: 'isDirty',
-        value: function isDirty() {
-            return String(this.input.checked) != this.element.dataset.originalValue;
-        }
-    }]);
-
     return VSwitch;
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 477 */
+/* 476 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -82645,7 +82662,7 @@ var VSwitch = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 478 */
+/* 477 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -82653,9 +82670,10 @@ var VSwitch = function (_VBaseToggle) {
 /* unused harmony export VRichTextArea */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(194);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(483);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(482);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__ = __webpack_require__(48);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -82663,6 +82681,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 
 
 
@@ -82681,8 +82700,8 @@ function initRichTextArea(e) {
     registerBlots();
 }
 
-var VRichTextArea = function (_eventHandlerMixin) {
-    _inherits(VRichTextArea, _eventHandlerMixin);
+var VRichTextArea = function (_dirtyableMixin) {
+    _inherits(VRichTextArea, _dirtyableMixin);
 
     function VRichTextArea(element, mdcComponent) {
         _classCallCheck(this, VRichTextArea);
@@ -82695,7 +82714,7 @@ var VRichTextArea = function (_eventHandlerMixin) {
             theme: 'snow',
             placeholder: _this.quillEditorElement.dataset.placeholder
         });
-        _this.element.dataset.originalValue = _this.value();
+        _this.originalValue = _this.value();
 
         hookupCustomToolbarButtons(_this);
         return _this;
@@ -82714,8 +82733,8 @@ var VRichTextArea = function (_eventHandlerMixin) {
     }, {
         key: "value",
         value: function value() {
-            // If the quill editor is empty calling innerHTML will still return '<p><br/></p>' which it
-            // uses to represent an empty doc.
+            // If the quill editor is empty calling innerHTML will still return
+            // '<p><br/></p>' which it uses to represent an empty doc.
             var doc = this.quill.root.innerHTML;
             return doc == QUILL_EMPTY_DOC ? '' : doc;
         }
@@ -82729,7 +82748,7 @@ var VRichTextArea = function (_eventHandlerMixin) {
     }, {
         key: "reset",
         value: function reset() {
-            this.setValue(this.element.dataset.originalValue);
+            this.setValue(this.originalValue);
         }
     }, {
         key: "setValue",
@@ -82739,12 +82758,12 @@ var VRichTextArea = function (_eventHandlerMixin) {
     }, {
         key: "isDirty",
         value: function isDirty() {
-            return this.value() !== this.element.dataset.originalValue;
+            return this.dirtyable && this.value().localeCompare(this.originalValue) !== 0;
         }
     }]);
 
     return VRichTextArea;
-}(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
+}(Object(__WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */])));
 
 var blotRegistry = new WeakSet();
 
@@ -82881,7 +82900,7 @@ function configureQuill() {
 }
 
 /***/ }),
-/* 479 */
+/* 478 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -82895,9 +82914,9 @@ function configureQuill() {
 
 
 
-var base64 = __webpack_require__(480);
-var ieee754 = __webpack_require__(481);
-var isArray = __webpack_require__(482);
+var base64 = __webpack_require__(479);
+var ieee754 = __webpack_require__(480);
+var isArray = __webpack_require__(481);
 
 exports.Buffer = Buffer;
 exports.SlowBuffer = SlowBuffer;
@@ -84622,10 +84641,10 @@ function blitBuffer(src, dst, offset, length) {
 function isnan(val) {
   return val !== val; // eslint-disable-line no-self-compare
 }
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(65)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(66)))
 
 /***/ }),
-/* 480 */
+/* 479 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -84752,7 +84771,7 @@ function fromByteArray(uint8) {
 }
 
 /***/ }),
-/* 481 */
+/* 480 */
 /***/ (function(module, exports) {
 
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
@@ -84841,7 +84860,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 };
 
 /***/ }),
-/* 482 */
+/* 481 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -84851,7 +84870,7 @@ module.exports = Array.isArray || function (arr) {
 };
 
 /***/ }),
-/* 483 */
+/* 482 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -84906,7 +84925,7 @@ var HorizontalRuleBlot = function (_Embed) {
 }(Embed);;
 
 /***/ }),
-/* 484 */
+/* 483 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -84986,18 +85005,16 @@ var VStepper = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 485 */
+/* 484 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRadios;
 /* unused harmony export VRadio */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(86);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(486);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(87);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(485);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_radio__);
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -85022,18 +85039,11 @@ var VRadio = function (_VBaseToggle) {
         return _possibleConstructorReturn(this, (VRadio.__proto__ || Object.getPrototypeOf(VRadio)).call(this, element, mdcComponent));
     }
 
-    _createClass(VRadio, [{
-        key: 'isDirty',
-        value: function isDirty() {
-            return String(this.input.checked) != this.element.dataset.originalValue;
-        }
-    }]);
-
     return VRadio;
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 486 */
+/* 485 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -87610,7 +87620,7 @@ var VRadio = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 487 */
+/* 486 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -87618,10 +87628,11 @@ var VRadio = function (_VBaseToggle) {
 /* unused harmony export VSlider */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(488);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(487);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_slider__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(121);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(122);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(122);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__mixins_dirtyable__ = __webpack_require__(48);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -87638,13 +87649,14 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+
 function initSliders(e) {
     console.debug('\tSliders');
     Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-slider', VSlider, __WEBPACK_IMPORTED_MODULE_2__material_slider__["MDCSlider"]);
 }
 
-var VSlider = function (_visibilityObserverMi) {
-    _inherits(VSlider, _visibilityObserverMi);
+var VSlider = function (_dirtyableMixin) {
+    _inherits(VSlider, _dirtyableMixin);
 
     function VSlider(element, mdcComponent) {
         _classCallCheck(this, VSlider);
@@ -87652,6 +87664,7 @@ var VSlider = function (_visibilityObserverMi) {
         var _this = _possibleConstructorReturn(this, (VSlider.__proto__ || Object.getPrototypeOf(VSlider)).call(this, element, mdcComponent));
 
         _this.recalcWhenVisible(_this);
+        _this.originalValue = _this.value();
         return _this;
     }
 
@@ -87678,7 +87691,7 @@ var VSlider = function (_visibilityObserverMi) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.setValue(this.element.dataset.originalValue);
+            this.setValue(this.originalValue);
         }
     }, {
         key: 'setValue',
@@ -87688,7 +87701,7 @@ var VSlider = function (_visibilityObserverMi) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.value() != this.element.dataset.originalValue;
+            return this.dirtyable && this.value() !== this.originalValue;
         }
     }, {
         key: 'initEventListener',
@@ -87712,10 +87725,10 @@ var VSlider = function (_visibilityObserverMi) {
     }]);
 
     return VSlider;
-}(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
+}(Object(__WEBPACK_IMPORTED_MODULE_5__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]))));
 
 /***/ }),
-/* 488 */
+/* 487 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -89785,13 +89798,14 @@ var VSlider = function (_visibilityObserverMi) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 489 */
+/* 488 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initHiddenFields;
 /* unused harmony export VHiddenField */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_dirtyable__ = __webpack_require__(48);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -89802,18 +89816,22 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+
 function initHiddenFields(e) {
     console.debug('\tHiddenFields');
     Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-hidden-field', VHiddenField, null);
 }
 
-var VHiddenField = function (_VBaseComponent) {
-    _inherits(VHiddenField, _VBaseComponent);
+var VHiddenField = function (_dirtyableMixin) {
+    _inherits(VHiddenField, _dirtyableMixin);
 
     function VHiddenField(element, mdcComponent) {
         _classCallCheck(this, VHiddenField);
 
-        return _possibleConstructorReturn(this, (VHiddenField.__proto__ || Object.getPrototypeOf(VHiddenField)).call(this, element, mdcComponent));
+        var _this = _possibleConstructorReturn(this, (VHiddenField.__proto__ || Object.getPrototypeOf(VHiddenField)).call(this, element, mdcComponent));
+
+        _this.originalValue = _this.value();
+        return _this;
     }
 
     // Called to collect data for submission
@@ -89842,7 +89860,7 @@ var VHiddenField = function (_VBaseComponent) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.element.value = this.element.dataset.originalValue;
+            this.element.value = this.originalValue;
         }
     }, {
         key: 'setValue',
@@ -89852,15 +89870,15 @@ var VHiddenField = function (_VBaseComponent) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.value() != this.element.dataset.originalValue;
+            return this.dirtyable && this.value() !== this.originalValue;
         }
     }]);
 
     return VHiddenField;
-}(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]);
+}(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_dirtyable__["a" /* dirtyableMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 490 */
+/* 489 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -89897,7 +89915,7 @@ var VContent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 491 */
+/* 490 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -89948,7 +89966,7 @@ var VColumn = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 492 */
+/* 491 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -89956,7 +89974,7 @@ var VColumn = function (_eventHandlerMixin2) {
 /* unused harmony export VTabBar */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(493);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(492);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_tab_bar__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -89986,7 +90004,7 @@ var VTabBar = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 493 */
+/* 492 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -96458,7 +96476,7 @@ var VTabBar = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 494 */
+/* 493 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -96588,7 +96606,7 @@ function initTables(e) {
 }
 
 /***/ }),
-/* 495 */
+/* 494 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -96596,6 +96614,7 @@ function initTables(e) {
 /* unused harmony export VFileInput */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__ = __webpack_require__(48);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -96607,13 +96626,14 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+
 function initFileInputs(e) {
     console.debug('\tFile Inputs');
     Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-file-input', VFileInput, null);
 }
 
-var VFileInput = function (_eventHandlerMixin) {
-    _inherits(VFileInput, _eventHandlerMixin);
+var VFileInput = function (_dirtyableMixin) {
+    _inherits(VFileInput, _dirtyableMixin);
 
     function VFileInput(element, mdcComponent) {
         _classCallCheck(this, VFileInput);
@@ -96628,6 +96648,7 @@ var VFileInput = function (_eventHandlerMixin) {
                 return _this.handleFileSelection(e);
             }, false);
         });
+        _this.originalValue = _this.input.value;
         return _this;
     }
 
@@ -96705,7 +96726,7 @@ var VFileInput = function (_eventHandlerMixin) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.input.value != this.element.dataset.originalValue;
+            return this.dirtyable && this.input.value !== this.originalValue;
         }
 
         // From an example based on: https://www.quirksmode.org/dom/inputfile.html
@@ -96718,10 +96739,10 @@ var VFileInput = function (_eventHandlerMixin) {
     }]);
 
     return VFileInput;
-}(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
+}(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 496 */
+/* 495 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -96729,7 +96750,7 @@ var VFileInput = function (_eventHandlerMixin) {
 /* unused harmony export VFormField */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(47);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(497);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(496);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_form_field__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -96761,7 +96782,7 @@ var VFormField = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 497 */
+/* 496 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -99266,7 +99287,7 @@ var VFormField = function (_VBaseContainer) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 498 */
+/* 497 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99311,7 +99332,7 @@ var VImage = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 499 */
+/* 498 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99361,7 +99382,7 @@ var VTypography = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 500 */
+/* 499 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99399,7 +99420,7 @@ var VTooltip = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 501 */
+/* 500 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99516,14 +99537,14 @@ var VPluginComponent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 502 */
+/* 501 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initProgress;
 /* unused harmony export VProgress */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__ = __webpack_require__(503);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__ = __webpack_require__(502);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -99574,11 +99595,11 @@ var VProgress = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 503 */
+/* 502 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(504);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(503);
 /* harmony namespace reexport (by used) */ __webpack_require__.d(__webpack_exports__, "a", function() { return __WEBPACK_IMPORTED_MODULE_0__component__["a"]; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(196);
 /* unused harmony namespace reexport */
@@ -99609,13 +99630,13 @@ var VProgress = function (_VBaseComponent) {
 //# sourceMappingURL=index.js.map
 
 /***/ }),
-/* 504 */
+/* 503 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgress; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(124);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(505);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(504);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(196);
 /**
  * @license
@@ -99716,12 +99737,12 @@ var MDCLinearProgress = /** @class */function (_super) {
 //# sourceMappingURL=component.js.map
 
 /***/ }),
-/* 505 */
+/* 504 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCComponent; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(124);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(195);
 /**
  * @license
@@ -99827,7 +99848,7 @@ var MDCComponent = /** @class */function () {
 //# sourceMappingURL=component.js.map
 
 /***/ }),
-/* 506 */
+/* 505 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99920,7 +99941,7 @@ function getCorrectEventName(windowObj, eventType) {
 //# sourceMappingURL=util.js.map
 
 /***/ }),
-/* 507 */
+/* 506 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99960,7 +99981,7 @@ var strings = {
 //# sourceMappingURL=constants.js.map
 
 /***/ }),
-/* 508 */
+/* 507 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";

--- a/public/wc.js
+++ b/public/wc.js
@@ -71,7 +71,7 @@
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseComponent; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = hookupComponents;
 /* harmony export (immutable) */ __webpack_exports__["c"] = unhookupComponents;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_errors__ = __webpack_require__(20);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_errors__ = __webpack_require__(21);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -359,7 +359,7 @@ module.exports =
 check((typeof globalThis === 'undefined' ? 'undefined' : _typeof(globalThis)) == O && globalThis) || check((typeof window === 'undefined' ? 'undefined' : _typeof(window)) == O && window) || check((typeof self === 'undefined' ? 'undefined' : _typeof(self)) == O && self) || check((typeof global === 'undefined' ? 'undefined' : _typeof(global)) == O && global) ||
 // eslint-disable-next-line no-new-func
 Function('return this')();
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6)))
 
 /***/ }),
 /* 4 */
@@ -600,6 +600,59 @@ var VBaseContainer = function (_VBaseComponent) {
 
 /***/ }),
 /* 5 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return dirtyableMixin; });
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var dirtyableMixin = function dirtyableMixin(Base) {
+    return function (_Base) {
+        _inherits(_class, _Base);
+
+        function _class() {
+            _classCallCheck(this, _class);
+
+            return _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).apply(this, arguments));
+        }
+
+        _createClass(_class, [{
+            key: 'isDirty',
+            value: function isDirty() {
+                // Implement in extending classes.
+                throw new Error('Implement isDirty()');
+            }
+        }, {
+            key: 'originalValue',
+            get: function get() {
+                return this._originalValue;
+            },
+            set: function set(value) {
+                this._originalValue = value;
+            }
+        }, {
+            key: 'dirtyable',
+            get: function get() {
+                if (!this.element) {
+                    return false;
+                }
+
+                return this.element.hasAttribute('data-dirtyable');
+            }
+        }]);
+
+        return _class;
+    }(Base);
+};
+
+/***/ }),
+/* 6 */
 /***/ (function(module, exports) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -626,10 +679,10 @@ try {
 module.exports = g;
 
 /***/ }),
-/* 6 */
+/* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var fails = __webpack_require__(7);
+var fails = __webpack_require__(8);
 
 // Thank's IE8 for his funny defineProperty
 module.exports = !fails(function () {
@@ -639,7 +692,7 @@ module.exports = !fails(function () {
 });
 
 /***/ }),
-/* 7 */
+/* 8 */
 /***/ (function(module, exports) {
 
 module.exports = function (exec) {
@@ -651,7 +704,7 @@ module.exports = function (exec) {
 };
 
 /***/ }),
-/* 8 */
+/* 9 */
 /***/ (function(module, exports) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -661,7 +714,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 9 */
+/* 10 */
 /***/ (function(module, exports) {
 
 var hasOwnProperty = {}.hasOwnProperty;
@@ -671,12 +724,12 @@ module.exports = function (it, key) {
 };
 
 /***/ }),
-/* 10 */
+/* 11 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(6);
-var definePropertyModule = __webpack_require__(22);
-var createPropertyDescriptor = __webpack_require__(35);
+var DESCRIPTORS = __webpack_require__(7);
+var definePropertyModule = __webpack_require__(23);
+var createPropertyDescriptor = __webpack_require__(36);
 
 module.exports = DESCRIPTORS ? function (object, key, value) {
   return definePropertyModule.f(object, key, createPropertyDescriptor(1, value));
@@ -686,7 +739,7 @@ module.exports = DESCRIPTORS ? function (object, key, value) {
 };
 
 /***/ }),
-/* 11 */
+/* 12 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -852,7 +905,7 @@ var MDCTopAppBarAdapter = function () {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCTopAppBarAdapter);
 
 /***/ }),
-/* 12 */
+/* 13 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -909,10 +962,10 @@ var strings = {
 
 
 /***/ }),
-/* 13 */
+/* 14 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(8);
+var isObject = __webpack_require__(9);
 
 module.exports = function (it) {
   if (!isObject(it)) {
@@ -921,11 +974,11 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 14 */
+/* 15 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
-var setGlobal = __webpack_require__(23);
+var setGlobal = __webpack_require__(24);
 var IS_PURE = __webpack_require__(77);
 
 var SHARED = '__core-js_shared__';
@@ -940,10 +993,10 @@ var store = global[SHARED] || setGlobal(SHARED, {});
 });
 
 /***/ }),
-/* 15 */
+/* 16 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toInteger = __webpack_require__(25);
+var toInteger = __webpack_require__(26);
 
 var min = Math.min;
 
@@ -954,7 +1007,7 @@ module.exports = function (argument) {
 };
 
 /***/ }),
-/* 16 */
+/* 17 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -1065,16 +1118,16 @@ function expandParams(results, params) {
 }
 
 /***/ }),
-/* 17 */
+/* 18 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(32);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(33);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(101);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(100);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(20);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(21);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(58);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -1281,13 +1334,13 @@ var VBase = function (_VUrls) {
 }(__WEBPACK_IMPORTED_MODULE_3__utils_urls__["a" /* VUrls */]);
 
 /***/ }),
-/* 18 */
+/* 19 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(12);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(29);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(13);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(30);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -1435,13 +1488,14 @@ var MDCTopAppBarBaseFoundation = function (_MDCFoundation) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCTopAppBarBaseFoundation);
 
 /***/ }),
-/* 19 */
+/* 20 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseToggle; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__ = __webpack_require__(5);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -1453,8 +1507,9 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
-var VBaseToggle = function (_eventHandlerMixin) {
-    _inherits(VBaseToggle, _eventHandlerMixin);
+
+var VBaseToggle = function (_dirtyableMixin) {
+    _inherits(VBaseToggle, _dirtyableMixin);
 
     function VBaseToggle(element, mdcComponent) {
         _classCallCheck(this, VBaseToggle);
@@ -1467,6 +1522,8 @@ var VBaseToggle = function (_eventHandlerMixin) {
             // Revert to previous checked state on failed post.
             _this.mdcComponent.checked = !_this.mdcComponent.checked;
         });
+
+        _this.originalValue = _this.input.checked;
         return _this;
     }
 
@@ -1505,25 +1562,30 @@ var VBaseToggle = function (_eventHandlerMixin) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.input.checked = this.element.dataset.originalValue;
+            this.input.checked = this.originalValue;
         }
     }, {
         key: 'setValue',
         value: function setValue(value) {
             this.input.value = value;
         }
+    }, {
+        key: 'isDirty',
+        value: function isDirty() {
+            return this.dirtyable && this.input.checked !== this.originalValue;
+        }
     }]);
 
     return VBaseToggle;
-}(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
+}(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 20 */
+/* 21 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VErrors; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(32);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(33);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
@@ -1811,30 +1873,28 @@ var VErrors = function () {
 }();
 
 /***/ }),
-/* 21 */
+/* 22 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // toObject with fallback for non-array-like ES3 strings
 var IndexedObject = __webpack_require__(75);
-var requireObjectCoercible = __webpack_require__(37);
+var requireObjectCoercible = __webpack_require__(38);
 
 module.exports = function (it) {
   return IndexedObject(requireObjectCoercible(it));
 };
 
 /***/ }),
-/* 22 */
+/* 23 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(6);
-var IE8_DOM_DEFINE = __webpack_require__(39);
-var anObject = __webpack_require__(13);
-var toPrimitive = __webpack_require__(38);
+var DESCRIPTORS = __webpack_require__(7);
+var IE8_DOM_DEFINE = __webpack_require__(40);
+var anObject = __webpack_require__(14);
+var toPrimitive = __webpack_require__(39);
 
 var nativeDefineProperty = Object.defineProperty;
 
-// `Object.defineProperty` method
-// https://tc39.github.io/ecma262/#sec-object.defineproperty
 exports.f = DESCRIPTORS ? nativeDefineProperty : function defineProperty(O, P, Attributes) {
   anObject(O);
   P = toPrimitive(P, true);
@@ -1848,11 +1908,11 @@ exports.f = DESCRIPTORS ? nativeDefineProperty : function defineProperty(O, P, A
 };
 
 /***/ }),
-/* 23 */
+/* 24 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
-var hide = __webpack_require__(10);
+var hide = __webpack_require__(11);
 
 module.exports = function (key, value) {
   try {
@@ -1863,13 +1923,13 @@ module.exports = function (key, value) {
 };
 
 /***/ }),
-/* 24 */
+/* 25 */
 /***/ (function(module, exports) {
 
 module.exports = {};
 
 /***/ }),
-/* 25 */
+/* 26 */
 /***/ (function(module, exports) {
 
 var ceil = Math.ceil;
@@ -1882,14 +1942,14 @@ module.exports = function (argument) {
 };
 
 /***/ }),
-/* 26 */
+/* 27 */
 /***/ (function(module, exports) {
 
 // IE8- don't enum bug keys
 module.exports = ['constructor', 'hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable', 'toLocaleString', 'toString', 'valueOf'];
 
 /***/ }),
-/* 27 */
+/* 28 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -1951,27 +2011,27 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 };
 
 /***/ }),
-/* 28 */
+/* 29 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VEvents; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = initEvents;
 /* harmony export (immutable) */ __webpack_exports__["c"] = removeEvents;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(99);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(100);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(106);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(98);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(99);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(105);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(60);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(20);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(109);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(110);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(111);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(112);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(113);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(114);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(115);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(116);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(117);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(21);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(108);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(109);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(110);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(111);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(112);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(113);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(114);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(115);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(116);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -2296,7 +2356,7 @@ function fireAfterLoad(e) {
 }
 
 /***/ }),
-/* 29 */
+/* 30 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -2405,7 +2465,7 @@ var MDCFoundation = function () {
 /* harmony default export */ __webpack_exports__["a"] = (MDCFoundation);
 
 /***/ }),
-/* 30 */
+/* 31 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -2734,45 +2794,45 @@ function __importDefault(mod) {
 }
 
 /***/ }),
-/* 31 */
+/* 32 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initialize;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(70);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(94);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(96);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(93);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(95);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(56);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(28);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(118);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(119);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(121);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(129);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(29);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(117);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(118);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(120);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(128);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(59);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(131);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(133);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(134);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(135);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(136);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(138);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(140);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(142);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(148);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(149);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(151);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(153);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(154);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(155);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(156);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(158);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(159);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(160);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(162);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(163);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(164);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(165);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(166);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(172);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(130);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(132);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(133);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(134);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(135);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(137);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(139);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(141);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(147);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(148);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(150);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(152);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(153);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(154);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(155);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(157);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(158);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(159);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(161);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(162);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(163);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(164);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(165);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(171);
 
 
 
@@ -2855,24 +2915,24 @@ function initialize(root, setRoot) {
 }
 
 /***/ }),
-/* 32 */
+/* 33 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(72);
 
 /***/ }),
-/* 33 */
+/* 34 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var global = __webpack_require__(3);
-var getOwnPropertyDescriptor = __webpack_require__(34).f;
-var hide = __webpack_require__(10);
+var getOwnPropertyDescriptor = __webpack_require__(35).f;
+var hide = __webpack_require__(11);
 var redefine = __webpack_require__(76);
-var setGlobal = __webpack_require__(23);
+var setGlobal = __webpack_require__(24);
 var copyConstructorProperties = __webpack_require__(80);
-var isForced = __webpack_require__(87);
+var isForced = __webpack_require__(86);
 
 /*
   options.target      - name of the target object
@@ -2922,21 +2982,19 @@ module.exports = function (options, source) {
 };
 
 /***/ }),
-/* 34 */
+/* 35 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(6);
+var DESCRIPTORS = __webpack_require__(7);
 var propertyIsEnumerableModule = __webpack_require__(74);
-var createPropertyDescriptor = __webpack_require__(35);
-var toIndexedObject = __webpack_require__(21);
-var toPrimitive = __webpack_require__(38);
-var has = __webpack_require__(9);
-var IE8_DOM_DEFINE = __webpack_require__(39);
+var createPropertyDescriptor = __webpack_require__(36);
+var toIndexedObject = __webpack_require__(22);
+var toPrimitive = __webpack_require__(39);
+var has = __webpack_require__(10);
+var IE8_DOM_DEFINE = __webpack_require__(40);
 
 var nativeGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 
-// `Object.getOwnPropertyDescriptor` method
-// https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptor
 exports.f = DESCRIPTORS ? nativeGetOwnPropertyDescriptor : function getOwnPropertyDescriptor(O, P) {
   O = toIndexedObject(O);
   P = toPrimitive(P, true);
@@ -2947,7 +3005,7 @@ exports.f = DESCRIPTORS ? nativeGetOwnPropertyDescriptor : function getOwnProper
 };
 
 /***/ }),
-/* 35 */
+/* 36 */
 /***/ (function(module, exports) {
 
 module.exports = function (bitmap, value) {
@@ -2960,7 +3018,7 @@ module.exports = function (bitmap, value) {
 };
 
 /***/ }),
-/* 36 */
+/* 37 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -2970,7 +3028,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 37 */
+/* 38 */
 /***/ (function(module, exports) {
 
 // `RequireObjectCoercible` abstract operation
@@ -2981,31 +3039,30 @@ module.exports = function (it) {
 };
 
 /***/ }),
-/* 38 */
+/* 39 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(8);
+var isObject = __webpack_require__(9);
 
-// `ToPrimitive` abstract operation
-// https://tc39.github.io/ecma262/#sec-toprimitive
+// 7.1.1 ToPrimitive(input [, PreferredType])
 // instead of the ES6 spec version, we didn't implement @@toPrimitive case
 // and the second argument - flag - preferred type is a string
-module.exports = function (input, PREFERRED_STRING) {
-  if (!isObject(input)) return input;
+module.exports = function (it, S) {
+  if (!isObject(it)) return it;
   var fn, val;
-  if (PREFERRED_STRING && typeof (fn = input.toString) == 'function' && !isObject(val = fn.call(input))) return val;
-  if (typeof (fn = input.valueOf) == 'function' && !isObject(val = fn.call(input))) return val;
-  if (!PREFERRED_STRING && typeof (fn = input.toString) == 'function' && !isObject(val = fn.call(input))) return val;
+  if (S && typeof (fn = it.toString) == 'function' && !isObject(val = fn.call(it))) return val;
+  if (typeof (fn = it.valueOf) == 'function' && !isObject(val = fn.call(it))) return val;
+  if (!S && typeof (fn = it.toString) == 'function' && !isObject(val = fn.call(it))) return val;
   throw TypeError("Can't convert object to primitive value");
 };
 
 /***/ }),
-/* 39 */
+/* 40 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(6);
-var fails = __webpack_require__(7);
-var createElement = __webpack_require__(40);
+var DESCRIPTORS = __webpack_require__(7);
+var fails = __webpack_require__(8);
+var createElement = __webpack_require__(41);
 
 // Thank's IE8 for his funny defineProperty
 module.exports = !DESCRIPTORS && !fails(function () {
@@ -3017,34 +3074,34 @@ module.exports = !DESCRIPTORS && !fails(function () {
 });
 
 /***/ }),
-/* 40 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var global = __webpack_require__(3);
-var isObject = __webpack_require__(8);
-
-var document = global.document;
-// typeof document.createElement is 'object' in old IE
-var EXISTS = isObject(document) && isObject(document.createElement);
-
-module.exports = function (it) {
-  return EXISTS ? document.createElement(it) : {};
-};
-
-/***/ }),
 /* 41 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var shared = __webpack_require__(14);
+var global = __webpack_require__(3);
+var isObject = __webpack_require__(9);
 
-module.exports = shared('native-function-to-string', Function.toString);
+var document = global.document;
+// typeof document.createElement is 'object' in old IE
+var exist = isObject(document) && isObject(document.createElement);
+
+module.exports = function (it) {
+  return exist ? document.createElement(it) : {};
+};
 
 /***/ }),
 /* 42 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var shared = __webpack_require__(14);
-var uid = __webpack_require__(43);
+var shared = __webpack_require__(15);
+
+module.exports = shared('native-function-to-string', Function.toString);
+
+/***/ }),
+/* 43 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var shared = __webpack_require__(15);
+var uid = __webpack_require__(44);
 
 var keys = shared('keys');
 
@@ -3053,39 +3110,26 @@ module.exports = function (key) {
 };
 
 /***/ }),
-/* 43 */
+/* 44 */
 /***/ (function(module, exports) {
 
 var id = 0;
 var postfix = Math.random();
 
 module.exports = function (key) {
-  return 'Symbol(' + String(key === undefined ? '' : key) + ')_' + (++id + postfix).toString(36);
-};
-
-/***/ }),
-/* 44 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var path = __webpack_require__(82);
-var global = __webpack_require__(3);
-
-var aFunction = function aFunction(variable) {
-  return typeof variable == 'function' ? variable : undefined;
-};
-
-module.exports = function (namespace, method) {
-  return arguments.length < 2 ? aFunction(path[namespace]) || aFunction(global[namespace]) : path[namespace] && path[namespace][method] || global[namespace] && global[namespace][method];
+  return 'Symbol('.concat(key === undefined ? '' : key, ')_', (++id + postfix).toString(36));
 };
 
 /***/ }),
 /* 45 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var has = __webpack_require__(9);
-var toIndexedObject = __webpack_require__(21);
-var indexOf = __webpack_require__(84).indexOf;
-var hiddenKeys = __webpack_require__(24);
+var has = __webpack_require__(10);
+var toIndexedObject = __webpack_require__(22);
+var arrayIncludes = __webpack_require__(83);
+var hiddenKeys = __webpack_require__(25);
+
+var arrayIndexOf = arrayIncludes(false);
 
 module.exports = function (object, names) {
   var O = toIndexedObject(object);
@@ -3097,7 +3141,7 @@ module.exports = function (object, names) {
   } // Don't enum bug & hidden keys
   while (names.length > i) {
     if (has(O, key = names[i++])) {
-      ~indexOf(result, key) || result.push(key);
+      ~arrayIndexOf(result, key) || result.push(key);
     }
   }return result;
 };
@@ -3110,7 +3154,7 @@ module.exports = function (object, names) {
 
 
 var isArray = __webpack_require__(47);
-var toLength = __webpack_require__(15);
+var toLength = __webpack_require__(16);
 var bind = __webpack_require__(48);
 
 // `FlattenIntoArray` abstract operation
@@ -3145,7 +3189,7 @@ module.exports = flattenIntoArray;
 /* 47 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var classof = __webpack_require__(36);
+var classof = __webpack_require__(37);
 
 // `IsArray` abstract operation
 // https://tc39.github.io/ecma262/#sec-isarray
@@ -3200,7 +3244,7 @@ module.exports = function (it) {
 /* 50 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var requireObjectCoercible = __webpack_require__(37);
+var requireObjectCoercible = __webpack_require__(38);
 
 // `ToObject` abstract operation
 // https://tc39.github.io/ecma262/#sec-toobject
@@ -3212,7 +3256,7 @@ module.exports = function (argument) {
 /* 51 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(8);
+var isObject = __webpack_require__(9);
 var isArray = __webpack_require__(47);
 var wellKnownSymbol = __webpack_require__(52);
 
@@ -3237,9 +3281,9 @@ module.exports = function (originalArray, length) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
-var shared = __webpack_require__(14);
-var uid = __webpack_require__(43);
-var NATIVE_SYMBOL = __webpack_require__(88);
+var shared = __webpack_require__(15);
+var uid = __webpack_require__(44);
+var NATIVE_SYMBOL = __webpack_require__(87);
 
 var _Symbol = global.Symbol;
 var store = shared('wks');
@@ -3253,8 +3297,8 @@ module.exports = function (name) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var wellKnownSymbol = __webpack_require__(52);
-var create = __webpack_require__(90);
-var hide = __webpack_require__(10);
+var create = __webpack_require__(89);
+var hide = __webpack_require__(11);
 
 var UNSCOPABLES = wellKnownSymbol('unscopables');
 var ArrayPrototype = Array.prototype;
@@ -9705,7 +9749,8 @@ module.exports = function (CONSTRUCTOR, METHOD, length) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_textfield__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(27);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(28);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__ = __webpack_require__(5);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -9713,6 +9758,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 
 
 
@@ -9727,8 +9773,8 @@ function initTextFields(e) {
     Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-text-field', VTextField, __WEBPACK_IMPORTED_MODULE_0__material_textfield__["MDCTextField"]);
 }
 
-var VTextField = function (_visibilityObserverMi) {
-    _inherits(VTextField, _visibilityObserverMi);
+var VTextField = function (_dirtyableMixin) {
+    _inherits(VTextField, _dirtyableMixin);
 
     function VTextField(element, mdcComponent) {
         _classCallCheck(this, VTextField);
@@ -9747,6 +9793,8 @@ var VTextField = function (_visibilityObserverMi) {
                 _this.element.dispatchEvent(new Event(AFTER_INPUT_EVENT));
             }, AFTER_INPUT_TIMEOUT);
         });
+
+        _this.originalValue = _this.value();
         return _this;
     }
 
@@ -9843,7 +9891,7 @@ var VTextField = function (_visibilityObserverMi) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.input.value = this.element.dataset.originalValue;
+            this.input.value = this.originalValue;
         }
     }, {
         key: 'setValue',
@@ -9853,7 +9901,7 @@ var VTextField = function (_visibilityObserverMi) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.value() !== this.element.dataset.originalValue;
+            return this.dirtyable && this.value().localeCompare(this.originalValue) !== 0;
         }
     }, {
         key: 'onShow',
@@ -9884,14 +9932,14 @@ var VTextField = function (_visibilityObserverMi) {
     }]);
 
     return VTextField;
-}(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */])));
+}(Object(__WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]))));
 
 /***/ }),
 /* 57 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(98);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(97);
 
 
 /* harmony default export */ __webpack_exports__["a"] = (new __WEBPACK_IMPORTED_MODULE_0__utils_config__["a" /* default */]({
@@ -10049,11 +10097,11 @@ var VUrls = function () {
 /* harmony export (immutable) */ __webpack_exports__["b"] = uninitMenus;
 /* harmony export (immutable) */ __webpack_exports__["a"] = initMenus;
 /* unused harmony export VMenu */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(108);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(107);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_menu__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events__ = __webpack_require__(28);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events__ = __webpack_require__(29);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -10219,7 +10267,7 @@ var VDialog = function () {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__foundation__ = __webpack_require__(29);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__foundation__ = __webpack_require__(30);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -27265,7 +27313,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
     /******/)["default"]
   );
 });
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(143).Buffer, __webpack_require__(2)(module)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(142).Buffer, __webpack_require__(2)(module)))
 
 /***/ }),
 /* 66 */
@@ -27358,10 +27406,10 @@ var MDCFoundation = /** @class */function () {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgressFoundation; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(30);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(170);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(169);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(66);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(171);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(170);
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -27501,8 +27549,8 @@ module.exports = __webpack_require__(69);
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__components_initialize__ = __webpack_require__(31);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__webcomponents_webcomponentsjs_custom_elements_es5_adapter_js__ = __webpack_require__(173);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__components_initialize__ = __webpack_require__(32);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__webcomponents_webcomponentsjs_custom_elements_es5_adapter_js__ = __webpack_require__(172);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__webcomponents_webcomponentsjs_custom_elements_es5_adapter_js___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__webcomponents_webcomponentsjs_custom_elements_es5_adapter_js__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -27522,7 +27570,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 // Webcomponent polyfil
 window.WebComponents = window.WebComponents || {};
-window.WebComponents.root = __webpack_require__(174);
+window.WebComponents.root = __webpack_require__(173);
 
 function loadFont(src) {
     var lnk = document.createElement('link');
@@ -27584,7 +27632,7 @@ var FlowMatic = function (_HTMLElement) {
     return FlowMatic;
 }(HTMLElement);
 
-__webpack_require__(178);
+__webpack_require__(177);
 customElements.define('flow-matic', FlowMatic);
 
 /***/ }),
@@ -29649,7 +29697,7 @@ var VButton = function (_eventHandlerMixin) {
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(73);
-__webpack_require__(89);
+__webpack_require__(88);
 var entryUnbind = __webpack_require__(54);
 
 module.exports = entryUnbind('Array', 'flat');
@@ -29661,18 +29709,18 @@ module.exports = entryUnbind('Array', 'flat');
 "use strict";
 
 
-var $ = __webpack_require__(33);
+var $ = __webpack_require__(34);
 var flattenIntoArray = __webpack_require__(46);
 var toObject = __webpack_require__(50);
-var toLength = __webpack_require__(15);
-var toInteger = __webpack_require__(25);
+var toLength = __webpack_require__(16);
+var toInteger = __webpack_require__(26);
 var arraySpeciesCreate = __webpack_require__(51);
 
 // `Array.prototype.flat` method
 // https://github.com/tc39/proposal-flatMap
 $({ target: 'Array', proto: true }, {
   flat: function flat() /* depthArg = 1 */{
-    var depthArg = arguments.length ? arguments[0] : undefined;
+    var depthArg = arguments[0];
     var O = toObject(this);
     var sourceLen = toLength(O.length);
     var A = arraySpeciesCreate(O, 0);
@@ -29694,8 +29742,6 @@ var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 // Nashorn ~ JDK8 bug
 var NASHORN_BUG = getOwnPropertyDescriptor && !nativePropertyIsEnumerable.call({ 1: 2 }, 1);
 
-// `Object.prototype.propertyIsEnumerable` method implementation
-// https://tc39.github.io/ecma262/#sec-object.prototype.propertyisenumerable
 exports.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
   var descriptor = getOwnPropertyDescriptor(this, V);
   return !!descriptor && descriptor.enumerable;
@@ -29705,12 +29751,12 @@ exports.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
 /* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var fails = __webpack_require__(7);
-var classof = __webpack_require__(36);
+// fallback for non-array-like ES3 and non-enumerable old V8 strings
+var fails = __webpack_require__(8);
+var classof = __webpack_require__(37);
 
 var split = ''.split;
 
-// fallback for non-array-like ES3 and non-enumerable old V8 strings
 module.exports = fails(function () {
   // throws an error in rhino, see https://github.com/mozilla/rhino/issues/346
   // eslint-disable-next-line no-prototype-builtins
@@ -29724,11 +29770,11 @@ module.exports = fails(function () {
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
-var shared = __webpack_require__(14);
-var hide = __webpack_require__(10);
-var has = __webpack_require__(9);
-var setGlobal = __webpack_require__(23);
-var nativeFunctionToString = __webpack_require__(41);
+var shared = __webpack_require__(15);
+var hide = __webpack_require__(11);
+var has = __webpack_require__(10);
+var setGlobal = __webpack_require__(24);
+var nativeFunctionToString = __webpack_require__(42);
 var InternalStateModule = __webpack_require__(78);
 
 var getInternalState = InternalStateModule.get;
@@ -29773,11 +29819,11 @@ module.exports = false;
 
 var NATIVE_WEAK_MAP = __webpack_require__(79);
 var global = __webpack_require__(3);
-var isObject = __webpack_require__(8);
-var hide = __webpack_require__(10);
-var objectHas = __webpack_require__(9);
-var sharedKey = __webpack_require__(42);
-var hiddenKeys = __webpack_require__(24);
+var isObject = __webpack_require__(9);
+var hide = __webpack_require__(11);
+var objectHas = __webpack_require__(10);
+var sharedKey = __webpack_require__(43);
+var hiddenKeys = __webpack_require__(25);
 
 var WeakMap = global.WeakMap;
 var set, get, has;
@@ -29838,7 +29884,7 @@ module.exports = {
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
-var nativeFunctionToString = __webpack_require__(41);
+var nativeFunctionToString = __webpack_require__(42);
 
 var WeakMap = global.WeakMap;
 
@@ -29848,10 +29894,10 @@ module.exports = typeof WeakMap === 'function' && /native code/.test(nativeFunct
 /* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var has = __webpack_require__(9);
+var has = __webpack_require__(10);
 var ownKeys = __webpack_require__(81);
-var getOwnPropertyDescriptorModule = __webpack_require__(34);
-var definePropertyModule = __webpack_require__(22);
+var getOwnPropertyDescriptorModule = __webpack_require__(35);
+var definePropertyModule = __webpack_require__(23);
 
 module.exports = function (target, source) {
   var keys = ownKeys(source);
@@ -29867,13 +29913,15 @@ module.exports = function (target, source) {
 /* 81 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var getBuiltIn = __webpack_require__(44);
-var getOwnPropertyNamesModule = __webpack_require__(83);
-var getOwnPropertySymbolsModule = __webpack_require__(86);
-var anObject = __webpack_require__(13);
+var global = __webpack_require__(3);
+var getOwnPropertyNamesModule = __webpack_require__(82);
+var getOwnPropertySymbolsModule = __webpack_require__(85);
+var anObject = __webpack_require__(14);
+
+var Reflect = global.Reflect;
 
 // all object keys, includes non-enumerable and symbols
-module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
+module.exports = Reflect && Reflect.ownKeys || function ownKeys(it) {
   var keys = getOwnPropertyNamesModule.f(anObject(it));
   var getOwnPropertySymbols = getOwnPropertySymbolsModule.f;
   return getOwnPropertySymbols ? keys.concat(getOwnPropertySymbols(it)) : keys;
@@ -29883,33 +29931,30 @@ module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
 /* 82 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(3);
-
-/***/ }),
-/* 83 */
-/***/ (function(module, exports, __webpack_require__) {
-
+// 19.1.2.7 / 15.2.3.4 Object.getOwnPropertyNames(O)
 var internalObjectKeys = __webpack_require__(45);
-var enumBugKeys = __webpack_require__(26);
+var enumBugKeys = __webpack_require__(27);
 
 var hiddenKeys = enumBugKeys.concat('length', 'prototype');
 
-// `Object.getOwnPropertyNames` method
-// https://tc39.github.io/ecma262/#sec-object.getownpropertynames
 exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
   return internalObjectKeys(O, hiddenKeys);
 };
 
 /***/ }),
-/* 84 */
+/* 83 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toIndexedObject = __webpack_require__(21);
-var toLength = __webpack_require__(15);
-var toAbsoluteIndex = __webpack_require__(85);
+var toIndexedObject = __webpack_require__(22);
+var toLength = __webpack_require__(16);
+var toAbsoluteIndex = __webpack_require__(84);
 
 // `Array.prototype.{ indexOf, includes }` methods implementation
-var createMethod = function createMethod(IS_INCLUDES) {
+// false -> Array#indexOf
+// https://tc39.github.io/ecma262/#sec-array.prototype.indexof
+// true  -> Array#includes
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+module.exports = function (IS_INCLUDES) {
   return function ($this, el, fromIndex) {
     var O = toIndexedObject($this);
     var length = toLength(O.length);
@@ -29923,25 +29968,18 @@ var createMethod = function createMethod(IS_INCLUDES) {
       if (value != value) return true;
       // Array#indexOf ignores holes, Array#includes - not
     } else for (; length > index; index++) {
-      if ((IS_INCLUDES || index in O) && O[index] === el) return IS_INCLUDES || index || 0;
+      if (IS_INCLUDES || index in O) {
+        if (O[index] === el) return IS_INCLUDES || index || 0;
+      }
     }return !IS_INCLUDES && -1;
   };
 };
 
-module.exports = {
-  // `Array.prototype.includes` method
-  // https://tc39.github.io/ecma262/#sec-array.prototype.includes
-  includes: createMethod(true),
-  // `Array.prototype.indexOf` method
-  // https://tc39.github.io/ecma262/#sec-array.prototype.indexof
-  indexOf: createMethod(false)
-};
-
 /***/ }),
-/* 85 */
+/* 84 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toInteger = __webpack_require__(25);
+var toInteger = __webpack_require__(26);
 
 var max = Math.max;
 var min = Math.min;
@@ -29955,16 +29993,16 @@ module.exports = function (index, length) {
 };
 
 /***/ }),
-/* 86 */
+/* 85 */
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 /***/ }),
-/* 87 */
+/* 86 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var fails = __webpack_require__(7);
+var fails = __webpack_require__(8);
 
 var replacement = /#|\.prototype\./;
 
@@ -29984,10 +30022,10 @@ var POLYFILL = isForced.POLYFILL = 'P';
 module.exports = isForced;
 
 /***/ }),
-/* 88 */
+/* 87 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var fails = __webpack_require__(7);
+var fails = __webpack_require__(8);
 
 module.exports = !!Object.getOwnPropertySymbols && !fails(function () {
   // Chrome 38 Symbol has incorrect toString conversion
@@ -29996,7 +30034,7 @@ module.exports = !!Object.getOwnPropertySymbols && !fails(function () {
 });
 
 /***/ }),
-/* 89 */
+/* 88 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -30006,16 +30044,16 @@ var addToUnscopables = __webpack_require__(53);
 addToUnscopables('flat');
 
 /***/ }),
-/* 90 */
+/* 89 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var anObject = __webpack_require__(13);
-var defineProperties = __webpack_require__(91);
-var enumBugKeys = __webpack_require__(26);
-var hiddenKeys = __webpack_require__(24);
-var html = __webpack_require__(93);
-var documentCreateElement = __webpack_require__(40);
-var sharedKey = __webpack_require__(42);
+var anObject = __webpack_require__(14);
+var defineProperties = __webpack_require__(90);
+var enumBugKeys = __webpack_require__(27);
+var hiddenKeys = __webpack_require__(25);
+var html = __webpack_require__(92);
+var documentCreateElement = __webpack_require__(41);
+var sharedKey = __webpack_require__(43);
 var IE_PROTO = sharedKey('IE_PROTO');
 
 var PROTOTYPE = 'prototype';
@@ -30044,8 +30082,7 @@ var _createDict = function createDict() {
   }return _createDict();
 };
 
-// `Object.create` method
-// https://tc39.github.io/ecma262/#sec-object.create
+// 19.1.2.2 / 15.2.3.5 Object.create(O [, Properties])
 module.exports = Object.create || function create(O, Properties) {
   var result;
   if (O !== null) {
@@ -30061,50 +30098,49 @@ module.exports = Object.create || function create(O, Properties) {
 hiddenKeys[IE_PROTO] = true;
 
 /***/ }),
-/* 91 */
+/* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DESCRIPTORS = __webpack_require__(6);
-var definePropertyModule = __webpack_require__(22);
-var anObject = __webpack_require__(13);
-var objectKeys = __webpack_require__(92);
+var DESCRIPTORS = __webpack_require__(7);
+var definePropertyModule = __webpack_require__(23);
+var anObject = __webpack_require__(14);
+var objectKeys = __webpack_require__(91);
 
-// `Object.defineProperties` method
-// https://tc39.github.io/ecma262/#sec-object.defineproperties
 module.exports = DESCRIPTORS ? Object.defineProperties : function defineProperties(O, Properties) {
   anObject(O);
   var keys = objectKeys(Properties);
   var length = keys.length;
-  var index = 0;
+  var i = 0;
   var key;
-  while (length > index) {
-    definePropertyModule.f(O, key = keys[index++], Properties[key]);
+  while (length > i) {
+    definePropertyModule.f(O, key = keys[i++], Properties[key]);
   }return O;
+};
+
+/***/ }),
+/* 91 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var internalObjectKeys = __webpack_require__(45);
+var enumBugKeys = __webpack_require__(27);
+
+// 19.1.2.14 / 15.2.3.14 Object.keys(O)
+module.exports = Object.keys || function keys(O) {
+  return internalObjectKeys(O, enumBugKeys);
 };
 
 /***/ }),
 /* 92 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var internalObjectKeys = __webpack_require__(45);
-var enumBugKeys = __webpack_require__(26);
+var global = __webpack_require__(3);
 
-// `Object.keys` method
-// https://tc39.github.io/ecma262/#sec-object.keys
-module.exports = Object.keys || function keys(O) {
-  return internalObjectKeys(O, enumBugKeys);
-};
+var document = global.document;
+
+module.exports = document && document.documentElement;
 
 /***/ }),
 /* 93 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var getBuiltIn = __webpack_require__(44);
-
-module.exports = getBuiltIn('document', 'documentElement');
-
-/***/ }),
-/* 94 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -30113,7 +30149,7 @@ module.exports = getBuiltIn('document', 'documentElement');
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(4);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(95);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(94);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3__material_dialog__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -30279,7 +30315,7 @@ var VDialog = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 95 */
+/* 94 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -33897,13 +33933,13 @@ var VDialog = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 96 */
+/* 95 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDateTime;
 /* unused harmony export VDateTime */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(97);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(96);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield__ = __webpack_require__(55);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__material_textfield__);
@@ -33928,6 +33964,7 @@ function initDateTime(e) {
     console.debug('\tDateTime');
     Object(__WEBPACK_IMPORTED_MODULE_3__base_component__["b" /* hookupComponents */])(e, '.v-datetime', VDateTime, __WEBPACK_IMPORTED_MODULE_1__material_textfield__["MDCTextField"]);
 }
+
 var VDateTime = function (_VTextField) {
     _inherits(VDateTime, _VTextField);
 
@@ -33959,6 +33996,7 @@ var VDateTime = function (_VTextField) {
         element.addEventListener('click', function () {
             return _this.toggle();
         });
+        _this.originalValue = _this.fp.input.value;
         return _this;
     }
 
@@ -33974,7 +34012,7 @@ var VDateTime = function (_VTextField) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.fp.setDate(this.element.dataset.originalValue);
+            this.fp.setDate(this.originalValue);
         }
     }, {
         key: 'open',
@@ -34012,8 +34050,13 @@ var VDateTime = function (_VTextField) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
+            if (!this.dirtyable) {
+                return false;
+            }
+
             var currVal = new Date(this.fp.input.value);
-            var prevVal = new Date(this.element.dataset.originalValue);
+            var prevVal = new Date(this.originalValue);
+
             return currVal.getTime() !== prevVal.getTime();
         }
     }]);
@@ -34022,2196 +34065,2190 @@ var VDateTime = function (_VTextField) {
 }(__WEBPACK_IMPORTED_MODULE_2__text_fields__["a" /* VTextField */]);
 
 /***/ }),
-/* 97 */
+/* 96 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-/* flatpickr v4.6.2, @license MIT */
+/* flatpickr v4.5.2, @license MIT */
 (function (global, factory) {
-    ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = factory() :  true ? !(__WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+  ( false ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = factory() :  true ? !(__WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) :
 				__WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : (global = global || self, global.flatpickr = factory());
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : global.flatpickr = factory();
 })(this, function () {
-    'use strict';
+  'use strict';
 
-    /*! *****************************************************************************
-    Copyright (c) Microsoft Corporation. All rights reserved.
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-    this file except in compliance with the License. You may obtain a copy of the
-    License at http://www.apache.org/licenses/LICENSE-2.0
-      THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-    WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-    MERCHANTABLITY OR NON-INFRINGEMENT.
-      See the Apache Version 2.0 License for specific language governing permissions
-    and limitations under the License.
-    ***************************************************************************** */
+  var pad = function pad(number) {
+    return ("0" + number).slice(-2);
+  };
+  var int = function int(bool) {
+    return bool === true ? 1 : 0;
+  };
+  function debounce(func, wait, immediate) {
+    if (immediate === void 0) {
+      immediate = false;
+    }
 
-    var _assign = function __assign() {
-        _assign = Object.assign || function __assign(t) {
-            for (var s, i = 1, n = arguments.length; i < n; i++) {
-                s = arguments[i];
-                for (var p in s) {
-                    if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
-                }
-            }
-            return t;
-        };
-        return _assign.apply(this, arguments);
+    var timeout;
+    return function () {
+      var context = this,
+          args = arguments;
+      timeout !== null && clearTimeout(timeout);
+      timeout = window.setTimeout(function () {
+        timeout = null;
+        if (!immediate) func.apply(context, args);
+      }, wait);
+      if (immediate && !timeout) func.apply(context, args);
     };
+  }
+  var arrayify = function arrayify(obj) {
+    return obj instanceof Array ? obj : [obj];
+  };
 
-    var HOOKS = ["onChange", "onClose", "onDayCreate", "onDestroy", "onKeyDown", "onMonthChange", "onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange", "onPreCalendarPosition"];
-    var defaults = {
-        _disable: [],
-        _enable: [],
-        allowInput: false,
-        altFormat: "F j, Y",
-        altInput: false,
-        altInputClass: "form-control input",
-        animate: (typeof window === 'undefined' ? 'undefined' : _typeof(window)) === "object" && window.navigator.userAgent.indexOf("MSIE") === -1,
-        ariaDateFormat: "F j, Y",
-        clickOpens: true,
-        closeOnSelect: true,
-        conjunction: ", ",
-        dateFormat: "Y-m-d",
-        defaultHour: 12,
-        defaultMinute: 0,
-        defaultSeconds: 0,
-        disable: [],
-        disableMobile: false,
-        enable: [],
-        enableSeconds: false,
-        enableTime: false,
-        errorHandler: function errorHandler(err) {
-            return typeof console !== "undefined" && console.warn(err);
-        },
-        getWeek: function getWeek(givenDate) {
-            var date = new Date(givenDate.getTime());
-            date.setHours(0, 0, 0, 0);
-            // Thursday in current week decides the year.
-            date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
-            // January 4 is always in week 1.
-            var week1 = new Date(date.getFullYear(), 0, 4);
-            // Adjust to Thursday in week 1 and count number of weeks from date to week1.
-            return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getDay() + 6) % 7) / 7);
-        },
-        hourIncrement: 1,
-        ignoredFocusElements: [],
-        inline: false,
-        locale: "default",
-        minuteIncrement: 5,
-        mode: "single",
-        monthSelectorType: "dropdown",
-        nextArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
-        noCalendar: false,
-        now: new Date(),
-        onChange: [],
-        onClose: [],
-        onDayCreate: [],
-        onDestroy: [],
-        onKeyDown: [],
-        onMonthChange: [],
-        onOpen: [],
-        onParseConfig: [],
-        onReady: [],
-        onValueUpdate: [],
-        onYearChange: [],
-        onPreCalendarPosition: [],
-        plugins: [],
-        position: "auto",
-        positionElement: undefined,
-        prevArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
-        shorthandCurrentMonth: false,
-        showMonths: 1,
-        static: false,
-        time_24hr: false,
-        weekNumbers: false,
-        wrap: false
-    };
+  var do_nothing = function do_nothing() {
+    return undefined;
+  };
 
-    var english = {
-        weekdays: {
-            shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-            longhand: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-        },
-        months: {
-            shorthand: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-            longhand: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-        },
-        daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-        firstDayOfWeek: 0,
-        ordinal: function ordinal(nth) {
-            var s = nth % 100;
-            if (s > 3 && s < 21) return "th";
-            switch (s % 10) {
-                case 1:
-                    return "st";
-                case 2:
-                    return "nd";
-                case 3:
-                    return "rd";
-                default:
-                    return "th";
-            }
-        },
-        rangeSeparator: " to ",
-        weekAbbreviation: "Wk",
-        scrollTitle: "Scroll to increment",
-        toggleTitle: "Click to toggle",
-        amPM: ["AM", "PM"],
-        yearAriaLabel: "Year",
-        hourAriaLabel: "Hour",
-        minuteAriaLabel: "Minute",
-        time_24hr: false
-    };
+  var monthToStr = function monthToStr(monthNumber, shorthand, locale) {
+    return locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
+  };
+  var revFormat = {
+    D: do_nothing,
+    F: function F(dateObj, monthName, locale) {
+      dateObj.setMonth(locale.months.longhand.indexOf(monthName));
+    },
+    G: function G(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    H: function H(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    J: function J(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    K: function K(dateObj, amPM, locale) {
+      dateObj.setHours(dateObj.getHours() % 12 + 12 * int(new RegExp(locale.amPM[1], "i").test(amPM)));
+    },
+    M: function M(dateObj, shortMonth, locale) {
+      dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
+    },
+    S: function S(dateObj, seconds) {
+      dateObj.setSeconds(parseFloat(seconds));
+    },
+    U: function U(_, unixSeconds) {
+      return new Date(parseFloat(unixSeconds) * 1000);
+    },
+    W: function W(dateObj, weekNum) {
+      var weekNumber = parseInt(weekNum);
+      return new Date(dateObj.getFullYear(), 0, 2 + (weekNumber - 1) * 7, 0, 0, 0, 0);
+    },
+    Y: function Y(dateObj, year) {
+      dateObj.setFullYear(parseFloat(year));
+    },
+    Z: function Z(_, ISODate) {
+      return new Date(ISODate);
+    },
+    d: function d(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    h: function h(dateObj, hour) {
+      dateObj.setHours(parseFloat(hour));
+    },
+    i: function i(dateObj, minutes) {
+      dateObj.setMinutes(parseFloat(minutes));
+    },
+    j: function j(dateObj, day) {
+      dateObj.setDate(parseFloat(day));
+    },
+    l: do_nothing,
+    m: function m(dateObj, month) {
+      dateObj.setMonth(parseFloat(month) - 1);
+    },
+    n: function n(dateObj, month) {
+      dateObj.setMonth(parseFloat(month) - 1);
+    },
+    s: function s(dateObj, seconds) {
+      dateObj.setSeconds(parseFloat(seconds));
+    },
+    w: do_nothing,
+    y: function y(dateObj, year) {
+      dateObj.setFullYear(2000 + parseFloat(year));
+    }
+  };
+  var tokenRegex = {
+    D: "(\\w+)",
+    F: "(\\w+)",
+    G: "(\\d\\d|\\d)",
+    H: "(\\d\\d|\\d)",
+    J: "(\\d\\d|\\d)\\w+",
+    K: "",
+    M: "(\\w+)",
+    S: "(\\d\\d|\\d)",
+    U: "(.+)",
+    W: "(\\d\\d|\\d)",
+    Y: "(\\d{4})",
+    Z: "(.+)",
+    d: "(\\d\\d|\\d)",
+    h: "(\\d\\d|\\d)",
+    i: "(\\d\\d|\\d)",
+    j: "(\\d\\d|\\d)",
+    l: "(\\w+)",
+    m: "(\\d\\d|\\d)",
+    n: "(\\d\\d|\\d)",
+    s: "(\\d\\d|\\d)",
+    w: "(\\d\\d|\\d)",
+    y: "(\\d{2})"
+  };
+  var formats = {
+    Z: function Z(date) {
+      return date.toISOString();
+    },
+    D: function D(date, locale, options) {
+      return locale.weekdays.shorthand[formats.w(date, locale, options)];
+    },
+    F: function F(date, locale, options) {
+      return monthToStr(formats.n(date, locale, options) - 1, false, locale);
+    },
+    G: function G(date, locale, options) {
+      return pad(formats.h(date, locale, options));
+    },
+    H: function H(date) {
+      return pad(date.getHours());
+    },
+    J: function J(date, locale) {
+      return locale.ordinal !== undefined ? date.getDate() + locale.ordinal(date.getDate()) : date.getDate();
+    },
+    K: function K(date, locale) {
+      return locale.amPM[int(date.getHours() > 11)];
+    },
+    M: function M(date, locale) {
+      return monthToStr(date.getMonth(), true, locale);
+    },
+    S: function S(date) {
+      return pad(date.getSeconds());
+    },
+    U: function U(date) {
+      return date.getTime() / 1000;
+    },
+    W: function W(date, _, options) {
+      return options.getWeek(date);
+    },
+    Y: function Y(date) {
+      return date.getFullYear();
+    },
+    d: function d(date) {
+      return pad(date.getDate());
+    },
+    h: function h(date) {
+      return date.getHours() % 12 ? date.getHours() % 12 : 12;
+    },
+    i: function i(date) {
+      return pad(date.getMinutes());
+    },
+    j: function j(date) {
+      return date.getDate();
+    },
+    l: function l(date, locale) {
+      return locale.weekdays.longhand[date.getDay()];
+    },
+    m: function m(date) {
+      return pad(date.getMonth() + 1);
+    },
+    n: function n(date) {
+      return date.getMonth() + 1;
+    },
+    s: function s(date) {
+      return date.getSeconds();
+    },
+    w: function w(date) {
+      return date.getDay();
+    },
+    y: function y(date) {
+      return String(date.getFullYear()).substring(2);
+    }
+  };
 
-    var pad = function pad(number) {
-        return ("0" + number).slice(-2);
+  var english = {
+    weekdays: {
+      shorthand: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+      longhand: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    },
+    months: {
+      shorthand: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+      longhand: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+    },
+    daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+    firstDayOfWeek: 0,
+    ordinal: function ordinal(nth) {
+      var s = nth % 100;
+      if (s > 3 && s < 21) return "th";
+
+      switch (s % 10) {
+        case 1:
+          return "st";
+
+        case 2:
+          return "nd";
+
+        case 3:
+          return "rd";
+
+        default:
+          return "th";
+      }
+    },
+    rangeSeparator: " to ",
+    weekAbbreviation: "Wk",
+    scrollTitle: "Scroll to increment",
+    toggleTitle: "Click to toggle",
+    amPM: ["AM", "PM"],
+    yearAriaLabel: "Year"
+  };
+
+  var createDateFormatter = function createDateFormatter(_ref) {
+    var _ref$config = _ref.config,
+        config = _ref$config === void 0 ? defaults : _ref$config,
+        _ref$l10n = _ref.l10n,
+        l10n = _ref$l10n === void 0 ? english : _ref$l10n;
+    return function (dateObj, frmt, overrideLocale) {
+      var locale = overrideLocale || l10n;
+
+      if (config.formatDate !== undefined) {
+        return config.formatDate(dateObj, frmt, locale);
+      }
+
+      return frmt.split("").map(function (c, i, arr) {
+        return formats[c] && arr[i - 1] !== "\\" ? formats[c](dateObj, locale, config) : c !== "\\" ? c : "";
+      }).join("");
     };
-    var int = function int(bool) {
-        return bool === true ? 1 : 0;
-    };
-    /* istanbul ignore next */
-    function debounce(func, wait, immediate) {
-        if (immediate === void 0) {
-            immediate = false;
+  };
+  var createDateParser = function createDateParser(_ref2) {
+    var _ref2$config = _ref2.config,
+        config = _ref2$config === void 0 ? defaults : _ref2$config,
+        _ref2$l10n = _ref2.l10n,
+        l10n = _ref2$l10n === void 0 ? english : _ref2$l10n;
+    return function (date, givenFormat, timeless, customLocale) {
+      if (date !== 0 && !date) return undefined;
+      var locale = customLocale || l10n;
+      var parsedDate;
+      var date_orig = date;
+      if (date instanceof Date) parsedDate = new Date(date.getTime());else if (typeof date !== "string" && date.toFixed !== undefined) parsedDate = new Date(date);else if (typeof date === "string") {
+        var format = givenFormat || (config || defaults).dateFormat;
+        var datestr = String(date).trim();
+
+        if (datestr === "today") {
+          parsedDate = new Date();
+          timeless = true;
+        } else if (/Z$/.test(datestr) || /GMT$/.test(datestr)) parsedDate = new Date(date);else if (config && config.parseDate) parsedDate = config.parseDate(date, format);else {
+          parsedDate = !config || !config.noCalendar ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0) : new Date(new Date().setHours(0, 0, 0, 0));
+          var matched,
+              ops = [];
+
+          for (var i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
+            var token = format[i];
+            var isBackSlash = token === "\\";
+            var escaped = format[i - 1] === "\\" || isBackSlash;
+
+            if (tokenRegex[token] && !escaped) {
+              regexStr += tokenRegex[token];
+              var match = new RegExp(regexStr).exec(date);
+
+              if (match && (matched = true)) {
+                ops[token !== "Y" ? "push" : "unshift"]({
+                  fn: revFormat[token],
+                  val: match[++matchIndex]
+                });
+              }
+            } else if (!isBackSlash) regexStr += ".";
+
+            ops.forEach(function (_ref3) {
+              var fn = _ref3.fn,
+                  val = _ref3.val;
+              return parsedDate = fn(parsedDate, val, locale) || parsedDate;
+            });
+          }
+
+          parsedDate = matched ? parsedDate : undefined;
         }
-        var timeout;
-        return function () {
-            var context = this,
-                args = arguments;
-            timeout !== null && clearTimeout(timeout);
-            timeout = window.setTimeout(function () {
-                timeout = null;
-                if (!immediate) func.apply(context, args);
-            }, wait);
-            if (immediate && !timeout) func.apply(context, args);
-        };
-    }
-    var arrayify = function arrayify(obj) {
-        return obj instanceof Array ? obj : [obj];
-    };
+      }
 
-    function toggleClass(elem, className, bool) {
-        if (bool === true) return elem.classList.add(className);
-        elem.classList.remove(className);
-    }
-    function createElement(tag, className, content) {
-        var e = window.document.createElement(tag);
-        className = className || "";
-        content = content || "";
-        e.className = className;
-        if (content !== undefined) e.textContent = content;
-        return e;
-    }
-    function clearNode(node) {
-        while (node.firstChild) {
-            node.removeChild(node.firstChild);
-        }
-    }
-    function findParent(node, condition) {
-        if (condition(node)) return node;else if (node.parentNode) return findParent(node.parentNode, condition);
-        return undefined; // nothing found
-    }
-    function createNumberInput(inputClassName, opts) {
-        var wrapper = createElement("div", "numInputWrapper"),
-            numInput = createElement("input", "numInput " + inputClassName),
-            arrowUp = createElement("span", "arrowUp"),
-            arrowDown = createElement("span", "arrowDown");
-        if (navigator.userAgent.indexOf("MSIE 9.0") === -1) {
-            numInput.type = "number";
-        } else {
-            numInput.type = "text";
-            numInput.pattern = "\\d*";
-        }
-        if (opts !== undefined) for (var key in opts) {
-            numInput.setAttribute(key, opts[key]);
-        }wrapper.appendChild(numInput);
-        wrapper.appendChild(arrowUp);
-        wrapper.appendChild(arrowDown);
-        return wrapper;
-    }
-    function getEventTarget(event) {
-        if (typeof event.composedPath === "function") {
-            var path = event.composedPath();
-            return path[0];
-        }
-        return event.target;
-    }
-
-    var doNothing = function doNothing() {
+      if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
+        config.errorHandler(new Error("Invalid date provided: " + date_orig));
         return undefined;
-    };
-    var monthToStr = function monthToStr(monthNumber, shorthand, locale) {
-        return locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
-    };
-    var revFormat = {
-        D: doNothing,
-        F: function F(dateObj, monthName, locale) {
-            dateObj.setMonth(locale.months.longhand.indexOf(monthName));
-        },
-        G: function G(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        H: function H(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        J: function J(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        K: function K(dateObj, amPM, locale) {
-            dateObj.setHours(dateObj.getHours() % 12 + 12 * int(new RegExp(locale.amPM[1], "i").test(amPM)));
-        },
-        M: function M(dateObj, shortMonth, locale) {
-            dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
-        },
-        S: function S(dateObj, seconds) {
-            dateObj.setSeconds(parseFloat(seconds));
-        },
-        U: function U(_, unixSeconds) {
-            return new Date(parseFloat(unixSeconds) * 1000);
-        },
-        W: function W(dateObj, weekNum, locale) {
-            var weekNumber = parseInt(weekNum);
-            var date = new Date(dateObj.getFullYear(), 0, 2 + (weekNumber - 1) * 7, 0, 0, 0, 0);
-            date.setDate(date.getDate() - date.getDay() + locale.firstDayOfWeek);
-            return date;
-        },
-        Y: function Y(dateObj, year) {
-            dateObj.setFullYear(parseFloat(year));
-        },
-        Z: function Z(_, ISODate) {
-            return new Date(ISODate);
-        },
-        d: function d(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        h: function h(dateObj, hour) {
-            dateObj.setHours(parseFloat(hour));
-        },
-        i: function i(dateObj, minutes) {
-            dateObj.setMinutes(parseFloat(minutes));
-        },
-        j: function j(dateObj, day) {
-            dateObj.setDate(parseFloat(day));
-        },
-        l: doNothing,
-        m: function m(dateObj, month) {
-            dateObj.setMonth(parseFloat(month) - 1);
-        },
-        n: function n(dateObj, month) {
-            dateObj.setMonth(parseFloat(month) - 1);
-        },
-        s: function s(dateObj, seconds) {
-            dateObj.setSeconds(parseFloat(seconds));
-        },
-        u: function u(_, unixMillSeconds) {
-            return new Date(parseFloat(unixMillSeconds));
-        },
-        w: doNothing,
-        y: function y(dateObj, year) {
-            dateObj.setFullYear(2000 + parseFloat(year));
-        }
-    };
-    var tokenRegex = {
-        D: "(\\w+)",
-        F: "(\\w+)",
-        G: "(\\d\\d|\\d)",
-        H: "(\\d\\d|\\d)",
-        J: "(\\d\\d|\\d)\\w+",
-        K: "",
-        M: "(\\w+)",
-        S: "(\\d\\d|\\d)",
-        U: "(.+)",
-        W: "(\\d\\d|\\d)",
-        Y: "(\\d{4})",
-        Z: "(.+)",
-        d: "(\\d\\d|\\d)",
-        h: "(\\d\\d|\\d)",
-        i: "(\\d\\d|\\d)",
-        j: "(\\d\\d|\\d)",
-        l: "(\\w+)",
-        m: "(\\d\\d|\\d)",
-        n: "(\\d\\d|\\d)",
-        s: "(\\d\\d|\\d)",
-        u: "(.+)",
-        w: "(\\d\\d|\\d)",
-        y: "(\\d{2})"
-    };
-    var formats = {
-        // get the date in UTC
-        Z: function Z(date) {
-            return date.toISOString();
-        },
-        // weekday name, short, e.g. Thu
-        D: function D(date, locale, options) {
-            return locale.weekdays.shorthand[formats.w(date, locale, options)];
-        },
-        // full month name e.g. January
-        F: function F(date, locale, options) {
-            return monthToStr(formats.n(date, locale, options) - 1, false, locale);
-        },
-        // padded hour 1-12
-        G: function G(date, locale, options) {
-            return pad(formats.h(date, locale, options));
-        },
-        // hours with leading zero e.g. 03
-        H: function H(date) {
-            return pad(date.getHours());
-        },
-        // day (1-30) with ordinal suffix e.g. 1st, 2nd
-        J: function J(date, locale) {
-            return locale.ordinal !== undefined ? date.getDate() + locale.ordinal(date.getDate()) : date.getDate();
-        },
-        // AM/PM
-        K: function K(date, locale) {
-            return locale.amPM[int(date.getHours() > 11)];
-        },
-        // shorthand month e.g. Jan, Sep, Oct, etc
-        M: function M(date, locale) {
-            return monthToStr(date.getMonth(), true, locale);
-        },
-        // seconds 00-59
-        S: function S(date) {
-            return pad(date.getSeconds());
-        },
-        // unix timestamp
-        U: function U(date) {
-            return date.getTime() / 1000;
-        },
-        W: function W(date, _, options) {
-            return options.getWeek(date);
-        },
-        // full year e.g. 2016
-        Y: function Y(date) {
-            return date.getFullYear();
-        },
-        // day in month, padded (01-30)
-        d: function d(date) {
-            return pad(date.getDate());
-        },
-        // hour from 1-12 (am/pm)
-        h: function h(date) {
-            return date.getHours() % 12 ? date.getHours() % 12 : 12;
-        },
-        // minutes, padded with leading zero e.g. 09
-        i: function i(date) {
-            return pad(date.getMinutes());
-        },
-        // day in month (1-30)
-        j: function j(date) {
-            return date.getDate();
-        },
-        // weekday name, full, e.g. Thursday
-        l: function l(date, locale) {
-            return locale.weekdays.longhand[date.getDay()];
-        },
-        // padded month number (01-12)
-        m: function m(date) {
-            return pad(date.getMonth() + 1);
-        },
-        // the month number (1-12)
-        n: function n(date) {
-            return date.getMonth() + 1;
-        },
-        // seconds 0-59
-        s: function s(date) {
-            return date.getSeconds();
-        },
-        // Unix Milliseconds
-        u: function u(date) {
-            return date.getTime();
-        },
-        // number of the day of the week
-        w: function w(date) {
-            return date.getDay();
-        },
-        // last two digits of year e.g. 16 for 2016
-        y: function y(date) {
-            return String(date.getFullYear()).substring(2);
-        }
-    };
+      }
 
-    var createDateFormatter = function createDateFormatter(_a) {
-        var _b = _a.config,
-            config = _b === void 0 ? defaults : _b,
-            _c = _a.l10n,
-            l10n = _c === void 0 ? english : _c;
-        return function (dateObj, frmt, overrideLocale) {
-            var locale = overrideLocale || l10n;
-            if (config.formatDate !== undefined) {
-                return config.formatDate(dateObj, frmt, locale);
-            }
-            return frmt.split("").map(function (c, i, arr) {
-                return formats[c] && arr[i - 1] !== "\\" ? formats[c](dateObj, locale, config) : c !== "\\" ? c : "";
-            }).join("");
-        };
+      if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
+      return parsedDate;
     };
-    var createDateParser = function createDateParser(_a) {
-        var _b = _a.config,
-            config = _b === void 0 ? defaults : _b,
-            _c = _a.l10n,
-            l10n = _c === void 0 ? english : _c;
-        return function (date, givenFormat, timeless, customLocale) {
-            if (date !== 0 && !date) return undefined;
-            var locale = customLocale || l10n;
-            var parsedDate;
-            var dateOrig = date;
-            if (date instanceof Date) parsedDate = new Date(date.getTime());else if (typeof date !== "string" && date.toFixed !== undefined // timestamp
-            )
-                // create a copy
-                parsedDate = new Date(date);else if (typeof date === "string") {
-                // date string
-                var format = givenFormat || (config || defaults).dateFormat;
-                var datestr = String(date).trim();
-                if (datestr === "today") {
-                    parsedDate = new Date();
-                    timeless = true;
-                } else if (/Z$/.test(datestr) || /GMT$/.test(datestr) // datestrings w/ timezone
-                ) parsedDate = new Date(date);else if (config && config.parseDate) parsedDate = config.parseDate(date, format);else {
-                    parsedDate = !config || !config.noCalendar ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0) : new Date(new Date().setHours(0, 0, 0, 0));
-                    var matched = void 0,
-                        ops = [];
-                    for (var i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
-                        var token_1 = format[i];
-                        var isBackSlash = token_1 === "\\";
-                        var escaped = format[i - 1] === "\\" || isBackSlash;
-                        if (tokenRegex[token_1] && !escaped) {
-                            regexStr += tokenRegex[token_1];
-                            var match = new RegExp(regexStr).exec(date);
-                            if (match && (matched = true)) {
-                                ops[token_1 !== "Y" ? "push" : "unshift"]({
-                                    fn: revFormat[token_1],
-                                    val: match[++matchIndex]
-                                });
-                            }
-                        } else if (!isBackSlash) regexStr += "."; // don't really care
-                        ops.forEach(function (_a) {
-                            var fn = _a.fn,
-                                val = _a.val;
-                            return parsedDate = fn(parsedDate, val, locale) || parsedDate;
-                        });
-                    }
-                    parsedDate = matched ? parsedDate : undefined;
-                }
-            }
-            /* istanbul ignore next */
-            if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
-                config.errorHandler(new Error("Invalid date provided: " + dateOrig));
-                return undefined;
-            }
-            if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
-            return parsedDate;
-        };
-    };
-    /**
-     * Compute the difference in dates, measured in ms
-     */
-    function compareDates(date1, date2, timeless) {
-        if (timeless === void 0) {
-            timeless = true;
-        }
-        if (timeless !== false) {
-            return new Date(date1.getTime()).setHours(0, 0, 0, 0) - new Date(date2.getTime()).setHours(0, 0, 0, 0);
-        }
-        return date1.getTime() - date2.getTime();
-    }
-    var isBetween = function isBetween(ts, ts1, ts2) {
-        return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
-    };
-    var duration = {
-        DAY: 86400000
-    };
-
-    if (typeof Object.assign !== "function") {
-        Object.assign = function (target) {
-            var args = [];
-            for (var _i = 1; _i < arguments.length; _i++) {
-                args[_i - 1] = arguments[_i];
-            }
-            if (!target) {
-                throw TypeError("Cannot convert undefined or null to object");
-            }
-            var _loop_1 = function _loop_1(source) {
-                if (source) {
-                    Object.keys(source).forEach(function (key) {
-                        return target[key] = source[key];
-                    });
-                }
-            };
-            for (var _a = 0, args_1 = args; _a < args_1.length; _a++) {
-                var source = args_1[_a];
-                _loop_1(source);
-            }
-            return target;
-        };
+  };
+  function compareDates(date1, date2, timeless) {
+    if (timeless === void 0) {
+      timeless = true;
     }
 
-    var DEBOUNCED_CHANGE_MS = 300;
-    function FlatpickrInstance(element, instanceConfig) {
-        var self = {
-            config: _assign({}, defaults, flatpickr.defaultConfig),
-            l10n: english
-        };
-        self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
-        self._handlers = [];
-        self.pluginElements = [];
-        self.loadedPlugins = [];
-        self._bind = bind;
-        self._setHoursFromDate = setHoursFromDate;
-        self._positionCalendar = positionCalendar;
-        self.changeMonth = changeMonth;
-        self.changeYear = changeYear;
-        self.clear = clear;
-        self.close = close;
-        self._createElement = createElement;
-        self.destroy = destroy;
-        self.isEnabled = isEnabled;
-        self.jumpToDate = jumpToDate;
-        self.open = open;
-        self.redraw = redraw;
-        self.set = set;
-        self.setDate = setDate;
-        self.toggle = toggle;
-        function setupHelperFunctions() {
-            self.utils = {
-                getDaysInMonth: function getDaysInMonth(month, yr) {
-                    if (month === void 0) {
-                        month = self.currentMonth;
-                    }
-                    if (yr === void 0) {
-                        yr = self.currentYear;
-                    }
-                    if (month === 1 && (yr % 4 === 0 && yr % 100 !== 0 || yr % 400 === 0)) return 29;
-                    return self.l10n.daysInMonth[month];
-                }
-            };
-        }
-        function init() {
-            self.element = self.input = element;
-            self.isOpen = false;
-            parseConfig();
-            setupLocale();
-            setupInputs();
-            setupDates();
-            setupHelperFunctions();
-            if (!self.isMobile) build();
-            bindEvents();
-            if (self.selectedDates.length || self.config.noCalendar) {
-                if (self.config.enableTime) {
-                    setHoursFromDate(self.config.noCalendar ? self.latestSelectedDateObj || self.config.minDate : undefined);
-                }
-                updateValue(false);
-            }
-            setCalendarWidth();
-            self.showTimeInput = self.selectedDates.length > 0 || self.config.noCalendar;
-            var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-            /* TODO: investigate this further
-                       Currently, there is weird positioning behavior in safari causing pages
-              to scroll up. https://github.com/chmln/flatpickr/issues/563
-                       However, most browsers are not Safari and positioning is expensive when used
-              in scale. https://github.com/chmln/flatpickr/issues/1096
-            */
-            if (!self.isMobile && isSafari) {
-                positionCalendar();
-            }
-            triggerEvent("onReady");
-        }
-        function bindToInstance(fn) {
-            return fn.bind(self);
-        }
-        function setCalendarWidth() {
-            var config = self.config;
-            if (config.weekNumbers === false && config.showMonths === 1) return;else if (config.noCalendar !== true) {
-                window.requestAnimationFrame(function () {
-                    if (self.calendarContainer !== undefined) {
-                        self.calendarContainer.style.visibility = "hidden";
-                        self.calendarContainer.style.display = "block";
-                    }
-                    if (self.daysContainer !== undefined) {
-                        var daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
-                        self.daysContainer.style.width = daysWidth + "px";
-                        self.calendarContainer.style.width = daysWidth + (self.weekWrapper !== undefined ? self.weekWrapper.offsetWidth : 0) + "px";
-                        self.calendarContainer.style.removeProperty("visibility");
-                        self.calendarContainer.style.removeProperty("display");
-                    }
-                });
-            }
-        }
-        /**
-         * The handler for all events targeting the time inputs
-         */
-        function updateTime(e) {
-            if (self.selectedDates.length === 0) {
-                setDefaultTime();
-            }
-            if (e !== undefined && e.type !== "blur") {
-                timeWrapper(e);
-            }
-            var prevValue = self._input.value;
-            setHoursFromInputs();
-            updateValue();
-            if (self._input.value !== prevValue) {
-                self._debouncedChange();
-            }
-        }
-        function ampm2military(hour, amPM) {
-            return hour % 12 + 12 * int(amPM === self.l10n.amPM[1]);
-        }
-        function military2ampm(hour) {
-            switch (hour % 24) {
-                case 0:
-                case 12:
-                    return 12;
-                default:
-                    return hour % 12;
-            }
-        }
-        /**
-         * Syncs the selected date object time with user's time input
-         */
-        function setHoursFromInputs() {
-            if (self.hourElement === undefined || self.minuteElement === undefined) return;
-            var hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
-                minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
-                seconds = self.secondElement !== undefined ? (parseInt(self.secondElement.value, 10) || 0) % 60 : 0;
-            if (self.amPM !== undefined) {
-                hours = ampm2military(hours, self.amPM.textContent);
-            }
-            var limitMinHours = self.config.minTime !== undefined || self.config.minDate && self.minDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.minDate, true) === 0;
-            var limitMaxHours = self.config.maxTime !== undefined || self.config.maxDate && self.maxDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.maxDate, true) === 0;
-            if (limitMaxHours) {
-                var maxTime = self.config.maxTime !== undefined ? self.config.maxTime : self.config.maxDate;
-                hours = Math.min(hours, maxTime.getHours());
-                if (hours === maxTime.getHours()) minutes = Math.min(minutes, maxTime.getMinutes());
-                if (minutes === maxTime.getMinutes()) seconds = Math.min(seconds, maxTime.getSeconds());
-            }
-            if (limitMinHours) {
-                var minTime = self.config.minTime !== undefined ? self.config.minTime : self.config.minDate;
-                hours = Math.max(hours, minTime.getHours());
-                if (hours === minTime.getHours()) minutes = Math.max(minutes, minTime.getMinutes());
-                if (minutes === minTime.getMinutes()) seconds = Math.max(seconds, minTime.getSeconds());
-            }
-            setHours(hours, minutes, seconds);
-        }
-        /**
-         * Syncs time input values with a date
-         */
-        function setHoursFromDate(dateObj) {
-            var date = dateObj || self.latestSelectedDateObj;
-            if (date) setHours(date.getHours(), date.getMinutes(), date.getSeconds());
-        }
-        function setDefaultHours() {
-            var hours = self.config.defaultHour;
-            var minutes = self.config.defaultMinute;
-            var seconds = self.config.defaultSeconds;
-            if (self.config.minDate !== undefined) {
-                var minHr = self.config.minDate.getHours();
-                var minMinutes = self.config.minDate.getMinutes();
-                hours = Math.max(hours, minHr);
-                if (hours === minHr) minutes = Math.max(minMinutes, minutes);
-                if (hours === minHr && minutes === minMinutes) seconds = self.config.minDate.getSeconds();
-            }
-            if (self.config.maxDate !== undefined) {
-                var maxHr = self.config.maxDate.getHours();
-                var maxMinutes = self.config.maxDate.getMinutes();
-                hours = Math.min(hours, maxHr);
-                if (hours === maxHr) minutes = Math.min(maxMinutes, minutes);
-                if (hours === maxHr && minutes === maxMinutes) seconds = self.config.maxDate.getSeconds();
-            }
-            setHours(hours, minutes, seconds);
-        }
-        /**
-         * Sets the hours, minutes, and optionally seconds
-         * of the latest selected date object and the
-         * corresponding time inputs
-         * @param {Number} hours the hour. whether its military
-         *                 or am-pm gets inferred from config
-         * @param {Number} minutes the minutes
-         * @param {Number} seconds the seconds (optional)
-         */
-        function setHours(hours, minutes, seconds) {
-            if (self.latestSelectedDateObj !== undefined) {
-                self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
-            }
-            if (!self.hourElement || !self.minuteElement || self.isMobile) return;
-            self.hourElement.value = pad(!self.config.time_24hr ? (12 + hours) % 12 + 12 * int(hours % 12 === 0) : hours);
-            self.minuteElement.value = pad(minutes);
-            if (self.amPM !== undefined) self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
-            if (self.secondElement !== undefined) self.secondElement.value = pad(seconds);
-        }
-        /**
-         * Handles the year input and incrementing events
-         * @param {Event} event the keyup or increment event
-         */
-        function onYearInput(event) {
-            var year = parseInt(event.target.value) + (event.delta || 0);
-            if (year / 1000 > 1 || event.key === "Enter" && !/[^\d]/.test(year.toString())) {
-                changeYear(year);
-            }
-        }
-        /**
-         * Essentially addEventListener + tracking
-         * @param {Element} element the element to addEventListener to
-         * @param {String} event the event name
-         * @param {Function} handler the event handler
-         */
-        function bind(element, event, handler, options) {
-            if (event instanceof Array) return event.forEach(function (ev) {
-                return bind(element, ev, handler, options);
-            });
-            if (element instanceof Array) return element.forEach(function (el) {
-                return bind(el, event, handler, options);
-            });
-            element.addEventListener(event, handler, options);
-            self._handlers.push({
-                element: element,
-                event: event,
-                handler: handler,
-                options: options
-            });
-        }
-        /**
-         * A mousedown handler which mimics click.
-         * Minimizes latency, since we don't need to wait for mouseup in most cases.
-         * Also, avoids handling right clicks.
-         *
-         * @param {Function} handler the event handler
-         */
-        function onClick(handler) {
-            return function (evt) {
-                evt.which === 1 && handler(evt);
-            };
-        }
-        function triggerChange() {
-            triggerEvent("onChange");
-        }
-        /**
-         * Adds all the necessary event listeners
-         */
-        function bindEvents() {
-            if (self.config.wrap) {
-                ["open", "close", "toggle", "clear"].forEach(function (evt) {
-                    Array.prototype.forEach.call(self.element.querySelectorAll("[data-" + evt + "]"), function (el) {
-                        return bind(el, "click", self[evt]);
-                    });
-                });
-            }
-            if (self.isMobile) {
-                setupMobile();
-                return;
-            }
-            var debouncedResize = debounce(onResize, 50);
-            self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
-            if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent)) bind(self.daysContainer, "mouseover", function (e) {
-                if (self.config.mode === "range") onMouseOver(e.target);
-            });
-            bind(window.document.body, "keydown", onKeyDown);
-            if (!self.config.inline && !self.config.static) bind(window, "resize", debouncedResize);
-            if (window.ontouchstart !== undefined) bind(window.document, "touchstart", documentClick);else bind(window.document, "mousedown", onClick(documentClick));
-            bind(window.document, "focus", documentClick, { capture: true });
-            if (self.config.clickOpens === true) {
-                bind(self._input, "focus", self.open);
-                bind(self._input, "mousedown", onClick(self.open));
-            }
-            if (self.daysContainer !== undefined) {
-                bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
-                bind(self.monthNav, ["keyup", "increment"], onYearInput);
-                bind(self.daysContainer, "mousedown", onClick(selectDate));
-            }
-            if (self.timeContainer !== undefined && self.minuteElement !== undefined && self.hourElement !== undefined) {
-                var selText = function selText(e) {
-                    return e.target.select();
-                };
-                bind(self.timeContainer, ["increment"], updateTime);
-                bind(self.timeContainer, "blur", updateTime, { capture: true });
-                bind(self.timeContainer, "mousedown", onClick(timeIncrement));
-                bind([self.hourElement, self.minuteElement], ["focus", "click"], selText);
-                if (self.secondElement !== undefined) bind(self.secondElement, "focus", function () {
-                    return self.secondElement && self.secondElement.select();
-                });
-                if (self.amPM !== undefined) {
-                    bind(self.amPM, "mousedown", onClick(function (e) {
-                        updateTime(e);
-                        triggerChange();
-                    }));
-                }
-            }
-        }
-        /**
-         * Set the calendar view to a particular date.
-         * @param {Date} jumpDate the date to set the view to
-         * @param {boolean} triggerChange if change events should be triggered
-         */
-        function jumpToDate(jumpDate, triggerChange) {
-            var jumpTo = jumpDate !== undefined ? self.parseDate(jumpDate) : self.latestSelectedDateObj || (self.config.minDate && self.config.minDate > self.now ? self.config.minDate : self.config.maxDate && self.config.maxDate < self.now ? self.config.maxDate : self.now);
-            var oldYear = self.currentYear;
-            var oldMonth = self.currentMonth;
-            try {
-                if (jumpTo !== undefined) {
-                    self.currentYear = jumpTo.getFullYear();
-                    self.currentMonth = jumpTo.getMonth();
-                }
-            } catch (e) {
-                /* istanbul ignore next */
-                e.message = "Invalid date supplied: " + jumpTo;
-                self.config.errorHandler(e);
-            }
-            if (triggerChange && self.currentYear !== oldYear) {
-                triggerEvent("onYearChange");
-                buildMonthSwitch();
-            }
-            if (triggerChange && (self.currentYear !== oldYear || self.currentMonth !== oldMonth)) {
-                triggerEvent("onMonthChange");
-            }
-            self.redraw();
-        }
-        /**
-         * The up/down arrow handler for time inputs
-         * @param {Event} e the click event
-         */
-        function timeIncrement(e) {
-            if (~e.target.className.indexOf("arrow")) incrementNumInput(e, e.target.classList.contains("arrowUp") ? 1 : -1);
-        }
-        /**
-         * Increments/decrements the value of input associ-
-         * ated with the up/down arrow by dispatching an
-         * "increment" event on the input.
-         *
-         * @param {Event} e the click event
-         * @param {Number} delta the diff (usually 1 or -1)
-         * @param {Element} inputElem the input element
-         */
-        function incrementNumInput(e, delta, inputElem) {
-            var target = e && e.target;
-            var input = inputElem || target && target.parentNode && target.parentNode.firstChild;
-            var event = createEvent("increment");
-            event.delta = delta;
-            input && input.dispatchEvent(event);
-        }
-        function build() {
-            var fragment = window.document.createDocumentFragment();
-            self.calendarContainer = createElement("div", "flatpickr-calendar");
-            self.calendarContainer.tabIndex = -1;
-            if (!self.config.noCalendar) {
-                fragment.appendChild(buildMonthNav());
-                self.innerContainer = createElement("div", "flatpickr-innerContainer");
-                if (self.config.weekNumbers) {
-                    var _a = buildWeeks(),
-                        weekWrapper = _a.weekWrapper,
-                        weekNumbers = _a.weekNumbers;
-                    self.innerContainer.appendChild(weekWrapper);
-                    self.weekNumbers = weekNumbers;
-                    self.weekWrapper = weekWrapper;
-                }
-                self.rContainer = createElement("div", "flatpickr-rContainer");
-                self.rContainer.appendChild(buildWeekdays());
-                if (!self.daysContainer) {
-                    self.daysContainer = createElement("div", "flatpickr-days");
-                    self.daysContainer.tabIndex = -1;
-                }
-                buildDays();
-                self.rContainer.appendChild(self.daysContainer);
-                self.innerContainer.appendChild(self.rContainer);
-                fragment.appendChild(self.innerContainer);
-            }
-            if (self.config.enableTime) {
-                fragment.appendChild(buildTime());
-            }
-            toggleClass(self.calendarContainer, "rangeMode", self.config.mode === "range");
-            toggleClass(self.calendarContainer, "animate", self.config.animate === true);
-            toggleClass(self.calendarContainer, "multiMonth", self.config.showMonths > 1);
-            self.calendarContainer.appendChild(fragment);
-            var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType !== undefined;
-            if (self.config.inline || self.config.static) {
-                self.calendarContainer.classList.add(self.config.inline ? "inline" : "static");
-                if (self.config.inline) {
-                    if (!customAppend && self.element.parentNode) self.element.parentNode.insertBefore(self.calendarContainer, self._input.nextSibling);else if (self.config.appendTo !== undefined) self.config.appendTo.appendChild(self.calendarContainer);
-                }
-                if (self.config.static) {
-                    var wrapper = createElement("div", "flatpickr-wrapper");
-                    if (self.element.parentNode) self.element.parentNode.insertBefore(wrapper, self.element);
-                    wrapper.appendChild(self.element);
-                    if (self.altInput) wrapper.appendChild(self.altInput);
-                    wrapper.appendChild(self.calendarContainer);
-                }
-            }
-            if (!self.config.static && !self.config.inline) (self.config.appendTo !== undefined ? self.config.appendTo : window.document.body).appendChild(self.calendarContainer);
-        }
-        function createDay(className, date, dayNumber, i) {
-            var dateIsEnabled = isEnabled(date, true),
-                dayElement = createElement("span", "flatpickr-day " + className, date.getDate().toString());
-            dayElement.dateObj = date;
-            dayElement.$i = i;
-            dayElement.setAttribute("aria-label", self.formatDate(date, self.config.ariaDateFormat));
-            if (className.indexOf("hidden") === -1 && compareDates(date, self.now) === 0) {
-                self.todayDateElem = dayElement;
-                dayElement.classList.add("today");
-                dayElement.setAttribute("aria-current", "date");
-            }
-            if (dateIsEnabled) {
-                dayElement.tabIndex = -1;
-                if (isDateSelected(date)) {
-                    dayElement.classList.add("selected");
-                    self.selectedDateElem = dayElement;
-                    if (self.config.mode === "range") {
-                        toggleClass(dayElement, "startRange", self.selectedDates[0] && compareDates(date, self.selectedDates[0], true) === 0);
-                        toggleClass(dayElement, "endRange", self.selectedDates[1] && compareDates(date, self.selectedDates[1], true) === 0);
-                        if (className === "nextMonthDay") dayElement.classList.add("inRange");
-                    }
-                }
-            } else {
-                dayElement.classList.add("flatpickr-disabled");
-            }
-            if (self.config.mode === "range") {
-                if (isDateInRange(date) && !isDateSelected(date)) dayElement.classList.add("inRange");
-            }
-            if (self.weekNumbers && self.config.showMonths === 1 && className !== "prevMonthDay" && dayNumber % 7 === 1) {
-                self.weekNumbers.insertAdjacentHTML("beforeend", "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>");
-            }
-            triggerEvent("onDayCreate", dayElement);
-            return dayElement;
-        }
-        function focusOnDayElem(targetNode) {
-            targetNode.focus();
-            if (self.config.mode === "range") onMouseOver(targetNode);
-        }
-        function getFirstAvailableDay(delta) {
-            var startMonth = delta > 0 ? 0 : self.config.showMonths - 1;
-            var endMonth = delta > 0 ? self.config.showMonths : -1;
-            for (var m = startMonth; m != endMonth; m += delta) {
-                var month = self.daysContainer.children[m];
-                var startIndex = delta > 0 ? 0 : month.children.length - 1;
-                var endIndex = delta > 0 ? month.children.length : -1;
-                for (var i = startIndex; i != endIndex; i += delta) {
-                    var c = month.children[i];
-                    if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj)) return c;
-                }
-            }
-            return undefined;
-        }
-        function getNextAvailableDay(current, delta) {
-            var givenMonth = current.className.indexOf("Month") === -1 ? current.dateObj.getMonth() : self.currentMonth;
-            var endMonth = delta > 0 ? self.config.showMonths : -1;
-            var loopDelta = delta > 0 ? 1 : -1;
-            for (var m = givenMonth - self.currentMonth; m != endMonth; m += loopDelta) {
-                var month = self.daysContainer.children[m];
-                var startIndex = givenMonth - self.currentMonth === m ? current.$i + delta : delta < 0 ? month.children.length - 1 : 0;
-                var numMonthDays = month.children.length;
-                for (var i = startIndex; i >= 0 && i < numMonthDays && i != (delta > 0 ? numMonthDays : -1); i += loopDelta) {
-                    var c = month.children[i];
-                    if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj) && Math.abs(current.$i - i) >= Math.abs(delta)) return focusOnDayElem(c);
-                }
-            }
-            self.changeMonth(loopDelta);
-            focusOnDay(getFirstAvailableDay(loopDelta), 0);
-            return undefined;
-        }
-        function focusOnDay(current, offset) {
-            var dayFocused = isInView(document.activeElement || document.body);
-            var startElem = current !== undefined ? current : dayFocused ? document.activeElement : self.selectedDateElem !== undefined && isInView(self.selectedDateElem) ? self.selectedDateElem : self.todayDateElem !== undefined && isInView(self.todayDateElem) ? self.todayDateElem : getFirstAvailableDay(offset > 0 ? 1 : -1);
-            if (startElem === undefined) return self._input.focus();
-            if (!dayFocused) return focusOnDayElem(startElem);
-            getNextAvailableDay(startElem, offset);
-        }
-        function buildMonthDays(year, month) {
-            var firstOfMonth = (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
-            var prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12);
-            var daysInMonth = self.utils.getDaysInMonth(month),
-                days = window.document.createDocumentFragment(),
-                isMultiMonth = self.config.showMonths > 1,
-                prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
-                nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
-            var dayNumber = prevMonthDays + 1 - firstOfMonth,
-                dayIndex = 0;
-            // prepend days from the ending of previous month
-            for (; dayNumber <= prevMonthDays; dayNumber++, dayIndex++) {
-                days.appendChild(createDay(prevMonthDayClass, new Date(year, month - 1, dayNumber), dayNumber, dayIndex));
-            }
-            // Start at 1 since there is no 0th day
-            for (dayNumber = 1; dayNumber <= daysInMonth; dayNumber++, dayIndex++) {
-                days.appendChild(createDay("", new Date(year, month, dayNumber), dayNumber, dayIndex));
-            }
-            // append days from the next month
-            for (var dayNum = daysInMonth + 1; dayNum <= 42 - firstOfMonth && (self.config.showMonths === 1 || dayIndex % 7 !== 0); dayNum++, dayIndex++) {
-                days.appendChild(createDay(nextMonthDayClass, new Date(year, month + 1, dayNum % daysInMonth), dayNum, dayIndex));
-            }
-            //updateNavigationCurrentMonth();
-            var dayContainer = createElement("div", "dayContainer");
-            dayContainer.appendChild(days);
-            return dayContainer;
-        }
-        function buildDays() {
-            if (self.daysContainer === undefined) {
-                return;
-            }
-            clearNode(self.daysContainer);
-            // TODO: week numbers for each month
-            if (self.weekNumbers) clearNode(self.weekNumbers);
-            var frag = document.createDocumentFragment();
-            for (var i = 0; i < self.config.showMonths; i++) {
-                var d = new Date(self.currentYear, self.currentMonth, 1);
-                d.setMonth(self.currentMonth + i);
-                frag.appendChild(buildMonthDays(d.getFullYear(), d.getMonth()));
-            }
-            self.daysContainer.appendChild(frag);
-            self.days = self.daysContainer.firstChild;
-            if (self.config.mode === "range" && self.selectedDates.length === 1) {
-                onMouseOver();
-            }
-        }
-        function buildMonthSwitch() {
-            if (self.config.showMonths > 1 || self.config.monthSelectorType !== "dropdown") return;
-            var shouldBuildMonth = function shouldBuildMonth(month) {
-                if (self.config.minDate !== undefined && self.currentYear === self.config.minDate.getFullYear() && month < self.config.minDate.getMonth()) {
-                    return false;
-                }
-                return !(self.config.maxDate !== undefined && self.currentYear === self.config.maxDate.getFullYear() && month > self.config.maxDate.getMonth());
-            };
-            self.monthsDropdownContainer.tabIndex = -1;
-            self.monthsDropdownContainer.innerHTML = "";
-            for (var i = 0; i < 12; i++) {
-                if (!shouldBuildMonth(i)) continue;
-                var month = createElement("option", "flatpickr-monthDropdown-month");
-                month.value = new Date(self.currentYear, i).getMonth().toString();
-                month.textContent = monthToStr(i, self.config.shorthandCurrentMonth, self.l10n);
-                month.tabIndex = -1;
-                if (self.currentMonth === i) {
-                    month.selected = true;
-                }
-                self.monthsDropdownContainer.appendChild(month);
-            }
-        }
-        function buildMonth() {
-            var container = createElement("div", "flatpickr-month");
-            var monthNavFragment = window.document.createDocumentFragment();
-            var monthElement;
-            if (self.config.showMonths > 1 || self.config.monthSelectorType === "static") {
-                monthElement = createElement("span", "cur-month");
-            } else {
-                self.monthsDropdownContainer = createElement("select", "flatpickr-monthDropdown-months");
-                bind(self.monthsDropdownContainer, "change", function (e) {
-                    var target = e.target;
-                    var selectedMonth = parseInt(target.value, 10);
-                    self.changeMonth(selectedMonth - self.currentMonth);
-                    triggerEvent("onMonthChange");
-                });
-                buildMonthSwitch();
-                monthElement = self.monthsDropdownContainer;
-            }
-            var yearInput = createNumberInput("cur-year", { tabindex: "-1" });
-            var yearElement = yearInput.getElementsByTagName("input")[0];
-            yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
-            if (self.config.minDate) {
-                yearElement.setAttribute("min", self.config.minDate.getFullYear().toString());
-            }
-            if (self.config.maxDate) {
-                yearElement.setAttribute("max", self.config.maxDate.getFullYear().toString());
-                yearElement.disabled = !!self.config.minDate && self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
-            }
-            var currentMonth = createElement("div", "flatpickr-current-month");
-            currentMonth.appendChild(monthElement);
-            currentMonth.appendChild(yearInput);
-            monthNavFragment.appendChild(currentMonth);
-            container.appendChild(monthNavFragment);
-            return {
-                container: container,
-                yearElement: yearElement,
-                monthElement: monthElement
-            };
-        }
-        function buildMonths() {
-            clearNode(self.monthNav);
-            self.monthNav.appendChild(self.prevMonthNav);
-            if (self.config.showMonths) {
-                self.yearElements = [];
-                self.monthElements = [];
-            }
-            for (var m = self.config.showMonths; m--;) {
-                var month = buildMonth();
-                self.yearElements.push(month.yearElement);
-                self.monthElements.push(month.monthElement);
-                self.monthNav.appendChild(month.container);
-            }
-            self.monthNav.appendChild(self.nextMonthNav);
-        }
-        function buildMonthNav() {
-            self.monthNav = createElement("div", "flatpickr-months");
-            self.yearElements = [];
-            self.monthElements = [];
-            self.prevMonthNav = createElement("span", "flatpickr-prev-month");
-            self.prevMonthNav.innerHTML = self.config.prevArrow;
-            self.nextMonthNav = createElement("span", "flatpickr-next-month");
-            self.nextMonthNav.innerHTML = self.config.nextArrow;
-            buildMonths();
-            Object.defineProperty(self, "_hidePrevMonthArrow", {
-                get: function get() {
-                    return self.__hidePrevMonthArrow;
-                },
-                set: function set(bool) {
-                    if (self.__hidePrevMonthArrow !== bool) {
-                        toggleClass(self.prevMonthNav, "flatpickr-disabled", bool);
-                        self.__hidePrevMonthArrow = bool;
-                    }
-                }
-            });
-            Object.defineProperty(self, "_hideNextMonthArrow", {
-                get: function get() {
-                    return self.__hideNextMonthArrow;
-                },
-                set: function set(bool) {
-                    if (self.__hideNextMonthArrow !== bool) {
-                        toggleClass(self.nextMonthNav, "flatpickr-disabled", bool);
-                        self.__hideNextMonthArrow = bool;
-                    }
-                }
-            });
-            self.currentYearElement = self.yearElements[0];
-            updateNavigationCurrentMonth();
-            return self.monthNav;
-        }
-        function buildTime() {
-            self.calendarContainer.classList.add("hasTime");
-            if (self.config.noCalendar) self.calendarContainer.classList.add("noCalendar");
-            self.timeContainer = createElement("div", "flatpickr-time");
-            self.timeContainer.tabIndex = -1;
-            var separator = createElement("span", "flatpickr-time-separator", ":");
-            var hourInput = createNumberInput("flatpickr-hour", {
-                "aria-label": self.l10n.hourAriaLabel
-            });
-            self.hourElement = hourInput.getElementsByTagName("input")[0];
-            var minuteInput = createNumberInput("flatpickr-minute", {
-                "aria-label": self.l10n.minuteAriaLabel
-            });
-            self.minuteElement = minuteInput.getElementsByTagName("input")[0];
-            self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
-            self.hourElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getHours() : self.config.time_24hr ? self.config.defaultHour : military2ampm(self.config.defaultHour));
-            self.minuteElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getMinutes() : self.config.defaultMinute);
-            self.hourElement.setAttribute("step", self.config.hourIncrement.toString());
-            self.minuteElement.setAttribute("step", self.config.minuteIncrement.toString());
-            self.hourElement.setAttribute("min", self.config.time_24hr ? "0" : "1");
-            self.hourElement.setAttribute("max", self.config.time_24hr ? "23" : "12");
-            self.minuteElement.setAttribute("min", "0");
-            self.minuteElement.setAttribute("max", "59");
-            self.timeContainer.appendChild(hourInput);
-            self.timeContainer.appendChild(separator);
-            self.timeContainer.appendChild(minuteInput);
-            if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
-            if (self.config.enableSeconds) {
-                self.timeContainer.classList.add("hasSeconds");
-                var secondInput = createNumberInput("flatpickr-second");
-                self.secondElement = secondInput.getElementsByTagName("input")[0];
-                self.secondElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getSeconds() : self.config.defaultSeconds);
-                self.secondElement.setAttribute("step", self.minuteElement.getAttribute("step"));
-                self.secondElement.setAttribute("min", "0");
-                self.secondElement.setAttribute("max", "59");
-                self.timeContainer.appendChild(createElement("span", "flatpickr-time-separator", ":"));
-                self.timeContainer.appendChild(secondInput);
-            }
-            if (!self.config.time_24hr) {
-                // add self.amPM if appropriate
-                self.amPM = createElement("span", "flatpickr-am-pm", self.l10n.amPM[int((self.latestSelectedDateObj ? self.hourElement.value : self.config.defaultHour) > 11)]);
-                self.amPM.title = self.l10n.toggleTitle;
-                self.amPM.tabIndex = -1;
-                self.timeContainer.appendChild(self.amPM);
-            }
-            return self.timeContainer;
-        }
-        function buildWeekdays() {
-            if (!self.weekdayContainer) self.weekdayContainer = createElement("div", "flatpickr-weekdays");else clearNode(self.weekdayContainer);
-            for (var i = self.config.showMonths; i--;) {
-                var container = createElement("div", "flatpickr-weekdaycontainer");
-                self.weekdayContainer.appendChild(container);
-            }
-            updateWeekdays();
-            return self.weekdayContainer;
-        }
-        function updateWeekdays() {
-            var firstDayOfWeek = self.l10n.firstDayOfWeek;
-            var weekdays = self.l10n.weekdays.shorthand.slice();
-            if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {
-                weekdays = weekdays.splice(firstDayOfWeek, weekdays.length).concat(weekdays.splice(0, firstDayOfWeek));
-            }
-            for (var i = self.config.showMonths; i--;) {
-                self.weekdayContainer.children[i].innerHTML = "\n      <span class='flatpickr-weekday'>\n        " + weekdays.join("</span><span class='flatpickr-weekday'>") + "\n      </span>\n      ";
-            }
-        }
-        /* istanbul ignore next */
-        function buildWeeks() {
-            self.calendarContainer.classList.add("hasWeeks");
-            var weekWrapper = createElement("div", "flatpickr-weekwrapper");
-            weekWrapper.appendChild(createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation));
-            var weekNumbers = createElement("div", "flatpickr-weeks");
-            weekWrapper.appendChild(weekNumbers);
-            return {
-                weekWrapper: weekWrapper,
-                weekNumbers: weekNumbers
-            };
-        }
-        function changeMonth(value, isOffset) {
-            if (isOffset === void 0) {
-                isOffset = true;
-            }
-            var delta = isOffset ? value : value - self.currentMonth;
-            if (delta < 0 && self._hidePrevMonthArrow === true || delta > 0 && self._hideNextMonthArrow === true) return;
-            self.currentMonth += delta;
-            if (self.currentMonth < 0 || self.currentMonth > 11) {
-                self.currentYear += self.currentMonth > 11 ? 1 : -1;
-                self.currentMonth = (self.currentMonth + 12) % 12;
-                triggerEvent("onYearChange");
-                buildMonthSwitch();
-            }
-            buildDays();
-            triggerEvent("onMonthChange");
-            updateNavigationCurrentMonth();
-        }
-        function clear(triggerChangeEvent, toInitial) {
-            if (triggerChangeEvent === void 0) {
-                triggerChangeEvent = true;
-            }
-            if (toInitial === void 0) {
-                toInitial = true;
-            }
-            self.input.value = "";
-            if (self.altInput !== undefined) self.altInput.value = "";
-            if (self.mobileInput !== undefined) self.mobileInput.value = "";
-            self.selectedDates = [];
-            self.latestSelectedDateObj = undefined;
-            if (toInitial === true) {
-                self.currentYear = self._initialDate.getFullYear();
-                self.currentMonth = self._initialDate.getMonth();
-            }
-            self.showTimeInput = false;
-            if (self.config.enableTime === true) {
-                setDefaultHours();
-            }
-            self.redraw();
-            if (triggerChangeEvent)
-                // triggerChangeEvent is true (default) or an Event
-                triggerEvent("onChange");
-        }
-        function close() {
-            self.isOpen = false;
-            if (!self.isMobile) {
-                if (self.calendarContainer !== undefined) {
-                    self.calendarContainer.classList.remove("open");
-                }
-                if (self._input !== undefined) {
-                    self._input.classList.remove("active");
-                }
-            }
-            triggerEvent("onClose");
-        }
-        function destroy() {
-            if (self.config !== undefined) triggerEvent("onDestroy");
-            for (var i = self._handlers.length; i--;) {
-                var h = self._handlers[i];
-                h.element.removeEventListener(h.event, h.handler, h.options);
-            }
-            self._handlers = [];
-            if (self.mobileInput) {
-                if (self.mobileInput.parentNode) self.mobileInput.parentNode.removeChild(self.mobileInput);
-                self.mobileInput = undefined;
-            } else if (self.calendarContainer && self.calendarContainer.parentNode) {
-                if (self.config.static && self.calendarContainer.parentNode) {
-                    var wrapper = self.calendarContainer.parentNode;
-                    wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
-                    if (wrapper.parentNode) {
-                        while (wrapper.firstChild) {
-                            wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
-                        }wrapper.parentNode.removeChild(wrapper);
-                    }
-                } else self.calendarContainer.parentNode.removeChild(self.calendarContainer);
-            }
-            if (self.altInput) {
-                self.input.type = "text";
-                if (self.altInput.parentNode) self.altInput.parentNode.removeChild(self.altInput);
-                delete self.altInput;
-            }
-            if (self.input) {
-                self.input.type = self.input._type;
-                self.input.classList.remove("flatpickr-input");
-                self.input.removeAttribute("readonly");
-                self.input.value = "";
-            }
-            ["_showTimeInput", "latestSelectedDateObj", "_hideNextMonthArrow", "_hidePrevMonthArrow", "__hideNextMonthArrow", "__hidePrevMonthArrow", "isMobile", "isOpen", "selectedDateElem", "minDateHasTime", "maxDateHasTime", "days", "daysContainer", "_input", "_positionElement", "innerContainer", "rContainer", "monthNav", "todayDateElem", "calendarContainer", "weekdayContainer", "prevMonthNav", "nextMonthNav", "monthsDropdownContainer", "currentMonthElement", "currentYearElement", "navigationCurrentMonth", "selectedDateElem", "config"].forEach(function (k) {
-                try {
-                    delete self[k];
-                } catch (_) {}
-            });
-        }
-        function isCalendarElem(elem) {
-            if (self.config.appendTo && self.config.appendTo.contains(elem)) return true;
-            return self.calendarContainer.contains(elem);
-        }
-        function documentClick(e) {
-            if (self.isOpen && !self.config.inline) {
-                var eventTarget_1 = getEventTarget(e);
-                var isCalendarElement = isCalendarElem(eventTarget_1);
-                var isInput = eventTarget_1 === self.input || eventTarget_1 === self.altInput || self.element.contains(eventTarget_1) ||
-                // web components
-                // e.path is not present in all browsers. circumventing typechecks
-                e.path && e.path.indexOf && (~e.path.indexOf(self.input) || ~e.path.indexOf(self.altInput));
-                var lostFocus = e.type === "blur" ? isInput && e.relatedTarget && !isCalendarElem(e.relatedTarget) : !isInput && !isCalendarElement && !isCalendarElem(e.relatedTarget);
-                var isIgnored = !self.config.ignoredFocusElements.some(function (elem) {
-                    return elem.contains(eventTarget_1);
-                });
-                if (lostFocus && isIgnored) {
-                    self.close();
-                    if (self.config.mode === "range" && self.selectedDates.length === 1) {
-                        self.clear(false);
-                        self.redraw();
-                    }
-                }
-            }
-        }
-        function changeYear(newYear) {
-            if (!newYear || self.config.minDate && newYear < self.config.minDate.getFullYear() || self.config.maxDate && newYear > self.config.maxDate.getFullYear()) return;
-            var newYearNum = newYear,
-                isNewYear = self.currentYear !== newYearNum;
-            self.currentYear = newYearNum || self.currentYear;
-            if (self.config.maxDate && self.currentYear === self.config.maxDate.getFullYear()) {
-                self.currentMonth = Math.min(self.config.maxDate.getMonth(), self.currentMonth);
-            } else if (self.config.minDate && self.currentYear === self.config.minDate.getFullYear()) {
-                self.currentMonth = Math.max(self.config.minDate.getMonth(), self.currentMonth);
-            }
-            if (isNewYear) {
-                self.redraw();
-                triggerEvent("onYearChange");
-                buildMonthSwitch();
-            }
-        }
-        function isEnabled(date, timeless) {
-            if (timeless === void 0) {
-                timeless = true;
-            }
-            var dateToCheck = self.parseDate(date, undefined, timeless); // timeless
-            if (self.config.minDate && dateToCheck && compareDates(dateToCheck, self.config.minDate, timeless !== undefined ? timeless : !self.minDateHasTime) < 0 || self.config.maxDate && dateToCheck && compareDates(dateToCheck, self.config.maxDate, timeless !== undefined ? timeless : !self.maxDateHasTime) > 0) return false;
-            if (self.config.enable.length === 0 && self.config.disable.length === 0) return true;
-            if (dateToCheck === undefined) return false;
-            var bool = self.config.enable.length > 0,
-                array = bool ? self.config.enable : self.config.disable;
-            for (var i = 0, d = void 0; i < array.length; i++) {
-                d = array[i];
-                if (typeof d === "function" && d(dateToCheck) // disabled by function
-                ) return bool;else if (d instanceof Date && dateToCheck !== undefined && d.getTime() === dateToCheck.getTime())
-                    // disabled by date
-                    return bool;else if (typeof d === "string" && dateToCheck !== undefined) {
-                    // disabled by date string
-                    var parsed = self.parseDate(d, undefined, true);
-                    return parsed && parsed.getTime() === dateToCheck.getTime() ? bool : !bool;
-                } else if (
-                // disabled by range
-                (typeof d === 'undefined' ? 'undefined' : _typeof(d)) === "object" && dateToCheck !== undefined && d.from && d.to && dateToCheck.getTime() >= d.from.getTime() && dateToCheck.getTime() <= d.to.getTime()) return bool;
-            }
-            return !bool;
-        }
-        function isInView(elem) {
-            if (self.daysContainer !== undefined) return elem.className.indexOf("hidden") === -1 && self.daysContainer.contains(elem);
-            return false;
-        }
-        function onKeyDown(e) {
-            // e.key                      e.keyCode
-            // "Backspace"                        8
-            // "Tab"                              9
-            // "Enter"                           13
-            // "Escape"     (IE "Esc")           27
-            // "ArrowLeft"  (IE "Left")          37
-            // "ArrowUp"    (IE "Up")            38
-            // "ArrowRight" (IE "Right")         39
-            // "ArrowDown"  (IE "Down")          40
-            // "Delete"     (IE "Del")           46
-            var isInput = e.target === self._input;
-            var allowInput = self.config.allowInput;
-            var allowKeydown = self.isOpen && (!allowInput || !isInput);
-            var allowInlineKeydown = self.config.inline && isInput && !allowInput;
-            if (e.keyCode === 13 && isInput) {
-                if (allowInput) {
-                    self.setDate(self._input.value, true, e.target === self.altInput ? self.config.altFormat : self.config.dateFormat);
-                    return e.target.blur();
-                } else {
-                    self.open();
-                }
-            } else if (isCalendarElem(e.target) || allowKeydown || allowInlineKeydown) {
-                var isTimeObj = !!self.timeContainer && self.timeContainer.contains(e.target);
-                switch (e.keyCode) {
-                    case 13:
-                        if (isTimeObj) {
-                            e.preventDefault();
-                            updateTime();
-                            focusAndClose();
-                        } else selectDate(e);
-                        break;
-                    case 27:
-                        // escape
-                        e.preventDefault();
-                        focusAndClose();
-                        break;
-                    case 8:
-                    case 46:
-                        if (isInput && !self.config.allowInput) {
-                            e.preventDefault();
-                            self.clear();
-                        }
-                        break;
-                    case 37:
-                    case 39:
-                        if (!isTimeObj && !isInput) {
-                            e.preventDefault();
-                            if (self.daysContainer !== undefined && (allowInput === false || document.activeElement && isInView(document.activeElement))) {
-                                var delta_1 = e.keyCode === 39 ? 1 : -1;
-                                if (!e.ctrlKey) focusOnDay(undefined, delta_1);else {
-                                    e.stopPropagation();
-                                    changeMonth(delta_1);
-                                    focusOnDay(getFirstAvailableDay(1), 0);
-                                }
-                            }
-                        } else if (self.hourElement) self.hourElement.focus();
-                        break;
-                    case 38:
-                    case 40:
-                        e.preventDefault();
-                        var delta = e.keyCode === 40 ? 1 : -1;
-                        if (self.daysContainer && e.target.$i !== undefined || e.target === self.input) {
-                            if (e.ctrlKey) {
-                                e.stopPropagation();
-                                changeYear(self.currentYear - delta);
-                                focusOnDay(getFirstAvailableDay(1), 0);
-                            } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
-                        } else if (e.target === self.currentYearElement) {
-                            changeYear(self.currentYear - delta);
-                        } else if (self.config.enableTime) {
-                            if (!isTimeObj && self.hourElement) self.hourElement.focus();
-                            updateTime(e);
-                            self._debouncedChange();
-                        }
-                        break;
-                    case 9:
-                        if (isTimeObj) {
-                            var elems = [self.hourElement, self.minuteElement, self.secondElement, self.amPM].concat(self.pluginElements).filter(function (x) {
-                                return x;
-                            });
-                            var i = elems.indexOf(e.target);
-                            if (i !== -1) {
-                                var target = elems[i + (e.shiftKey ? -1 : 1)];
-                                e.preventDefault();
-                                (target || self._input).focus();
-                            }
-                        } else if (!self.config.noCalendar && self.daysContainer && self.daysContainer.contains(e.target) && e.shiftKey) {
-                            e.preventDefault();
-                            self._input.focus();
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            if (self.amPM !== undefined && e.target === self.amPM) {
-                switch (e.key) {
-                    case self.l10n.amPM[0].charAt(0):
-                    case self.l10n.amPM[0].charAt(0).toLowerCase():
-                        self.amPM.textContent = self.l10n.amPM[0];
-                        setHoursFromInputs();
-                        updateValue();
-                        break;
-                    case self.l10n.amPM[1].charAt(0):
-                    case self.l10n.amPM[1].charAt(0).toLowerCase():
-                        self.amPM.textContent = self.l10n.amPM[1];
-                        setHoursFromInputs();
-                        updateValue();
-                        break;
-                }
-            }
-            if (isInput || isCalendarElem(e.target)) {
-                triggerEvent("onKeyDown", e);
-            }
-        }
-        function onMouseOver(elem) {
-            if (self.selectedDates.length !== 1 || elem && (!elem.classList.contains("flatpickr-day") || elem.classList.contains("flatpickr-disabled"))) return;
-            var hoverDate = elem ? elem.dateObj.getTime() : self.days.firstElementChild.dateObj.getTime(),
-                initialDate = self.parseDate(self.selectedDates[0], undefined, true).getTime(),
-                rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
-                rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime());
-            var containsDisabled = false;
-            var minRange = 0,
-                maxRange = 0;
-            for (var t = rangeStartDate; t < rangeEndDate; t += duration.DAY) {
-                if (!isEnabled(new Date(t), true)) {
-                    containsDisabled = containsDisabled || t > rangeStartDate && t < rangeEndDate;
-                    if (t < initialDate && (!minRange || t > minRange)) minRange = t;else if (t > initialDate && (!maxRange || t < maxRange)) maxRange = t;
-                }
-            }
-            for (var m = 0; m < self.config.showMonths; m++) {
-                var month = self.daysContainer.children[m];
-                var _loop_1 = function _loop_1(i, l) {
-                    var dayElem = month.children[i],
-                        date = dayElem.dateObj;
-                    var timestamp = date.getTime();
-                    var outOfRange = minRange > 0 && timestamp < minRange || maxRange > 0 && timestamp > maxRange;
-                    if (outOfRange) {
-                        dayElem.classList.add("notAllowed");
-                        ["inRange", "startRange", "endRange"].forEach(function (c) {
-                            dayElem.classList.remove(c);
-                        });
-                        return "continue";
-                    } else if (containsDisabled && !outOfRange) return "continue";
-                    ["startRange", "inRange", "endRange", "notAllowed"].forEach(function (c) {
-                        dayElem.classList.remove(c);
-                    });
-                    if (elem !== undefined) {
-                        elem.classList.add(hoverDate <= self.selectedDates[0].getTime() ? "startRange" : "endRange");
-                        if (initialDate < hoverDate && timestamp === initialDate) dayElem.classList.add("startRange");else if (initialDate > hoverDate && timestamp === initialDate) dayElem.classList.add("endRange");
-                        if (timestamp >= minRange && (maxRange === 0 || timestamp <= maxRange) && isBetween(timestamp, initialDate, hoverDate)) dayElem.classList.add("inRange");
-                    }
-                };
-                for (var i = 0, l = month.children.length; i < l; i++) {
-                    _loop_1(i, l);
-                }
-            }
-        }
-        function onResize() {
-            if (self.isOpen && !self.config.static && !self.config.inline) positionCalendar();
-        }
-        function setDefaultTime() {
-            self.setDate(self.config.minDate !== undefined ? new Date(self.config.minDate.getTime()) : new Date(), true);
-            setDefaultHours();
-            updateValue();
-        }
-        function open(e, positionElement) {
-            if (positionElement === void 0) {
-                positionElement = self._positionElement;
-            }
-            if (self.isMobile === true) {
-                if (e) {
-                    e.preventDefault();
-                    e.target && e.target.blur();
-                }
-                if (self.mobileInput !== undefined) {
-                    self.mobileInput.focus();
-                    self.mobileInput.click();
-                }
-                triggerEvent("onOpen");
-                return;
-            }
-            if (self._input.disabled || self.config.inline) return;
-            var wasOpen = self.isOpen;
-            self.isOpen = true;
-            if (!wasOpen) {
-                self.calendarContainer.classList.add("open");
-                self._input.classList.add("active");
-                triggerEvent("onOpen");
-                positionCalendar(positionElement);
-            }
-            if (self.config.enableTime === true && self.config.noCalendar === true) {
-                if (self.selectedDates.length === 0) {
-                    setDefaultTime();
-                }
-                if (self.config.allowInput === false && (e === undefined || !self.timeContainer.contains(e.relatedTarget))) {
-                    setTimeout(function () {
-                        return self.hourElement.select();
-                    }, 50);
-                }
-            }
-        }
-        function minMaxDateSetter(type) {
-            return function (date) {
-                var dateObj = self.config["_" + type + "Date"] = self.parseDate(date, self.config.dateFormat);
-                var inverseDateObj = self.config["_" + (type === "min" ? "max" : "min") + "Date"];
-                if (dateObj !== undefined) {
-                    self[type === "min" ? "minDateHasTime" : "maxDateHasTime"] = dateObj.getHours() > 0 || dateObj.getMinutes() > 0 || dateObj.getSeconds() > 0;
-                }
-                if (self.selectedDates) {
-                    self.selectedDates = self.selectedDates.filter(function (d) {
-                        return isEnabled(d);
-                    });
-                    if (!self.selectedDates.length && type === "min") setHoursFromDate(dateObj);
-                    updateValue();
-                }
-                if (self.daysContainer) {
-                    redraw();
-                    if (dateObj !== undefined) self.currentYearElement[type] = dateObj.getFullYear().toString();else self.currentYearElement.removeAttribute(type);
-                    self.currentYearElement.disabled = !!inverseDateObj && dateObj !== undefined && inverseDateObj.getFullYear() === dateObj.getFullYear();
-                }
-            };
-        }
-        function parseConfig() {
-            var boolOpts = ["wrap", "weekNumbers", "allowInput", "clickOpens", "time_24hr", "enableTime", "noCalendar", "altInput", "shorthandCurrentMonth", "inline", "static", "enableSeconds", "disableMobile"];
-            var userConfig = _assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
-            var formats = {};
-            self.config.parseDate = userConfig.parseDate;
-            self.config.formatDate = userConfig.formatDate;
-            Object.defineProperty(self.config, "enable", {
-                get: function get() {
-                    return self.config._enable;
-                },
-                set: function set(dates) {
-                    self.config._enable = parseDateRules(dates);
-                }
-            });
-            Object.defineProperty(self.config, "disable", {
-                get: function get() {
-                    return self.config._disable;
-                },
-                set: function set(dates) {
-                    self.config._disable = parseDateRules(dates);
-                }
-            });
-            var timeMode = userConfig.mode === "time";
-            if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
-                var defaultDateFormat = flatpickr.defaultConfig.dateFormat || defaults.dateFormat;
-                formats.dateFormat = userConfig.noCalendar || timeMode ? "H:i" + (userConfig.enableSeconds ? ":S" : "") : defaultDateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
-            }
-            if (userConfig.altInput && (userConfig.enableTime || timeMode) && !userConfig.altFormat) {
-                var defaultAltFormat = flatpickr.defaultConfig.altFormat || defaults.altFormat;
-                formats.altFormat = userConfig.noCalendar || timeMode ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K") : defaultAltFormat + (" h:i" + (userConfig.enableSeconds ? ":S" : "") + " K");
-            }
-            if (!userConfig.altInputClass) {
-                self.config.altInputClass = self.input.className + " " + self.config.altInputClass;
-            }
-            Object.defineProperty(self.config, "minDate", {
-                get: function get() {
-                    return self.config._minDate;
-                },
-                set: minMaxDateSetter("min")
-            });
-            Object.defineProperty(self.config, "maxDate", {
-                get: function get() {
-                    return self.config._maxDate;
-                },
-                set: minMaxDateSetter("max")
-            });
-            var minMaxTimeSetter = function minMaxTimeSetter(type) {
-                return function (val) {
-                    self.config[type === "min" ? "_minTime" : "_maxTime"] = self.parseDate(val, "H:i");
-                };
-            };
-            Object.defineProperty(self.config, "minTime", {
-                get: function get() {
-                    return self.config._minTime;
-                },
-                set: minMaxTimeSetter("min")
-            });
-            Object.defineProperty(self.config, "maxTime", {
-                get: function get() {
-                    return self.config._maxTime;
-                },
-                set: minMaxTimeSetter("max")
-            });
-            if (userConfig.mode === "time") {
-                self.config.noCalendar = true;
-                self.config.enableTime = true;
-            }
-            Object.assign(self.config, formats, userConfig);
-            for (var i = 0; i < boolOpts.length; i++) {
-                self.config[boolOpts[i]] = self.config[boolOpts[i]] === true || self.config[boolOpts[i]] === "true";
-            }HOOKS.filter(function (hook) {
-                return self.config[hook] !== undefined;
-            }).forEach(function (hook) {
-                self.config[hook] = arrayify(self.config[hook] || []).map(bindToInstance);
-            });
-            self.isMobile = !self.config.disableMobile && !self.config.inline && self.config.mode === "single" && !self.config.disable.length && !self.config.enable.length && !self.config.weekNumbers && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-            for (var i = 0; i < self.config.plugins.length; i++) {
-                var pluginConf = self.config.plugins[i](self) || {};
-                for (var key in pluginConf) {
-                    if (HOOKS.indexOf(key) > -1) {
-                        self.config[key] = arrayify(pluginConf[key]).map(bindToInstance).concat(self.config[key]);
-                    } else if (typeof userConfig[key] === "undefined") self.config[key] = pluginConf[key];
-                }
-            }
-            triggerEvent("onParseConfig");
-        }
-        function setupLocale() {
-            if (_typeof(self.config.locale) !== "object" && typeof flatpickr.l10ns[self.config.locale] === "undefined") self.config.errorHandler(new Error("flatpickr: invalid locale " + self.config.locale));
-            self.l10n = _assign({}, flatpickr.l10ns["default"], _typeof(self.config.locale) === "object" ? self.config.locale : self.config.locale !== "default" ? flatpickr.l10ns[self.config.locale] : undefined);
-            tokenRegex.K = "(" + self.l10n.amPM[0] + "|" + self.l10n.amPM[1] + "|" + self.l10n.amPM[0].toLowerCase() + "|" + self.l10n.amPM[1].toLowerCase() + ")";
-            var userConfig = _assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
-            if (userConfig.time_24hr === undefined && flatpickr.defaultConfig.time_24hr === undefined) {
-                self.config.time_24hr = self.l10n.time_24hr;
-            }
-            self.formatDate = createDateFormatter(self);
-            self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
-        }
-        function positionCalendar(customPositionElement) {
-            if (self.calendarContainer === undefined) return;
-            triggerEvent("onPreCalendarPosition");
-            var positionElement = customPositionElement || self._positionElement;
-            var calendarHeight = Array.prototype.reduce.call(self.calendarContainer.children, function (acc, child) {
-                return acc + child.offsetHeight;
-            }, 0),
-                calendarWidth = self.calendarContainer.offsetWidth,
-                configPos = self.config.position.split(" "),
-                configPosVertical = configPos[0],
-                configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
-                inputBounds = positionElement.getBoundingClientRect(),
-                distanceFromBottom = window.innerHeight - inputBounds.bottom,
-                showOnTop = configPosVertical === "above" || configPosVertical !== "below" && distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
-            var top = window.pageYOffset + inputBounds.top + (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
-            toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
-            toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
-            if (self.config.inline) return;
-            var left = window.pageXOffset + inputBounds.left - (configPosHorizontal != null && configPosHorizontal === "center" ? (calendarWidth - inputBounds.width) / 2 : 0);
-            var right = window.document.body.offsetWidth - inputBounds.right;
-            var rightMost = left + calendarWidth > window.document.body.offsetWidth;
-            var centerMost = right + calendarWidth > window.document.body.offsetWidth;
-            toggleClass(self.calendarContainer, "rightMost", rightMost);
-            if (self.config.static) return;
-            self.calendarContainer.style.top = top + "px";
-            if (!rightMost) {
-                self.calendarContainer.style.left = left + "px";
-                self.calendarContainer.style.right = "auto";
-            } else if (!centerMost) {
-                self.calendarContainer.style.left = "auto";
-                self.calendarContainer.style.right = right + "px";
-            } else {
-                var doc = document.styleSheets[0];
-                // some testing environments don't have css support
-                if (doc === undefined) return;
-                var bodyWidth = window.document.body.offsetWidth;
-                var centerLeft = Math.max(0, bodyWidth / 2 - calendarWidth / 2);
-                var centerBefore = ".flatpickr-calendar.centerMost:before";
-                var centerAfter = ".flatpickr-calendar.centerMost:after";
-                var centerIndex = doc.cssRules.length;
-                var centerStyle = "{left:" + inputBounds.left + "px;right:auto;}";
-                toggleClass(self.calendarContainer, "rightMost", false);
-                toggleClass(self.calendarContainer, "centerMost", true);
-                doc.insertRule(centerBefore + "," + centerAfter + centerStyle, centerIndex);
-                self.calendarContainer.style.left = centerLeft + "px";
-                self.calendarContainer.style.right = "auto";
-            }
-        }
-        function redraw() {
-            if (self.config.noCalendar || self.isMobile) return;
-            updateNavigationCurrentMonth();
-            buildDays();
-        }
-        function focusAndClose() {
-            self._input.focus();
-            if (window.navigator.userAgent.indexOf("MSIE") !== -1 || navigator.msMaxTouchPoints !== undefined) {
-                // hack - bugs in the way IE handles focus keeps the calendar open
-                setTimeout(self.close, 0);
-            } else {
-                self.close();
-            }
-        }
-        function selectDate(e) {
-            e.preventDefault();
-            e.stopPropagation();
-            var isSelectable = function isSelectable(day) {
-                return day.classList && day.classList.contains("flatpickr-day") && !day.classList.contains("flatpickr-disabled") && !day.classList.contains("notAllowed");
-            };
-            var t = findParent(e.target, isSelectable);
-            if (t === undefined) return;
-            var target = t;
-            var selectedDate = self.latestSelectedDateObj = new Date(target.dateObj.getTime());
-            var shouldChangeMonth = (selectedDate.getMonth() < self.currentMonth || selectedDate.getMonth() > self.currentMonth + self.config.showMonths - 1) && self.config.mode !== "range";
-            self.selectedDateElem = target;
-            if (self.config.mode === "single") self.selectedDates = [selectedDate];else if (self.config.mode === "multiple") {
-                var selectedIndex = isDateSelected(selectedDate);
-                if (selectedIndex) self.selectedDates.splice(parseInt(selectedIndex), 1);else self.selectedDates.push(selectedDate);
-            } else if (self.config.mode === "range") {
-                if (self.selectedDates.length === 2) {
-                    self.clear(false, false);
-                }
-                self.latestSelectedDateObj = selectedDate;
-                self.selectedDates.push(selectedDate);
-                // unless selecting same date twice, sort ascendingly
-                if (compareDates(selectedDate, self.selectedDates[0], true) !== 0) self.selectedDates.sort(function (a, b) {
-                    return a.getTime() - b.getTime();
-                });
-            }
-            setHoursFromInputs();
-            if (shouldChangeMonth) {
-                var isNewYear = self.currentYear !== selectedDate.getFullYear();
-                self.currentYear = selectedDate.getFullYear();
-                self.currentMonth = selectedDate.getMonth();
-                if (isNewYear) {
-                    triggerEvent("onYearChange");
-                    buildMonthSwitch();
-                }
-                triggerEvent("onMonthChange");
-            }
-            updateNavigationCurrentMonth();
-            buildDays();
-            updateValue();
-            if (self.config.enableTime) setTimeout(function () {
-                return self.showTimeInput = true;
-            }, 50);
-            // maintain focus
-            if (!shouldChangeMonth && self.config.mode !== "range" && self.config.showMonths === 1) focusOnDayElem(target);else if (self.selectedDateElem !== undefined && self.hourElement === undefined) {
-                self.selectedDateElem && self.selectedDateElem.focus();
-            }
-            if (self.hourElement !== undefined) self.hourElement !== undefined && self.hourElement.focus();
-            if (self.config.closeOnSelect) {
-                var single = self.config.mode === "single" && !self.config.enableTime;
-                var range = self.config.mode === "range" && self.selectedDates.length === 2 && !self.config.enableTime;
-                if (single || range) {
-                    focusAndClose();
-                }
-            }
-            triggerChange();
-        }
-        var CALLBACKS = {
-            locale: [setupLocale, updateWeekdays],
-            showMonths: [buildMonths, setCalendarWidth, buildWeekdays],
-            minDate: [jumpToDate],
-            maxDate: [jumpToDate]
-        };
-        function set(option, value) {
-            if (option !== null && (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === "object") {
-                Object.assign(self.config, option);
-                for (var key in option) {
-                    if (CALLBACKS[key] !== undefined) CALLBACKS[key].forEach(function (x) {
-                        return x();
-                    });
-                }
-            } else {
-                self.config[option] = value;
-                if (CALLBACKS[option] !== undefined) CALLBACKS[option].forEach(function (x) {
-                    return x();
-                });else if (HOOKS.indexOf(option) > -1) self.config[option] = arrayify(value);
-            }
-            self.redraw();
-            updateValue(false);
-        }
-        function setSelectedDate(inputDate, format) {
-            var dates = [];
-            if (inputDate instanceof Array) dates = inputDate.map(function (d) {
-                return self.parseDate(d, format);
-            });else if (inputDate instanceof Date || typeof inputDate === "number") dates = [self.parseDate(inputDate, format)];else if (typeof inputDate === "string") {
-                switch (self.config.mode) {
-                    case "single":
-                    case "time":
-                        dates = [self.parseDate(inputDate, format)];
-                        break;
-                    case "multiple":
-                        dates = inputDate.split(self.config.conjunction).map(function (date) {
-                            return self.parseDate(date, format);
-                        });
-                        break;
-                    case "range":
-                        dates = inputDate.split(self.l10n.rangeSeparator).map(function (date) {
-                            return self.parseDate(date, format);
-                        });
-                        break;
-                    default:
-                        break;
-                }
-            } else self.config.errorHandler(new Error("Invalid date supplied: " + JSON.stringify(inputDate)));
-            self.selectedDates = dates.filter(function (d) {
-                return d instanceof Date && isEnabled(d, false);
-            });
-            if (self.config.mode === "range") self.selectedDates.sort(function (a, b) {
-                return a.getTime() - b.getTime();
-            });
-        }
-        function setDate(date, triggerChange, format) {
-            if (triggerChange === void 0) {
-                triggerChange = false;
-            }
-            if (format === void 0) {
-                format = self.config.dateFormat;
-            }
-            if (date !== 0 && !date || date instanceof Array && date.length === 0) return self.clear(triggerChange);
-            setSelectedDate(date, format);
-            self.showTimeInput = self.selectedDates.length > 0;
-            self.latestSelectedDateObj = self.selectedDates[self.selectedDates.length - 1];
-            self.redraw();
-            jumpToDate();
-            setHoursFromDate();
-            if (self.selectedDates.length === 0) {
-                self.clear(false);
-            }
-            updateValue(triggerChange);
-            if (triggerChange) triggerEvent("onChange");
-        }
-        function parseDateRules(arr) {
-            return arr.slice().map(function (rule) {
-                if (typeof rule === "string" || typeof rule === "number" || rule instanceof Date) {
-                    return self.parseDate(rule, undefined, true);
-                } else if (rule && (typeof rule === 'undefined' ? 'undefined' : _typeof(rule)) === "object" && rule.from && rule.to) return {
-                    from: self.parseDate(rule.from, undefined),
-                    to: self.parseDate(rule.to, undefined)
-                };
-                return rule;
-            }).filter(function (x) {
-                return x;
-            }); // remove falsy values
-        }
-        function setupDates() {
-            self.selectedDates = [];
-            self.now = self.parseDate(self.config.now) || new Date();
-            // Workaround IE11 setting placeholder as the input's value
-            var preloadedDate = self.config.defaultDate || ((self.input.nodeName === "INPUT" || self.input.nodeName === "TEXTAREA") && self.input.placeholder && self.input.value === self.input.placeholder ? null : self.input.value);
-            if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
-            self._initialDate = self.selectedDates.length > 0 ? self.selectedDates[0] : self.config.minDate && self.config.minDate.getTime() > self.now.getTime() ? self.config.minDate : self.config.maxDate && self.config.maxDate.getTime() < self.now.getTime() ? self.config.maxDate : self.now;
-            self.currentYear = self._initialDate.getFullYear();
-            self.currentMonth = self._initialDate.getMonth();
-            if (self.selectedDates.length > 0) self.latestSelectedDateObj = self.selectedDates[0];
-            if (self.config.minTime !== undefined) self.config.minTime = self.parseDate(self.config.minTime, "H:i");
-            if (self.config.maxTime !== undefined) self.config.maxTime = self.parseDate(self.config.maxTime, "H:i");
-            self.minDateHasTime = !!self.config.minDate && (self.config.minDate.getHours() > 0 || self.config.minDate.getMinutes() > 0 || self.config.minDate.getSeconds() > 0);
-            self.maxDateHasTime = !!self.config.maxDate && (self.config.maxDate.getHours() > 0 || self.config.maxDate.getMinutes() > 0 || self.config.maxDate.getSeconds() > 0);
-            Object.defineProperty(self, "showTimeInput", {
-                get: function get() {
-                    return self._showTimeInput;
-                },
-                set: function set(bool) {
-                    self._showTimeInput = bool;
-                    if (self.calendarContainer) toggleClass(self.calendarContainer, "showTimeInput", bool);
-                    self.isOpen && positionCalendar();
-                }
-            });
-        }
-        function setupInputs() {
-            self.input = self.config.wrap ? element.querySelector("[data-input]") : element;
-            /* istanbul ignore next */
-            if (!self.input) {
-                self.config.errorHandler(new Error("Invalid input element specified"));
-                return;
-            }
-            // hack: store previous type to restore it after destroy()
-            self.input._type = self.input.type;
-            self.input.type = "text";
-            self.input.classList.add("flatpickr-input");
-            self._input = self.input;
-            if (self.config.altInput) {
-                // replicate self.element
-                self.altInput = createElement(self.input.nodeName, self.config.altInputClass);
-                self._input = self.altInput;
-                self.altInput.placeholder = self.input.placeholder;
-                self.altInput.disabled = self.input.disabled;
-                self.altInput.required = self.input.required;
-                self.altInput.tabIndex = self.input.tabIndex;
-                self.altInput.type = "text";
-                self.input.setAttribute("type", "hidden");
-                if (!self.config.static && self.input.parentNode) self.input.parentNode.insertBefore(self.altInput, self.input.nextSibling);
-            }
-            if (!self.config.allowInput) self._input.setAttribute("readonly", "readonly");
-            self._positionElement = self.config.positionElement || self._input;
-        }
-        function setupMobile() {
-            var inputType = self.config.enableTime ? self.config.noCalendar ? "time" : "datetime-local" : "date";
-            self.mobileInput = createElement("input", self.input.className + " flatpickr-mobile");
-            self.mobileInput.step = self.input.getAttribute("step") || "any";
-            self.mobileInput.tabIndex = 1;
-            self.mobileInput.type = inputType;
-            self.mobileInput.disabled = self.input.disabled;
-            self.mobileInput.required = self.input.required;
-            self.mobileInput.placeholder = self.input.placeholder;
-            self.mobileFormatStr = inputType === "datetime-local" ? "Y-m-d\\TH:i:S" : inputType === "date" ? "Y-m-d" : "H:i:S";
-            if (self.selectedDates.length > 0) {
-                self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(self.selectedDates[0], self.mobileFormatStr);
-            }
-            if (self.config.minDate) self.mobileInput.min = self.formatDate(self.config.minDate, "Y-m-d");
-            if (self.config.maxDate) self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
-            self.input.type = "hidden";
-            if (self.altInput !== undefined) self.altInput.type = "hidden";
-            try {
-                if (self.input.parentNode) self.input.parentNode.insertBefore(self.mobileInput, self.input.nextSibling);
-            } catch (_a) {}
-            bind(self.mobileInput, "change", function (e) {
-                self.setDate(e.target.value, false, self.mobileFormatStr);
-                triggerEvent("onChange");
-                triggerEvent("onClose");
-            });
-        }
-        function toggle(e) {
-            if (self.isOpen === true) return self.close();
-            self.open(e);
-        }
-        function triggerEvent(event, data) {
-            // If the instance has been destroyed already, all hooks have been removed
-            if (self.config === undefined) return;
-            var hooks = self.config[event];
-            if (hooks !== undefined && hooks.length > 0) {
-                for (var i = 0; hooks[i] && i < hooks.length; i++) {
-                    hooks[i](self.selectedDates, self.input.value, self, data);
-                }
-            }
-            if (event === "onChange") {
-                self.input.dispatchEvent(createEvent("change"));
-                // many front-end frameworks bind to the input event
-                self.input.dispatchEvent(createEvent("input"));
-            }
-        }
-        function createEvent(name) {
-            var e = document.createEvent("Event");
-            e.initEvent(name, true, true);
-            return e;
-        }
-        function isDateSelected(date) {
-            for (var i = 0; i < self.selectedDates.length; i++) {
-                if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
-            }
-            return false;
-        }
-        function isDateInRange(date) {
-            if (self.config.mode !== "range" || self.selectedDates.length < 2) return false;
-            return compareDates(date, self.selectedDates[0]) >= 0 && compareDates(date, self.selectedDates[1]) <= 0;
-        }
-        function updateNavigationCurrentMonth() {
-            if (self.config.noCalendar || self.isMobile || !self.monthNav) return;
-            self.yearElements.forEach(function (yearElement, i) {
-                var d = new Date(self.currentYear, self.currentMonth, 1);
-                d.setMonth(self.currentMonth + i);
-                if (self.config.showMonths > 1 || self.config.monthSelectorType === "static") {
-                    self.monthElements[i].textContent = monthToStr(d.getMonth(), self.config.shorthandCurrentMonth, self.l10n) + " ";
-                } else {
-                    self.monthsDropdownContainer.value = d.getMonth().toString();
-                }
-                yearElement.value = d.getFullYear().toString();
-            });
-            self._hidePrevMonthArrow = self.config.minDate !== undefined && (self.currentYear === self.config.minDate.getFullYear() ? self.currentMonth <= self.config.minDate.getMonth() : self.currentYear < self.config.minDate.getFullYear());
-            self._hideNextMonthArrow = self.config.maxDate !== undefined && (self.currentYear === self.config.maxDate.getFullYear() ? self.currentMonth + 1 > self.config.maxDate.getMonth() : self.currentYear > self.config.maxDate.getFullYear());
-        }
-        function getDateStr(format) {
-            return self.selectedDates.map(function (dObj) {
-                return self.formatDate(dObj, format);
-            }).filter(function (d, i, arr) {
-                return self.config.mode !== "range" || self.config.enableTime || arr.indexOf(d) === i;
-            }).join(self.config.mode !== "range" ? self.config.conjunction : self.l10n.rangeSeparator);
-        }
-        /**
-         * Updates the values of inputs associated with the calendar
-         */
-        function updateValue(triggerChange) {
-            if (triggerChange === void 0) {
-                triggerChange = true;
-            }
-            if (self.mobileInput !== undefined && self.mobileFormatStr) {
-                self.mobileInput.value = self.latestSelectedDateObj !== undefined ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr) : "";
-            }
-            self.input.value = getDateStr(self.config.dateFormat);
-            if (self.altInput !== undefined) {
-                self.altInput.value = getDateStr(self.config.altFormat);
-            }
-            if (triggerChange !== false) triggerEvent("onValueUpdate");
-        }
-        function onMonthNavClick(e) {
-            var isPrevMonth = self.prevMonthNav.contains(e.target);
-            var isNextMonth = self.nextMonthNav.contains(e.target);
-            if (isPrevMonth || isNextMonth) {
-                changeMonth(isPrevMonth ? -1 : 1);
-            } else if (self.yearElements.indexOf(e.target) >= 0) {
-                e.target.select();
-            } else if (e.target.classList.contains("arrowUp")) {
-                self.changeYear(self.currentYear + 1);
-            } else if (e.target.classList.contains("arrowDown")) {
-                self.changeYear(self.currentYear - 1);
-            }
-        }
-        function timeWrapper(e) {
-            e.preventDefault();
-            var isKeyDown = e.type === "keydown",
-                input = e.target;
-            if (self.amPM !== undefined && e.target === self.amPM) {
-                self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
-            }
-            var min = parseFloat(input.getAttribute("min")),
-                max = parseFloat(input.getAttribute("max")),
-                step = parseFloat(input.getAttribute("step")),
-                curValue = parseInt(input.value, 10),
-                delta = e.delta || (isKeyDown ? e.which === 38 ? 1 : -1 : 0);
-            var newValue = curValue + step * delta;
-            if (typeof input.value !== "undefined" && input.value.length === 2) {
-                var isHourElem = input === self.hourElement,
-                    isMinuteElem = input === self.minuteElement;
-                if (newValue < min) {
-                    newValue = max + newValue + int(!isHourElem) + (int(isHourElem) && int(!self.amPM));
-                    if (isMinuteElem) incrementNumInput(undefined, -1, self.hourElement);
-                } else if (newValue > max) {
-                    newValue = input === self.hourElement ? newValue - max - int(!self.amPM) : min;
-                    if (isMinuteElem) incrementNumInput(undefined, 1, self.hourElement);
-                }
-                if (self.amPM && isHourElem && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) {
-                    self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
-                }
-                input.value = pad(newValue);
-            }
-        }
-        init();
-        return self;
+    if (timeless !== false) {
+      return new Date(date1.getTime()).setHours(0, 0, 0, 0) - new Date(date2.getTime()).setHours(0, 0, 0, 0);
     }
-    /* istanbul ignore next */
-    function _flatpickr(nodeList, config) {
-        // static list
-        var nodes = Array.prototype.slice.call(nodeList).filter(function (x) {
-            return x instanceof HTMLElement;
+
+    return date1.getTime() - date2.getTime();
+  }
+  var getWeek = function getWeek(givenDate) {
+    var date = new Date(givenDate.getTime());
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7);
+    var week1 = new Date(date.getFullYear(), 0, 4);
+    return 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + (week1.getDay() + 6) % 7) / 7);
+  };
+  var isBetween = function isBetween(ts, ts1, ts2) {
+    return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
+  };
+  var duration = {
+    DAY: 86400000
+  };
+
+  var HOOKS = ["onChange", "onClose", "onDayCreate", "onDestroy", "onKeyDown", "onMonthChange", "onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange", "onPreCalendarPosition"];
+  var defaults = {
+    _disable: [],
+    _enable: [],
+    allowInput: false,
+    altFormat: "F j, Y",
+    altInput: false,
+    altInputClass: "form-control input",
+    animate: (typeof window === 'undefined' ? 'undefined' : _typeof(window)) === "object" && window.navigator.userAgent.indexOf("MSIE") === -1,
+    ariaDateFormat: "F j, Y",
+    clickOpens: true,
+    closeOnSelect: true,
+    conjunction: ", ",
+    dateFormat: "Y-m-d",
+    defaultHour: 12,
+    defaultMinute: 0,
+    defaultSeconds: 0,
+    disable: [],
+    disableMobile: false,
+    enable: [],
+    enableSeconds: false,
+    enableTime: false,
+    errorHandler: function errorHandler(err) {
+      return typeof console !== "undefined" && console.warn(err);
+    },
+    getWeek: getWeek,
+    hourIncrement: 1,
+    ignoredFocusElements: [],
+    inline: false,
+    locale: "default",
+    minuteIncrement: 5,
+    mode: "single",
+    nextArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
+    noCalendar: false,
+    now: new Date(),
+    onChange: [],
+    onClose: [],
+    onDayCreate: [],
+    onDestroy: [],
+    onKeyDown: [],
+    onMonthChange: [],
+    onOpen: [],
+    onParseConfig: [],
+    onReady: [],
+    onValueUpdate: [],
+    onYearChange: [],
+    onPreCalendarPosition: [],
+    plugins: [],
+    position: "auto",
+    positionElement: undefined,
+    prevArrow: "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
+    shorthandCurrentMonth: false,
+    showMonths: 1,
+    static: false,
+    time_24hr: false,
+    weekNumbers: false,
+    wrap: false
+  };
+
+  function toggleClass(elem, className, bool) {
+    if (bool === true) return elem.classList.add(className);
+    elem.classList.remove(className);
+  }
+  function createElement(tag, className, content) {
+    var e = window.document.createElement(tag);
+    className = className || "";
+    content = content || "";
+    e.className = className;
+    if (content !== undefined) e.textContent = content;
+    return e;
+  }
+  function clearNode(node) {
+    while (node.firstChild) {
+      node.removeChild(node.firstChild);
+    }
+  }
+  function findParent(node, condition) {
+    if (condition(node)) return node;else if (node.parentNode) return findParent(node.parentNode, condition);
+    return undefined;
+  }
+  function createNumberInput(inputClassName, opts) {
+    var wrapper = createElement("div", "numInputWrapper"),
+        numInput = createElement("input", "numInput " + inputClassName),
+        arrowUp = createElement("span", "arrowUp"),
+        arrowDown = createElement("span", "arrowDown");
+    numInput.type = "text";
+    numInput.pattern = "\\d*";
+    if (opts !== undefined) for (var key in opts) {
+      numInput.setAttribute(key, opts[key]);
+    }
+    wrapper.appendChild(numInput);
+    wrapper.appendChild(arrowUp);
+    wrapper.appendChild(arrowDown);
+    return wrapper;
+  }
+
+  if (typeof Object.assign !== "function") {
+    Object.assign = function (target) {
+      if (!target) {
+        throw TypeError("Cannot convert undefined or null to object");
+      }
+
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      var _loop = function _loop() {
+        var source = args[_i];
+
+        if (source) {
+          Object.keys(source).forEach(function (key) {
+            return target[key] = source[key];
+          });
+        }
+      };
+
+      for (var _i = 0; _i < args.length; _i++) {
+        _loop();
+      }
+
+      return target;
+    };
+  }
+
+  var DEBOUNCED_CHANGE_MS = 300;
+
+  function FlatpickrInstance(element, instanceConfig) {
+    var self = {
+      config: Object.assign({}, flatpickr.defaultConfig),
+      l10n: english
+    };
+    self.parseDate = createDateParser({
+      config: self.config,
+      l10n: self.l10n
+    });
+    self._handlers = [];
+    self._bind = bind;
+    self._setHoursFromDate = setHoursFromDate;
+    self._positionCalendar = positionCalendar;
+    self.changeMonth = changeMonth;
+    self.changeYear = changeYear;
+    self.clear = clear;
+    self.close = close;
+    self._createElement = createElement;
+    self.destroy = destroy;
+    self.isEnabled = isEnabled;
+    self.jumpToDate = jumpToDate;
+    self.open = open;
+    self.redraw = redraw;
+    self.set = set;
+    self.setDate = setDate;
+    self.toggle = toggle;
+
+    function setupHelperFunctions() {
+      self.utils = {
+        getDaysInMonth: function getDaysInMonth(month, yr) {
+          if (month === void 0) {
+            month = self.currentMonth;
+          }
+
+          if (yr === void 0) {
+            yr = self.currentYear;
+          }
+
+          if (month === 1 && (yr % 4 === 0 && yr % 100 !== 0 || yr % 400 === 0)) return 29;
+          return self.l10n.daysInMonth[month];
+        }
+      };
+    }
+
+    function init() {
+      self.element = self.input = element;
+      self.isOpen = false;
+      parseConfig();
+      setupLocale();
+      setupInputs();
+      setupDates();
+      setupHelperFunctions();
+      if (!self.isMobile) build();
+      bindEvents();
+
+      if (self.selectedDates.length || self.config.noCalendar) {
+        if (self.config.enableTime) {
+          setHoursFromDate(self.config.noCalendar ? self.latestSelectedDateObj || self.config.minDate : undefined);
+        }
+
+        updateValue(false);
+      }
+
+      setCalendarWidth();
+      self.showTimeInput = self.selectedDates.length > 0 || self.config.noCalendar;
+      var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+      if (!self.isMobile && isSafari) {
+        positionCalendar();
+      }
+
+      triggerEvent("onReady");
+    }
+
+    function bindToInstance(fn) {
+      return fn.bind(self);
+    }
+
+    function setCalendarWidth() {
+      var config = self.config;
+      if (config.weekNumbers === false && config.showMonths === 1) return;else if (config.noCalendar !== true) {
+        window.requestAnimationFrame(function () {
+          self.calendarContainer.style.visibility = "hidden";
+          self.calendarContainer.style.display = "block";
+
+          if (self.daysContainer !== undefined) {
+            var daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
+            self.daysContainer.style.width = daysWidth + "px";
+            self.calendarContainer.style.width = daysWidth + (self.weekWrapper !== undefined ? self.weekWrapper.offsetWidth : 0) + "px";
+            self.calendarContainer.style.removeProperty("visibility");
+            self.calendarContainer.style.removeProperty("display");
+          }
         });
-        var instances = [];
-        for (var i = 0; i < nodes.length; i++) {
-            var node = nodes[i];
-            try {
-                if (node.getAttribute("data-fp-omit") !== null) continue;
-                if (node._flatpickr !== undefined) {
-                    node._flatpickr.destroy();
-                    node._flatpickr = undefined;
-                }
-                node._flatpickr = FlatpickrInstance(node, config || {});
-                instances.push(node._flatpickr);
-            } catch (e) {
-                console.error(e);
-            }
-        }
-        return instances.length === 1 ? instances[0] : instances;
-    }
-    /* istanbul ignore next */
-    if (typeof HTMLElement !== "undefined" && typeof HTMLCollection !== "undefined" && typeof NodeList !== "undefined") {
-        // browser env
-        HTMLCollection.prototype.flatpickr = NodeList.prototype.flatpickr = function (config) {
-            return _flatpickr(this, config);
-        };
-        HTMLElement.prototype.flatpickr = function (config) {
-            return _flatpickr([this], config);
-        };
-    }
-    /* istanbul ignore next */
-    var flatpickr = function flatpickr(selector, config) {
-        if (typeof selector === "string") {
-            return _flatpickr(window.document.querySelectorAll(selector), config);
-        } else if (selector instanceof Node) {
-            return _flatpickr([selector], config);
-        } else {
-            return _flatpickr(selector, config);
-        }
-    };
-    /* istanbul ignore next */
-    flatpickr.defaultConfig = {};
-    flatpickr.l10ns = {
-        en: _assign({}, english),
-        "default": _assign({}, english)
-    };
-    flatpickr.localize = function (l10n) {
-        flatpickr.l10ns["default"] = _assign({}, flatpickr.l10ns["default"], l10n);
-    };
-    flatpickr.setDefaults = function (config) {
-        flatpickr.defaultConfig = _assign({}, flatpickr.defaultConfig, config);
-    };
-    flatpickr.parseDate = createDateParser({});
-    flatpickr.formatDate = createDateFormatter({});
-    flatpickr.compareDates = compareDates;
-    /* istanbul ignore next */
-    if (typeof jQuery !== "undefined" && typeof jQuery.fn !== "undefined") {
-        jQuery.fn.flatpickr = function (config) {
-            return _flatpickr(this, config);
-        };
-    }
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    Date.prototype.fp_incr = function (days) {
-        return new Date(this.getFullYear(), this.getMonth(), this.getDate() + (typeof days === "string" ? parseInt(days, 10) : days));
-    };
-    if (typeof window !== "undefined") {
-        window.flatpickr = flatpickr;
+      }
     }
 
-    return flatpickr;
+    function updateTime(e) {
+      if (self.selectedDates.length === 0) return;
+
+      if (e !== undefined && e.type !== "blur") {
+        timeWrapper(e);
+      }
+
+      var prevValue = self._input.value;
+      setHoursFromInputs();
+      updateValue();
+
+      if (self._input.value !== prevValue) {
+        self._debouncedChange();
+      }
+    }
+
+    function ampm2military(hour, amPM) {
+      return hour % 12 + 12 * int(amPM === self.l10n.amPM[1]);
+    }
+
+    function military2ampm(hour) {
+      switch (hour % 24) {
+        case 0:
+        case 12:
+          return 12;
+
+        default:
+          return hour % 12;
+      }
+    }
+
+    function setHoursFromInputs() {
+      if (self.hourElement === undefined || self.minuteElement === undefined) return;
+      var hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
+          minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
+          seconds = self.secondElement !== undefined ? (parseInt(self.secondElement.value, 10) || 0) % 60 : 0;
+
+      if (self.amPM !== undefined) {
+        hours = ampm2military(hours, self.amPM.textContent);
+      }
+
+      var limitMinHours = self.config.minTime !== undefined || self.config.minDate && self.minDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.minDate, true) === 0;
+      var limitMaxHours = self.config.maxTime !== undefined || self.config.maxDate && self.maxDateHasTime && self.latestSelectedDateObj && compareDates(self.latestSelectedDateObj, self.config.maxDate, true) === 0;
+
+      if (limitMaxHours) {
+        var maxTime = self.config.maxTime !== undefined ? self.config.maxTime : self.config.maxDate;
+        hours = Math.min(hours, maxTime.getHours());
+        if (hours === maxTime.getHours()) minutes = Math.min(minutes, maxTime.getMinutes());
+        if (minutes === maxTime.getMinutes()) seconds = Math.min(seconds, maxTime.getSeconds());
+      }
+
+      if (limitMinHours) {
+        var minTime = self.config.minTime !== undefined ? self.config.minTime : self.config.minDate;
+        hours = Math.max(hours, minTime.getHours());
+        if (hours === minTime.getHours()) minutes = Math.max(minutes, minTime.getMinutes());
+        if (minutes === minTime.getMinutes()) seconds = Math.max(seconds, minTime.getSeconds());
+      }
+
+      setHours(hours, minutes, seconds);
+    }
+
+    function setHoursFromDate(dateObj) {
+      var date = dateObj || self.latestSelectedDateObj;
+      if (date) setHours(date.getHours(), date.getMinutes(), date.getSeconds());
+    }
+
+    function setDefaultHours() {
+      var hours = self.config.defaultHour;
+      var minutes = self.config.defaultMinute;
+      var seconds = self.config.defaultSeconds;
+
+      if (self.config.minDate !== undefined) {
+        var min_hr = self.config.minDate.getHours();
+        var min_minutes = self.config.minDate.getMinutes();
+        hours = Math.max(hours, min_hr);
+        if (hours === min_hr) minutes = Math.max(min_minutes, minutes);
+        if (hours === min_hr && minutes === min_minutes) seconds = self.config.minDate.getSeconds();
+      }
+
+      if (self.config.maxDate !== undefined) {
+        var max_hr = self.config.maxDate.getHours();
+        var max_minutes = self.config.maxDate.getMinutes();
+        hours = Math.min(hours, max_hr);
+        if (hours === max_hr) minutes = Math.min(max_minutes, minutes);
+        if (hours === max_hr && minutes === max_minutes) seconds = self.config.maxDate.getSeconds();
+      }
+
+      setHours(hours, minutes, seconds);
+    }
+
+    function setHours(hours, minutes, seconds) {
+      if (self.latestSelectedDateObj !== undefined) {
+        self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
+      }
+
+      if (!self.hourElement || !self.minuteElement || self.isMobile) return;
+      self.hourElement.value = pad(!self.config.time_24hr ? (12 + hours) % 12 + 12 * int(hours % 12 === 0) : hours);
+      self.minuteElement.value = pad(minutes);
+      if (self.amPM !== undefined) self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
+      if (self.secondElement !== undefined) self.secondElement.value = pad(seconds);
+    }
+
+    function onYearInput(event) {
+      var year = parseInt(event.target.value) + (event.delta || 0);
+
+      if (year / 1000 > 1 || event.key === "Enter" && !/[^\d]/.test(year.toString())) {
+        changeYear(year);
+      }
+    }
+
+    function bind(element, event, handler, options) {
+      if (event instanceof Array) return event.forEach(function (ev) {
+        return bind(element, ev, handler, options);
+      });
+      if (element instanceof Array) return element.forEach(function (el) {
+        return bind(el, event, handler, options);
+      });
+      element.addEventListener(event, handler, options);
+
+      self._handlers.push({
+        element: element,
+        event: event,
+        handler: handler,
+        options: options
+      });
+    }
+
+    function onClick(handler) {
+      return function (evt) {
+        evt.which === 1 && handler(evt);
+      };
+    }
+
+    function triggerChange() {
+      triggerEvent("onChange");
+    }
+
+    function bindEvents() {
+      if (self.config.wrap) {
+        ["open", "close", "toggle", "clear"].forEach(function (evt) {
+          Array.prototype.forEach.call(self.element.querySelectorAll("[data-" + evt + "]"), function (el) {
+            return bind(el, "click", self[evt]);
+          });
+        });
+      }
+
+      if (self.isMobile) {
+        setupMobile();
+        return;
+      }
+
+      var debouncedResize = debounce(onResize, 50);
+      self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
+      if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent)) bind(self.daysContainer, "mouseover", function (e) {
+        if (self.config.mode === "range") onMouseOver(e.target);
+      });
+      bind(window.document.body, "keydown", onKeyDown);
+      if (!self.config.static) bind(self._input, "keydown", onKeyDown);
+      if (!self.config.inline && !self.config.static) bind(window, "resize", debouncedResize);
+      if (window.ontouchstart !== undefined) bind(window.document, "click", documentClick);else bind(window.document, "mousedown", onClick(documentClick));
+      bind(window.document, "focus", documentClick, {
+        capture: true
+      });
+
+      if (self.config.clickOpens === true) {
+        bind(self._input, "focus", self.open);
+        bind(self._input, "mousedown", onClick(self.open));
+      }
+
+      if (self.daysContainer !== undefined) {
+        bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
+        bind(self.monthNav, ["keyup", "increment"], onYearInput);
+        bind(self.daysContainer, "mousedown", onClick(selectDate));
+      }
+
+      if (self.timeContainer !== undefined && self.minuteElement !== undefined && self.hourElement !== undefined) {
+        var selText = function selText(e) {
+          return e.target.select();
+        };
+
+        bind(self.timeContainer, ["increment"], updateTime);
+        bind(self.timeContainer, "blur", updateTime, {
+          capture: true
+        });
+        bind(self.timeContainer, "mousedown", onClick(timeIncrement));
+        bind([self.hourElement, self.minuteElement], ["focus", "click"], selText);
+        if (self.secondElement !== undefined) bind(self.secondElement, "focus", function () {
+          return self.secondElement && self.secondElement.select();
+        });
+
+        if (self.amPM !== undefined) {
+          bind(self.amPM, "mousedown", onClick(function (e) {
+            updateTime(e);
+            triggerChange();
+          }));
+        }
+      }
+    }
+
+    function jumpToDate(jumpDate) {
+      var jumpTo = jumpDate !== undefined ? self.parseDate(jumpDate) : self.latestSelectedDateObj || (self.config.minDate && self.config.minDate > self.now ? self.config.minDate : self.config.maxDate && self.config.maxDate < self.now ? self.config.maxDate : self.now);
+
+      try {
+        if (jumpTo !== undefined) {
+          self.currentYear = jumpTo.getFullYear();
+          self.currentMonth = jumpTo.getMonth();
+        }
+      } catch (e) {
+        e.message = "Invalid date supplied: " + jumpTo;
+        self.config.errorHandler(e);
+      }
+
+      self.redraw();
+    }
+
+    function timeIncrement(e) {
+      if (~e.target.className.indexOf("arrow")) incrementNumInput(e, e.target.classList.contains("arrowUp") ? 1 : -1);
+    }
+
+    function incrementNumInput(e, delta, inputElem) {
+      var target = e && e.target;
+      var input = inputElem || target && target.parentNode && target.parentNode.firstChild;
+      var event = createEvent("increment");
+      event.delta = delta;
+      input && input.dispatchEvent(event);
+    }
+
+    function build() {
+      var fragment = window.document.createDocumentFragment();
+      self.calendarContainer = createElement("div", "flatpickr-calendar");
+      self.calendarContainer.tabIndex = -1;
+
+      if (!self.config.noCalendar) {
+        fragment.appendChild(buildMonthNav());
+        self.innerContainer = createElement("div", "flatpickr-innerContainer");
+
+        if (self.config.weekNumbers) {
+          var _buildWeeks = buildWeeks(),
+              weekWrapper = _buildWeeks.weekWrapper,
+              weekNumbers = _buildWeeks.weekNumbers;
+
+          self.innerContainer.appendChild(weekWrapper);
+          self.weekNumbers = weekNumbers;
+          self.weekWrapper = weekWrapper;
+        }
+
+        self.rContainer = createElement("div", "flatpickr-rContainer");
+        self.rContainer.appendChild(buildWeekdays());
+
+        if (!self.daysContainer) {
+          self.daysContainer = createElement("div", "flatpickr-days");
+          self.daysContainer.tabIndex = -1;
+        }
+
+        buildDays();
+        self.rContainer.appendChild(self.daysContainer);
+        self.innerContainer.appendChild(self.rContainer);
+        fragment.appendChild(self.innerContainer);
+      }
+
+      if (self.config.enableTime) {
+        fragment.appendChild(buildTime());
+      }
+
+      toggleClass(self.calendarContainer, "rangeMode", self.config.mode === "range");
+      toggleClass(self.calendarContainer, "animate", self.config.animate === true);
+      toggleClass(self.calendarContainer, "multiMonth", self.config.showMonths > 1);
+      self.calendarContainer.appendChild(fragment);
+      var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType !== undefined;
+
+      if (self.config.inline || self.config.static) {
+        self.calendarContainer.classList.add(self.config.inline ? "inline" : "static");
+
+        if (self.config.inline) {
+          if (!customAppend && self.element.parentNode) self.element.parentNode.insertBefore(self.calendarContainer, self._input.nextSibling);else if (self.config.appendTo !== undefined) self.config.appendTo.appendChild(self.calendarContainer);
+        }
+
+        if (self.config.static) {
+          var wrapper = createElement("div", "flatpickr-wrapper");
+          if (self.element.parentNode) self.element.parentNode.insertBefore(wrapper, self.element);
+          wrapper.appendChild(self.element);
+          if (self.altInput) wrapper.appendChild(self.altInput);
+          wrapper.appendChild(self.calendarContainer);
+        }
+      }
+
+      if (!self.config.static && !self.config.inline) (self.config.appendTo !== undefined ? self.config.appendTo : window.document.body).appendChild(self.calendarContainer);
+    }
+
+    function createDay(className, date, dayNumber, i) {
+      var dateIsEnabled = isEnabled(date, true),
+          dayElement = createElement("span", "flatpickr-day " + className, date.getDate().toString());
+      dayElement.dateObj = date;
+      dayElement.$i = i;
+      dayElement.setAttribute("aria-label", self.formatDate(date, self.config.ariaDateFormat));
+
+      if (className.indexOf("hidden") === -1 && compareDates(date, self.now) === 0) {
+        self.todayDateElem = dayElement;
+        dayElement.classList.add("today");
+        dayElement.setAttribute("aria-current", "date");
+      }
+
+      if (dateIsEnabled) {
+        dayElement.tabIndex = -1;
+
+        if (isDateSelected(date)) {
+          dayElement.classList.add("selected");
+          self.selectedDateElem = dayElement;
+
+          if (self.config.mode === "range") {
+            toggleClass(dayElement, "startRange", self.selectedDates[0] && compareDates(date, self.selectedDates[0], true) === 0);
+            toggleClass(dayElement, "endRange", self.selectedDates[1] && compareDates(date, self.selectedDates[1], true) === 0);
+            if (className === "nextMonthDay") dayElement.classList.add("inRange");
+          }
+        }
+      } else {
+        dayElement.classList.add("disabled");
+      }
+
+      if (self.config.mode === "range") {
+        if (isDateInRange(date) && !isDateSelected(date)) dayElement.classList.add("inRange");
+      }
+
+      if (self.weekNumbers && self.config.showMonths === 1 && className !== "prevMonthDay" && dayNumber % 7 === 1) {
+        self.weekNumbers.insertAdjacentHTML("beforeend", "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>");
+      }
+
+      triggerEvent("onDayCreate", dayElement);
+      return dayElement;
+    }
+
+    function focusOnDayElem(targetNode) {
+      targetNode.focus();
+      if (self.config.mode === "range") onMouseOver(targetNode);
+    }
+
+    function getFirstAvailableDay(delta) {
+      var startMonth = delta > 0 ? 0 : self.config.showMonths - 1;
+      var endMonth = delta > 0 ? self.config.showMonths : -1;
+
+      for (var m = startMonth; m != endMonth; m += delta) {
+        var month = self.daysContainer.children[m];
+        var startIndex = delta > 0 ? 0 : month.children.length - 1;
+        var endIndex = delta > 0 ? month.children.length : -1;
+
+        for (var i = startIndex; i != endIndex; i += delta) {
+          var c = month.children[i];
+          if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj)) return c;
+        }
+      }
+
+      return undefined;
+    }
+
+    function getNextAvailableDay(current, delta) {
+      var givenMonth = current.className.indexOf("Month") === -1 ? current.dateObj.getMonth() : self.currentMonth;
+      var endMonth = delta > 0 ? self.config.showMonths : -1;
+      var loopDelta = delta > 0 ? 1 : -1;
+
+      for (var m = givenMonth - self.currentMonth; m != endMonth; m += loopDelta) {
+        var month = self.daysContainer.children[m];
+        var startIndex = givenMonth - self.currentMonth === m ? current.$i + delta : delta < 0 ? month.children.length - 1 : 0;
+        var numMonthDays = month.children.length;
+
+        for (var i = startIndex; i >= 0 && i < numMonthDays && i != (delta > 0 ? numMonthDays : -1); i += loopDelta) {
+          var c = month.children[i];
+          if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj) && Math.abs(current.$i - i) >= Math.abs(delta)) return focusOnDayElem(c);
+        }
+      }
+
+      self.changeMonth(loopDelta);
+      focusOnDay(getFirstAvailableDay(loopDelta), 0);
+      return undefined;
+    }
+
+    function focusOnDay(current, offset) {
+      var dayFocused = isInView(document.activeElement || document.body);
+      var startElem = current !== undefined ? current : dayFocused ? document.activeElement : self.selectedDateElem !== undefined && isInView(self.selectedDateElem) ? self.selectedDateElem : self.todayDateElem !== undefined && isInView(self.todayDateElem) ? self.todayDateElem : getFirstAvailableDay(offset > 0 ? 1 : -1);
+      if (startElem === undefined) return self._input.focus();
+      if (!dayFocused) return focusOnDayElem(startElem);
+      getNextAvailableDay(startElem, offset);
+    }
+
+    function buildMonthDays(year, month) {
+      var firstOfMonth = (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
+      var prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12);
+      var daysInMonth = self.utils.getDaysInMonth(month),
+          days = window.document.createDocumentFragment(),
+          isMultiMonth = self.config.showMonths > 1,
+          prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
+          nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
+      var dayNumber = prevMonthDays + 1 - firstOfMonth,
+          dayIndex = 0;
+
+      for (; dayNumber <= prevMonthDays; dayNumber++, dayIndex++) {
+        days.appendChild(createDay(prevMonthDayClass, new Date(year, month - 1, dayNumber), dayNumber, dayIndex));
+      }
+
+      for (dayNumber = 1; dayNumber <= daysInMonth; dayNumber++, dayIndex++) {
+        days.appendChild(createDay("", new Date(year, month, dayNumber), dayNumber, dayIndex));
+      }
+
+      for (var dayNum = daysInMonth + 1; dayNum <= 42 - firstOfMonth && (self.config.showMonths === 1 || dayIndex % 7 !== 0); dayNum++, dayIndex++) {
+        days.appendChild(createDay(nextMonthDayClass, new Date(year, month + 1, dayNum % daysInMonth), dayNum, dayIndex));
+      }
+
+      var dayContainer = createElement("div", "dayContainer");
+      dayContainer.appendChild(days);
+      return dayContainer;
+    }
+
+    function buildDays() {
+      if (self.daysContainer === undefined) {
+        return;
+      }
+
+      clearNode(self.daysContainer);
+      if (self.weekNumbers) clearNode(self.weekNumbers);
+      var frag = document.createDocumentFragment();
+
+      for (var i = 0; i < self.config.showMonths; i++) {
+        var d = new Date(self.currentYear, self.currentMonth, 1);
+        d.setMonth(self.currentMonth + i);
+        frag.appendChild(buildMonthDays(d.getFullYear(), d.getMonth()));
+      }
+
+      self.daysContainer.appendChild(frag);
+      self.days = self.daysContainer.firstChild;
+
+      if (self.config.mode === "range" && self.selectedDates.length === 1) {
+        onMouseOver();
+      }
+    }
+
+    function buildMonth() {
+      var container = createElement("div", "flatpickr-month");
+      var monthNavFragment = window.document.createDocumentFragment();
+      var monthElement = createElement("span", "cur-month");
+      var yearInput = createNumberInput("cur-year", {
+        tabindex: "-1"
+      });
+      var yearElement = yearInput.getElementsByTagName("input")[0];
+      yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
+      if (self.config.minDate) yearElement.setAttribute("data-min", self.config.minDate.getFullYear().toString());
+
+      if (self.config.maxDate) {
+        yearElement.setAttribute("data-max", self.config.maxDate.getFullYear().toString());
+        yearElement.disabled = !!self.config.minDate && self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
+      }
+
+      var currentMonth = createElement("div", "flatpickr-current-month");
+      currentMonth.appendChild(monthElement);
+      currentMonth.appendChild(yearInput);
+      monthNavFragment.appendChild(currentMonth);
+      container.appendChild(monthNavFragment);
+      return {
+        container: container,
+        yearElement: yearElement,
+        monthElement: monthElement
+      };
+    }
+
+    function buildMonths() {
+      clearNode(self.monthNav);
+      self.monthNav.appendChild(self.prevMonthNav);
+
+      for (var m = self.config.showMonths; m--;) {
+        var month = buildMonth();
+        self.yearElements.push(month.yearElement);
+        self.monthElements.push(month.monthElement);
+        self.monthNav.appendChild(month.container);
+      }
+
+      self.monthNav.appendChild(self.nextMonthNav);
+    }
+
+    function buildMonthNav() {
+      self.monthNav = createElement("div", "flatpickr-months");
+      self.yearElements = [];
+      self.monthElements = [];
+      self.prevMonthNav = createElement("span", "flatpickr-prev-month");
+      self.prevMonthNav.innerHTML = self.config.prevArrow;
+      self.nextMonthNav = createElement("span", "flatpickr-next-month");
+      self.nextMonthNav.innerHTML = self.config.nextArrow;
+      buildMonths();
+      Object.defineProperty(self, "_hidePrevMonthArrow", {
+        get: function get() {
+          return self.__hidePrevMonthArrow;
+        },
+        set: function set(bool) {
+          if (self.__hidePrevMonthArrow !== bool) {
+            toggleClass(self.prevMonthNav, "disabled", bool);
+            self.__hidePrevMonthArrow = bool;
+          }
+        }
+      });
+      Object.defineProperty(self, "_hideNextMonthArrow", {
+        get: function get() {
+          return self.__hideNextMonthArrow;
+        },
+        set: function set(bool) {
+          if (self.__hideNextMonthArrow !== bool) {
+            toggleClass(self.nextMonthNav, "disabled", bool);
+            self.__hideNextMonthArrow = bool;
+          }
+        }
+      });
+      self.currentYearElement = self.yearElements[0];
+      updateNavigationCurrentMonth();
+      return self.monthNav;
+    }
+
+    function buildTime() {
+      self.calendarContainer.classList.add("hasTime");
+      if (self.config.noCalendar) self.calendarContainer.classList.add("noCalendar");
+      self.timeContainer = createElement("div", "flatpickr-time");
+      self.timeContainer.tabIndex = -1;
+      var separator = createElement("span", "flatpickr-time-separator", ":");
+      var hourInput = createNumberInput("flatpickr-hour");
+      self.hourElement = hourInput.getElementsByTagName("input")[0];
+      var minuteInput = createNumberInput("flatpickr-minute");
+      self.minuteElement = minuteInput.getElementsByTagName("input")[0];
+      self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
+      self.hourElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getHours() : self.config.time_24hr ? self.config.defaultHour : military2ampm(self.config.defaultHour));
+      self.minuteElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getMinutes() : self.config.defaultMinute);
+      self.hourElement.setAttribute("data-step", self.config.hourIncrement.toString());
+      self.minuteElement.setAttribute("data-step", self.config.minuteIncrement.toString());
+      self.hourElement.setAttribute("data-min", self.config.time_24hr ? "0" : "1");
+      self.hourElement.setAttribute("data-max", self.config.time_24hr ? "23" : "12");
+      self.minuteElement.setAttribute("data-min", "0");
+      self.minuteElement.setAttribute("data-max", "59");
+      self.timeContainer.appendChild(hourInput);
+      self.timeContainer.appendChild(separator);
+      self.timeContainer.appendChild(minuteInput);
+      if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
+
+      if (self.config.enableSeconds) {
+        self.timeContainer.classList.add("hasSeconds");
+        var secondInput = createNumberInput("flatpickr-second");
+        self.secondElement = secondInput.getElementsByTagName("input")[0];
+        self.secondElement.value = pad(self.latestSelectedDateObj ? self.latestSelectedDateObj.getSeconds() : self.config.defaultSeconds);
+        self.secondElement.setAttribute("data-step", self.minuteElement.getAttribute("data-step"));
+        self.secondElement.setAttribute("data-min", self.minuteElement.getAttribute("data-min"));
+        self.secondElement.setAttribute("data-max", self.minuteElement.getAttribute("data-max"));
+        self.timeContainer.appendChild(createElement("span", "flatpickr-time-separator", ":"));
+        self.timeContainer.appendChild(secondInput);
+      }
+
+      if (!self.config.time_24hr) {
+        self.amPM = createElement("span", "flatpickr-am-pm", self.l10n.amPM[int((self.latestSelectedDateObj ? self.hourElement.value : self.config.defaultHour) > 11)]);
+        self.amPM.title = self.l10n.toggleTitle;
+        self.amPM.tabIndex = -1;
+        self.timeContainer.appendChild(self.amPM);
+      }
+
+      return self.timeContainer;
+    }
+
+    function buildWeekdays() {
+      if (!self.weekdayContainer) self.weekdayContainer = createElement("div", "flatpickr-weekdays");else clearNode(self.weekdayContainer);
+
+      for (var i = self.config.showMonths; i--;) {
+        var container = createElement("div", "flatpickr-weekdaycontainer");
+        self.weekdayContainer.appendChild(container);
+      }
+
+      updateWeekdays();
+      return self.weekdayContainer;
+    }
+
+    function updateWeekdays() {
+      var firstDayOfWeek = self.l10n.firstDayOfWeek;
+      var weekdays = self.l10n.weekdays.shorthand.concat();
+
+      if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {
+        weekdays = weekdays.splice(firstDayOfWeek, weekdays.length).concat(weekdays.splice(0, firstDayOfWeek));
+      }
+
+      for (var i = self.config.showMonths; i--;) {
+        self.weekdayContainer.children[i].innerHTML = "\n      <span class=flatpickr-weekday>\n        " + weekdays.join("</span><span class=flatpickr-weekday>") + "\n      </span>\n      ";
+      }
+    }
+
+    function buildWeeks() {
+      self.calendarContainer.classList.add("hasWeeks");
+      var weekWrapper = createElement("div", "flatpickr-weekwrapper");
+      weekWrapper.appendChild(createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation));
+      var weekNumbers = createElement("div", "flatpickr-weeks");
+      weekWrapper.appendChild(weekNumbers);
+      return {
+        weekWrapper: weekWrapper,
+        weekNumbers: weekNumbers
+      };
+    }
+
+    function changeMonth(value, is_offset) {
+      if (is_offset === void 0) {
+        is_offset = true;
+      }
+
+      var delta = is_offset ? value : value - self.currentMonth;
+      if (delta < 0 && self._hidePrevMonthArrow === true || delta > 0 && self._hideNextMonthArrow === true) return;
+      self.currentMonth += delta;
+
+      if (self.currentMonth < 0 || self.currentMonth > 11) {
+        self.currentYear += self.currentMonth > 11 ? 1 : -1;
+        self.currentMonth = (self.currentMonth + 12) % 12;
+        triggerEvent("onYearChange");
+      }
+
+      buildDays();
+      triggerEvent("onMonthChange");
+      updateNavigationCurrentMonth();
+    }
+
+    function clear(triggerChangeEvent) {
+      if (triggerChangeEvent === void 0) {
+        triggerChangeEvent = true;
+      }
+
+      self.input.value = "";
+      if (self.altInput !== undefined) self.altInput.value = "";
+      if (self.mobileInput !== undefined) self.mobileInput.value = "";
+      self.selectedDates = [];
+      self.latestSelectedDateObj = undefined;
+      self.showTimeInput = false;
+
+      if (self.config.enableTime === true) {
+        setDefaultHours();
+      }
+
+      self.redraw();
+      if (triggerChangeEvent) triggerEvent("onChange");
+    }
+
+    function close() {
+      self.isOpen = false;
+
+      if (!self.isMobile) {
+        self.calendarContainer.classList.remove("open");
+
+        self._input.classList.remove("active");
+      }
+
+      triggerEvent("onClose");
+    }
+
+    function destroy() {
+      if (self.config !== undefined) triggerEvent("onDestroy");
+
+      for (var i = self._handlers.length; i--;) {
+        var h = self._handlers[i];
+        h.element.removeEventListener(h.event, h.handler, h.options);
+      }
+
+      self._handlers = [];
+
+      if (self.mobileInput) {
+        if (self.mobileInput.parentNode) self.mobileInput.parentNode.removeChild(self.mobileInput);
+        self.mobileInput = undefined;
+      } else if (self.calendarContainer && self.calendarContainer.parentNode) {
+        if (self.config.static && self.calendarContainer.parentNode) {
+          var wrapper = self.calendarContainer.parentNode;
+          wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
+
+          if (wrapper.parentNode) {
+            while (wrapper.firstChild) {
+              wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
+            }
+
+            wrapper.parentNode.removeChild(wrapper);
+          }
+        } else self.calendarContainer.parentNode.removeChild(self.calendarContainer);
+      }
+
+      if (self.altInput) {
+        self.input.type = "text";
+        if (self.altInput.parentNode) self.altInput.parentNode.removeChild(self.altInput);
+        delete self.altInput;
+      }
+
+      if (self.input) {
+        self.input.type = self.input._type;
+        self.input.classList.remove("flatpickr-input");
+        self.input.removeAttribute("readonly");
+        self.input.value = "";
+      }
+
+      ["_showTimeInput", "latestSelectedDateObj", "_hideNextMonthArrow", "_hidePrevMonthArrow", "__hideNextMonthArrow", "__hidePrevMonthArrow", "isMobile", "isOpen", "selectedDateElem", "minDateHasTime", "maxDateHasTime", "days", "daysContainer", "_input", "_positionElement", "innerContainer", "rContainer", "monthNav", "todayDateElem", "calendarContainer", "weekdayContainer", "prevMonthNav", "nextMonthNav", "currentMonthElement", "currentYearElement", "navigationCurrentMonth", "selectedDateElem", "config"].forEach(function (k) {
+        try {
+          delete self[k];
+        } catch (_) {}
+      });
+    }
+
+    function isCalendarElem(elem) {
+      if (self.config.appendTo && self.config.appendTo.contains(elem)) return true;
+      return self.calendarContainer.contains(elem);
+    }
+
+    function documentClick(e) {
+      if (self.isOpen && !self.config.inline) {
+        var isCalendarElement = isCalendarElem(e.target);
+        var isInput = e.target === self.input || e.target === self.altInput || self.element.contains(e.target) || e.path && e.path.indexOf && (~e.path.indexOf(self.input) || ~e.path.indexOf(self.altInput));
+        var lostFocus = e.type === "blur" ? isInput && e.relatedTarget && !isCalendarElem(e.relatedTarget) : !isInput && !isCalendarElement;
+        var isIgnored = !self.config.ignoredFocusElements.some(function (elem) {
+          return elem.contains(e.target);
+        });
+
+        if (lostFocus && isIgnored) {
+          self.close();
+
+          if (self.config.mode === "range" && self.selectedDates.length === 1) {
+            self.clear(false);
+            self.redraw();
+          }
+        }
+      }
+    }
+
+    function changeYear(newYear) {
+      if (!newYear || self.config.minDate && newYear < self.config.minDate.getFullYear() || self.config.maxDate && newYear > self.config.maxDate.getFullYear()) return;
+      var newYearNum = newYear,
+          isNewYear = self.currentYear !== newYearNum;
+      self.currentYear = newYearNum || self.currentYear;
+
+      if (self.config.maxDate && self.currentYear === self.config.maxDate.getFullYear()) {
+        self.currentMonth = Math.min(self.config.maxDate.getMonth(), self.currentMonth);
+      } else if (self.config.minDate && self.currentYear === self.config.minDate.getFullYear()) {
+        self.currentMonth = Math.max(self.config.minDate.getMonth(), self.currentMonth);
+      }
+
+      if (isNewYear) {
+        self.redraw();
+        triggerEvent("onYearChange");
+      }
+    }
+
+    function isEnabled(date, timeless) {
+      if (timeless === void 0) {
+        timeless = true;
+      }
+
+      var dateToCheck = self.parseDate(date, undefined, timeless);
+      if (self.config.minDate && dateToCheck && compareDates(dateToCheck, self.config.minDate, timeless !== undefined ? timeless : !self.minDateHasTime) < 0 || self.config.maxDate && dateToCheck && compareDates(dateToCheck, self.config.maxDate, timeless !== undefined ? timeless : !self.maxDateHasTime) > 0) return false;
+      if (self.config.enable.length === 0 && self.config.disable.length === 0) return true;
+      if (dateToCheck === undefined) return false;
+      var bool = self.config.enable.length > 0,
+          array = bool ? self.config.enable : self.config.disable;
+
+      for (var i = 0, d; i < array.length; i++) {
+        d = array[i];
+        if (typeof d === "function" && d(dateToCheck)) return bool;else if (d instanceof Date && dateToCheck !== undefined && d.getTime() === dateToCheck.getTime()) return bool;else if (typeof d === "string" && dateToCheck !== undefined) {
+          var parsed = self.parseDate(d, undefined, true);
+          return parsed && parsed.getTime() === dateToCheck.getTime() ? bool : !bool;
+        } else if ((typeof d === 'undefined' ? 'undefined' : _typeof(d)) === "object" && dateToCheck !== undefined && d.from && d.to && dateToCheck.getTime() >= d.from.getTime() && dateToCheck.getTime() <= d.to.getTime()) return bool;
+      }
+
+      return !bool;
+    }
+
+    function isInView(elem) {
+      if (self.daysContainer !== undefined) return elem.className.indexOf("hidden") === -1 && self.daysContainer.contains(elem);
+      return false;
+    }
+
+    function onKeyDown(e) {
+      var isInput = e.target === self._input;
+      var allowInput = self.config.allowInput;
+      var allowKeydown = self.isOpen && (!allowInput || !isInput);
+      var allowInlineKeydown = self.config.inline && isInput && !allowInput;
+
+      if (e.keyCode === 13 && isInput) {
+        if (allowInput) {
+          self.setDate(self._input.value, true, e.target === self.altInput ? self.config.altFormat : self.config.dateFormat);
+          return e.target.blur();
+        } else self.open();
+      } else if (isCalendarElem(e.target) || allowKeydown || allowInlineKeydown) {
+        var isTimeObj = !!self.timeContainer && self.timeContainer.contains(e.target);
+
+        switch (e.keyCode) {
+          case 13:
+            if (isTimeObj) updateTime();else selectDate(e);
+            break;
+
+          case 27:
+            e.preventDefault();
+            focusAndClose();
+            break;
+
+          case 8:
+          case 46:
+            if (isInput && !self.config.allowInput) {
+              e.preventDefault();
+              self.clear();
+            }
+
+            break;
+
+          case 37:
+          case 39:
+            if (!isTimeObj) {
+              e.preventDefault();
+
+              if (self.daysContainer !== undefined && (allowInput === false || isInView(document.activeElement))) {
+                var _delta = e.keyCode === 39 ? 1 : -1;
+
+                if (!e.ctrlKey) focusOnDay(undefined, _delta);else {
+                  changeMonth(_delta);
+                  focusOnDay(getFirstAvailableDay(1), 0);
+                }
+              }
+            } else if (self.hourElement) self.hourElement.focus();
+
+            break;
+
+          case 38:
+          case 40:
+            e.preventDefault();
+            var delta = e.keyCode === 40 ? 1 : -1;
+
+            if (self.daysContainer && e.target.$i !== undefined) {
+              if (e.ctrlKey) {
+                changeYear(self.currentYear - delta);
+                focusOnDay(getFirstAvailableDay(1), 0);
+              } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
+            } else if (self.config.enableTime) {
+              if (!isTimeObj && self.hourElement) self.hourElement.focus();
+              updateTime(e);
+
+              self._debouncedChange();
+            }
+
+            break;
+
+          case 9:
+            if (!isTimeObj) {
+              self.element.focus();
+              break;
+            }
+
+            var elems = [self.hourElement, self.minuteElement, self.secondElement, self.amPM].filter(function (x) {
+              return x;
+            });
+            var i = elems.indexOf(e.target);
+
+            if (i !== -1) {
+              var target = elems[i + (e.shiftKey ? -1 : 1)];
+
+              if (target !== undefined) {
+                e.preventDefault();
+                target.focus();
+              } else {
+                self.element.focus();
+              }
+            }
+
+            break;
+
+          default:
+            break;
+        }
+      }
+
+      if (self.amPM !== undefined && e.target === self.amPM) {
+        switch (e.key) {
+          case self.l10n.amPM[0].charAt(0):
+          case self.l10n.amPM[0].charAt(0).toLowerCase():
+            self.amPM.textContent = self.l10n.amPM[0];
+            setHoursFromInputs();
+            updateValue();
+            break;
+
+          case self.l10n.amPM[1].charAt(0):
+          case self.l10n.amPM[1].charAt(0).toLowerCase():
+            self.amPM.textContent = self.l10n.amPM[1];
+            setHoursFromInputs();
+            updateValue();
+            break;
+        }
+      }
+
+      triggerEvent("onKeyDown", e);
+    }
+
+    function onMouseOver(elem) {
+      if (self.selectedDates.length !== 1 || elem && (!elem.classList.contains("flatpickr-day") || elem.classList.contains("disabled"))) return;
+      var hoverDate = elem ? elem.dateObj.getTime() : self.days.firstElementChild.dateObj.getTime(),
+          initialDate = self.parseDate(self.selectedDates[0], undefined, true).getTime(),
+          rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
+          rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime()),
+          lastDate = self.daysContainer.lastChild.lastChild.dateObj.getTime();
+      var containsDisabled = false;
+      var minRange = 0,
+          maxRange = 0;
+
+      for (var t = rangeStartDate; t < lastDate; t += duration.DAY) {
+        if (!isEnabled(new Date(t), true)) {
+          containsDisabled = containsDisabled || t > rangeStartDate && t < rangeEndDate;
+          if (t < initialDate && (!minRange || t > minRange)) minRange = t;else if (t > initialDate && (!maxRange || t < maxRange)) maxRange = t;
+        }
+      }
+
+      for (var m = 0; m < self.config.showMonths; m++) {
+        var month = self.daysContainer.children[m];
+        var prevMonth = self.daysContainer.children[m - 1];
+
+        var _loop = function _loop(i, l) {
+          var dayElem = month.children[i],
+              date = dayElem.dateObj;
+          var timestamp = date.getTime();
+          var outOfRange = minRange > 0 && timestamp < minRange || maxRange > 0 && timestamp > maxRange;
+
+          if (outOfRange) {
+            dayElem.classList.add("notAllowed");
+            ["inRange", "startRange", "endRange"].forEach(function (c) {
+              dayElem.classList.remove(c);
+            });
+            return "continue";
+          } else if (containsDisabled && !outOfRange) return "continue";
+
+          ["startRange", "inRange", "endRange", "notAllowed"].forEach(function (c) {
+            dayElem.classList.remove(c);
+          });
+
+          if (elem !== undefined) {
+            elem.classList.add(hoverDate < self.selectedDates[0].getTime() ? "startRange" : "endRange");
+
+            if (month.contains(elem) || !(m > 0 && prevMonth && prevMonth.lastChild.dateObj.getTime() >= timestamp)) {
+              if (initialDate < hoverDate && timestamp === initialDate) dayElem.classList.add("startRange");else if (initialDate > hoverDate && timestamp === initialDate) dayElem.classList.add("endRange");
+              if (timestamp >= minRange && (maxRange === 0 || timestamp <= maxRange) && isBetween(timestamp, initialDate, hoverDate)) dayElem.classList.add("inRange");
+            }
+          }
+        };
+
+        for (var i = 0, l = month.children.length; i < l; i++) {
+          var _ret = _loop(i, l);
+
+          if (_ret === "continue") continue;
+        }
+      }
+    }
+
+    function onResize() {
+      if (self.isOpen && !self.config.static && !self.config.inline) positionCalendar();
+    }
+
+    function open(e, positionElement) {
+      if (positionElement === void 0) {
+        positionElement = self._positionElement;
+      }
+
+      if (self.isMobile === true) {
+        if (e) {
+          e.preventDefault();
+          e.target && e.target.blur();
+        }
+
+        if (self.mobileInput !== undefined) {
+          self.mobileInput.focus();
+          self.mobileInput.click();
+        }
+
+        triggerEvent("onOpen");
+        return;
+      }
+
+      if (self._input.disabled || self.config.inline) return;
+      var wasOpen = self.isOpen;
+      self.isOpen = true;
+
+      if (!wasOpen) {
+        self.calendarContainer.classList.add("open");
+
+        self._input.classList.add("active");
+
+        triggerEvent("onOpen");
+        positionCalendar(positionElement);
+      }
+
+      if (self.config.enableTime === true && self.config.noCalendar === true) {
+        if (self.selectedDates.length === 0) {
+          self.setDate(self.config.minDate !== undefined ? new Date(self.config.minDate.getTime()) : new Date(), false);
+          setDefaultHours();
+          updateValue();
+        }
+
+        if (self.config.allowInput === false && (e === undefined || !self.timeContainer.contains(e.relatedTarget))) {
+          setTimeout(function () {
+            return self.hourElement.select();
+          }, 50);
+        }
+      }
+    }
+
+    function minMaxDateSetter(type) {
+      return function (date) {
+        var dateObj = self.config["_" + type + "Date"] = self.parseDate(date, self.config.dateFormat);
+        var inverseDateObj = self.config["_" + (type === "min" ? "max" : "min") + "Date"];
+
+        if (dateObj !== undefined) {
+          self[type === "min" ? "minDateHasTime" : "maxDateHasTime"] = dateObj.getHours() > 0 || dateObj.getMinutes() > 0 || dateObj.getSeconds() > 0;
+        }
+
+        if (self.selectedDates) {
+          self.selectedDates = self.selectedDates.filter(function (d) {
+            return isEnabled(d);
+          });
+          if (!self.selectedDates.length && type === "min") setHoursFromDate(dateObj);
+          updateValue();
+        }
+
+        if (self.daysContainer) {
+          redraw();
+          if (dateObj !== undefined) self.currentYearElement[type] = dateObj.getFullYear().toString();else self.currentYearElement.removeAttribute(type);
+          self.currentYearElement.disabled = !!inverseDateObj && dateObj !== undefined && inverseDateObj.getFullYear() === dateObj.getFullYear();
+        }
+      };
+    }
+
+    function parseConfig() {
+      var boolOpts = ["wrap", "weekNumbers", "allowInput", "clickOpens", "time_24hr", "enableTime", "noCalendar", "altInput", "shorthandCurrentMonth", "inline", "static", "enableSeconds", "disableMobile"];
+      var userConfig = Object.assign({}, instanceConfig, JSON.parse(JSON.stringify(element.dataset || {})));
+      var formats$$1 = {};
+      self.config.parseDate = userConfig.parseDate;
+      self.config.formatDate = userConfig.formatDate;
+      Object.defineProperty(self.config, "enable", {
+        get: function get() {
+          return self.config._enable;
+        },
+        set: function set(dates) {
+          self.config._enable = parseDateRules(dates);
+        }
+      });
+      Object.defineProperty(self.config, "disable", {
+        get: function get() {
+          return self.config._disable;
+        },
+        set: function set(dates) {
+          self.config._disable = parseDateRules(dates);
+        }
+      });
+      var timeMode = userConfig.mode === "time";
+
+      if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
+        formats$$1.dateFormat = userConfig.noCalendar || timeMode ? "H:i" + (userConfig.enableSeconds ? ":S" : "") : flatpickr.defaultConfig.dateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
+      }
+
+      if (userConfig.altInput && (userConfig.enableTime || timeMode) && !userConfig.altFormat) {
+        formats$$1.altFormat = userConfig.noCalendar || timeMode ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K") : flatpickr.defaultConfig.altFormat + (" h:i" + (userConfig.enableSeconds ? ":S" : "") + " K");
+      }
+
+      Object.defineProperty(self.config, "minDate", {
+        get: function get() {
+          return self.config._minDate;
+        },
+        set: minMaxDateSetter("min")
+      });
+      Object.defineProperty(self.config, "maxDate", {
+        get: function get() {
+          return self.config._maxDate;
+        },
+        set: minMaxDateSetter("max")
+      });
+
+      var minMaxTimeSetter = function minMaxTimeSetter(type) {
+        return function (val) {
+          self.config[type === "min" ? "_minTime" : "_maxTime"] = self.parseDate(val, "H:i");
+        };
+      };
+
+      Object.defineProperty(self.config, "minTime", {
+        get: function get() {
+          return self.config._minTime;
+        },
+        set: minMaxTimeSetter("min")
+      });
+      Object.defineProperty(self.config, "maxTime", {
+        get: function get() {
+          return self.config._maxTime;
+        },
+        set: minMaxTimeSetter("max")
+      });
+
+      if (userConfig.mode === "time") {
+        self.config.noCalendar = true;
+        self.config.enableTime = true;
+      }
+
+      Object.assign(self.config, formats$$1, userConfig);
+
+      for (var i = 0; i < boolOpts.length; i++) {
+        self.config[boolOpts[i]] = self.config[boolOpts[i]] === true || self.config[boolOpts[i]] === "true";
+      }
+
+      HOOKS.filter(function (hook) {
+        return self.config[hook] !== undefined;
+      }).forEach(function (hook) {
+        self.config[hook] = arrayify(self.config[hook] || []).map(bindToInstance);
+      });
+      self.isMobile = !self.config.disableMobile && !self.config.inline && self.config.mode === "single" && !self.config.disable.length && !self.config.enable.length && !self.config.weekNumbers && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+
+      for (var _i = 0; _i < self.config.plugins.length; _i++) {
+        var pluginConf = self.config.plugins[_i](self) || {};
+
+        for (var key in pluginConf) {
+          if (HOOKS.indexOf(key) > -1) {
+            self.config[key] = arrayify(pluginConf[key]).map(bindToInstance).concat(self.config[key]);
+          } else if (typeof userConfig[key] === "undefined") self.config[key] = pluginConf[key];
+        }
+      }
+
+      triggerEvent("onParseConfig");
+    }
+
+    function setupLocale() {
+      if (_typeof(self.config.locale) !== "object" && typeof flatpickr.l10ns[self.config.locale] === "undefined") self.config.errorHandler(new Error("flatpickr: invalid locale " + self.config.locale));
+      self.l10n = Object.assign({}, flatpickr.l10ns.default, _typeof(self.config.locale) === "object" ? self.config.locale : self.config.locale !== "default" ? flatpickr.l10ns[self.config.locale] : undefined);
+      tokenRegex.K = "(" + self.l10n.amPM[0] + "|" + self.l10n.amPM[1] + "|" + self.l10n.amPM[0].toLowerCase() + "|" + self.l10n.amPM[1].toLowerCase() + ")";
+      self.formatDate = createDateFormatter(self);
+      self.parseDate = createDateParser({
+        config: self.config,
+        l10n: self.l10n
+      });
+    }
+
+    function positionCalendar(customPositionElement) {
+      if (self.calendarContainer === undefined) return;
+      triggerEvent("onPreCalendarPosition");
+      var positionElement = customPositionElement || self._positionElement;
+      var calendarHeight = Array.prototype.reduce.call(self.calendarContainer.children, function (acc, child) {
+        return acc + child.offsetHeight;
+      }, 0),
+          calendarWidth = self.calendarContainer.offsetWidth,
+          configPos = self.config.position.split(" "),
+          configPosVertical = configPos[0],
+          configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
+          inputBounds = positionElement.getBoundingClientRect(),
+          distanceFromBottom = window.innerHeight - inputBounds.bottom,
+          showOnTop = configPosVertical === "above" || configPosVertical !== "below" && distanceFromBottom < calendarHeight && inputBounds.top > calendarHeight;
+      var top = window.pageYOffset + inputBounds.top + (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
+      toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
+      toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
+      if (self.config.inline) return;
+      var left = window.pageXOffset + inputBounds.left - (configPosHorizontal != null && configPosHorizontal === "center" ? (calendarWidth - inputBounds.width) / 2 : 0);
+      var right = window.document.body.offsetWidth - inputBounds.right;
+      var rightMost = left + calendarWidth > window.document.body.offsetWidth;
+      toggleClass(self.calendarContainer, "rightMost", rightMost);
+      if (self.config.static) return;
+      self.calendarContainer.style.top = top + "px";
+
+      if (!rightMost) {
+        self.calendarContainer.style.left = left + "px";
+        self.calendarContainer.style.right = "auto";
+      } else {
+        self.calendarContainer.style.left = "auto";
+        self.calendarContainer.style.right = right + "px";
+      }
+    }
+
+    function redraw() {
+      if (self.config.noCalendar || self.isMobile) return;
+      updateNavigationCurrentMonth();
+      buildDays();
+    }
+
+    function focusAndClose() {
+      self._input.focus();
+
+      if (window.navigator.userAgent.indexOf("MSIE") !== -1 || navigator.msMaxTouchPoints !== undefined) {
+        setTimeout(self.close, 0);
+      } else {
+        self.close();
+      }
+    }
+
+    function selectDate(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      var isSelectable = function isSelectable(day) {
+        return day.classList && day.classList.contains("flatpickr-day") && !day.classList.contains("disabled") && !day.classList.contains("notAllowed");
+      };
+
+      var t = findParent(e.target, isSelectable);
+      if (t === undefined) return;
+      var target = t;
+      var selectedDate = self.latestSelectedDateObj = new Date(target.dateObj.getTime());
+      var shouldChangeMonth = (selectedDate.getMonth() < self.currentMonth || selectedDate.getMonth() > self.currentMonth + self.config.showMonths - 1) && self.config.mode !== "range";
+      self.selectedDateElem = target;
+      if (self.config.mode === "single") self.selectedDates = [selectedDate];else if (self.config.mode === "multiple") {
+        var selectedIndex = isDateSelected(selectedDate);
+        if (selectedIndex) self.selectedDates.splice(parseInt(selectedIndex), 1);else self.selectedDates.push(selectedDate);
+      } else if (self.config.mode === "range") {
+        if (self.selectedDates.length === 2) self.clear(false);
+        self.selectedDates.push(selectedDate);
+        if (compareDates(selectedDate, self.selectedDates[0], true) !== 0) self.selectedDates.sort(function (a, b) {
+          return a.getTime() - b.getTime();
+        });
+      }
+      setHoursFromInputs();
+
+      if (shouldChangeMonth) {
+        var isNewYear = self.currentYear !== selectedDate.getFullYear();
+        self.currentYear = selectedDate.getFullYear();
+        self.currentMonth = selectedDate.getMonth();
+        if (isNewYear) triggerEvent("onYearChange");
+        triggerEvent("onMonthChange");
+      }
+
+      updateNavigationCurrentMonth();
+      buildDays();
+      updateValue();
+      if (self.config.enableTime) setTimeout(function () {
+        return self.showTimeInput = true;
+      }, 50);
+      if (!shouldChangeMonth && self.config.mode !== "range" && self.config.showMonths === 1) focusOnDayElem(target);else self.selectedDateElem && self.selectedDateElem.focus();
+      if (self.hourElement !== undefined) setTimeout(function () {
+        return self.hourElement !== undefined && self.hourElement.select();
+      }, 451);
+
+      if (self.config.closeOnSelect) {
+        var single = self.config.mode === "single" && !self.config.enableTime;
+        var range = self.config.mode === "range" && self.selectedDates.length === 2 && !self.config.enableTime;
+
+        if (single || range) {
+          focusAndClose();
+        }
+      }
+
+      triggerChange();
+    }
+
+    var CALLBACKS = {
+      locale: [setupLocale, updateWeekdays],
+      showMonths: [buildMonths, setCalendarWidth, buildWeekdays]
+    };
+
+    function set(option, value) {
+      if (option !== null && (typeof option === 'undefined' ? 'undefined' : _typeof(option)) === "object") Object.assign(self.config, option);else {
+        self.config[option] = value;
+        if (CALLBACKS[option] !== undefined) CALLBACKS[option].forEach(function (x) {
+          return x();
+        });else if (HOOKS.indexOf(option) > -1) self.config[option] = arrayify(value);
+      }
+      self.redraw();
+      jumpToDate();
+      updateValue(false);
+    }
+
+    function setSelectedDate(inputDate, format) {
+      var dates = [];
+      if (inputDate instanceof Array) dates = inputDate.map(function (d) {
+        return self.parseDate(d, format);
+      });else if (inputDate instanceof Date || typeof inputDate === "number") dates = [self.parseDate(inputDate, format)];else if (typeof inputDate === "string") {
+        switch (self.config.mode) {
+          case "single":
+          case "time":
+            dates = [self.parseDate(inputDate, format)];
+            break;
+
+          case "multiple":
+            dates = inputDate.split(self.config.conjunction).map(function (date) {
+              return self.parseDate(date, format);
+            });
+            break;
+
+          case "range":
+            dates = inputDate.split(self.l10n.rangeSeparator).map(function (date) {
+              return self.parseDate(date, format);
+            });
+            break;
+
+          default:
+            break;
+        }
+      } else self.config.errorHandler(new Error("Invalid date supplied: " + JSON.stringify(inputDate)));
+      self.selectedDates = dates.filter(function (d) {
+        return d instanceof Date && isEnabled(d, false);
+      });
+      if (self.config.mode === "range") self.selectedDates.sort(function (a, b) {
+        return a.getTime() - b.getTime();
+      });
+    }
+
+    function setDate(date, triggerChange, format) {
+      if (triggerChange === void 0) {
+        triggerChange = false;
+      }
+
+      if (format === void 0) {
+        format = self.config.dateFormat;
+      }
+
+      if (date !== 0 && !date || date instanceof Array && date.length === 0) return self.clear(triggerChange);
+      setSelectedDate(date, format);
+      self.showTimeInput = self.selectedDates.length > 0;
+      self.latestSelectedDateObj = self.selectedDates[0];
+      self.redraw();
+      jumpToDate();
+      setHoursFromDate();
+      updateValue(triggerChange);
+      if (triggerChange) triggerEvent("onChange");
+    }
+
+    function parseDateRules(arr) {
+      return arr.slice().map(function (rule) {
+        if (typeof rule === "string" || typeof rule === "number" || rule instanceof Date) {
+          return self.parseDate(rule, undefined, true);
+        } else if (rule && (typeof rule === 'undefined' ? 'undefined' : _typeof(rule)) === "object" && rule.from && rule.to) return {
+          from: self.parseDate(rule.from, undefined),
+          to: self.parseDate(rule.to, undefined)
+        };
+
+        return rule;
+      }).filter(function (x) {
+        return x;
+      });
+    }
+
+    function setupDates() {
+      self.selectedDates = [];
+      self.now = self.parseDate(self.config.now) || new Date();
+      var preloadedDate = self.config.defaultDate || ((self.input.nodeName === "INPUT" || self.input.nodeName === "TEXTAREA") && self.input.placeholder && self.input.value === self.input.placeholder ? null : self.input.value);
+      if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
+      var initialDate = self.selectedDates.length > 0 ? self.selectedDates[0] : self.config.minDate && self.config.minDate.getTime() > self.now.getTime() ? self.config.minDate : self.config.maxDate && self.config.maxDate.getTime() < self.now.getTime() ? self.config.maxDate : self.now;
+      self.currentYear = initialDate.getFullYear();
+      self.currentMonth = initialDate.getMonth();
+      if (self.selectedDates.length > 0) self.latestSelectedDateObj = self.selectedDates[0];
+      if (self.config.minTime !== undefined) self.config.minTime = self.parseDate(self.config.minTime, "H:i");
+      if (self.config.maxTime !== undefined) self.config.maxTime = self.parseDate(self.config.maxTime, "H:i");
+      self.minDateHasTime = !!self.config.minDate && (self.config.minDate.getHours() > 0 || self.config.minDate.getMinutes() > 0 || self.config.minDate.getSeconds() > 0);
+      self.maxDateHasTime = !!self.config.maxDate && (self.config.maxDate.getHours() > 0 || self.config.maxDate.getMinutes() > 0 || self.config.maxDate.getSeconds() > 0);
+      Object.defineProperty(self, "showTimeInput", {
+        get: function get() {
+          return self._showTimeInput;
+        },
+        set: function set(bool) {
+          self._showTimeInput = bool;
+          if (self.calendarContainer) toggleClass(self.calendarContainer, "showTimeInput", bool);
+          self.isOpen && positionCalendar();
+        }
+      });
+    }
+
+    function setupInputs() {
+      self.input = self.config.wrap ? element.querySelector("[data-input]") : element;
+
+      if (!self.input) {
+        self.config.errorHandler(new Error("Invalid input element specified"));
+        return;
+      }
+
+      self.input._type = self.input.type;
+      self.input.type = "text";
+      self.input.classList.add("flatpickr-input");
+      self._input = self.input;
+
+      if (self.config.altInput) {
+        self.altInput = createElement(self.input.nodeName, self.input.className + " " + self.config.altInputClass);
+        self._input = self.altInput;
+        self.altInput.placeholder = self.input.placeholder;
+        self.altInput.disabled = self.input.disabled;
+        self.altInput.required = self.input.required;
+        self.altInput.tabIndex = self.input.tabIndex;
+        self.altInput.type = "text";
+        self.input.setAttribute("type", "hidden");
+        if (!self.config.static && self.input.parentNode) self.input.parentNode.insertBefore(self.altInput, self.input.nextSibling);
+      }
+
+      if (!self.config.allowInput) self._input.setAttribute("readonly", "readonly");
+      self._positionElement = self.config.positionElement || self._input;
+    }
+
+    function setupMobile() {
+      var inputType = self.config.enableTime ? self.config.noCalendar ? "time" : "datetime-local" : "date";
+      self.mobileInput = createElement("input", self.input.className + " flatpickr-mobile");
+      self.mobileInput.step = self.input.getAttribute("step") || "any";
+      self.mobileInput.tabIndex = 1;
+      self.mobileInput.type = inputType;
+      self.mobileInput.disabled = self.input.disabled;
+      self.mobileInput.required = self.input.required;
+      self.mobileInput.placeholder = self.input.placeholder;
+      self.mobileFormatStr = inputType === "datetime-local" ? "Y-m-d\\TH:i:S" : inputType === "date" ? "Y-m-d" : "H:i:S";
+
+      if (self.selectedDates.length > 0) {
+        self.mobileInput.defaultValue = self.mobileInput.value = self.formatDate(self.selectedDates[0], self.mobileFormatStr);
+      }
+
+      if (self.config.minDate) self.mobileInput.min = self.formatDate(self.config.minDate, "Y-m-d");
+      if (self.config.maxDate) self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
+      self.input.type = "hidden";
+      if (self.altInput !== undefined) self.altInput.type = "hidden";
+
+      try {
+        if (self.input.parentNode) self.input.parentNode.insertBefore(self.mobileInput, self.input.nextSibling);
+      } catch (_a) {}
+
+      bind(self.mobileInput, "change", function (e) {
+        self.setDate(e.target.value, false, self.mobileFormatStr);
+        triggerEvent("onChange");
+        triggerEvent("onClose");
+      });
+    }
+
+    function toggle(e) {
+      if (self.isOpen === true) return self.close();
+      self.open(e);
+    }
+
+    function triggerEvent(event, data) {
+      if (self.config === undefined) return;
+      var hooks = self.config[event];
+
+      if (hooks !== undefined && hooks.length > 0) {
+        for (var i = 0; hooks[i] && i < hooks.length; i++) {
+          hooks[i](self.selectedDates, self.input.value, self, data);
+        }
+      }
+
+      if (event === "onChange") {
+        self.input.dispatchEvent(createEvent("change"));
+        self.input.dispatchEvent(createEvent("input"));
+      }
+    }
+
+    function createEvent(name) {
+      var e = document.createEvent("Event");
+      e.initEvent(name, true, true);
+      return e;
+    }
+
+    function isDateSelected(date) {
+      for (var i = 0; i < self.selectedDates.length; i++) {
+        if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
+      }
+
+      return false;
+    }
+
+    function isDateInRange(date) {
+      if (self.config.mode !== "range" || self.selectedDates.length < 2) return false;
+      return compareDates(date, self.selectedDates[0]) >= 0 && compareDates(date, self.selectedDates[1]) <= 0;
+    }
+
+    function updateNavigationCurrentMonth() {
+      if (self.config.noCalendar || self.isMobile || !self.monthNav) return;
+      self.yearElements.forEach(function (yearElement, i) {
+        var d = new Date(self.currentYear, self.currentMonth, 1);
+        d.setMonth(self.currentMonth + i);
+        self.monthElements[i].textContent = monthToStr(d.getMonth(), self.config.shorthandCurrentMonth, self.l10n) + " ";
+        yearElement.value = d.getFullYear().toString();
+      });
+      self._hidePrevMonthArrow = self.config.minDate !== undefined && (self.currentYear === self.config.minDate.getFullYear() ? self.currentMonth <= self.config.minDate.getMonth() : self.currentYear < self.config.minDate.getFullYear());
+      self._hideNextMonthArrow = self.config.maxDate !== undefined && (self.currentYear === self.config.maxDate.getFullYear() ? self.currentMonth + 1 > self.config.maxDate.getMonth() : self.currentYear > self.config.maxDate.getFullYear());
+    }
+
+    function getDateStr(format) {
+      return self.selectedDates.map(function (dObj) {
+        return self.formatDate(dObj, format);
+      }).filter(function (d, i, arr) {
+        return self.config.mode !== "range" || self.config.enableTime || arr.indexOf(d) === i;
+      }).join(self.config.mode !== "range" ? self.config.conjunction : self.l10n.rangeSeparator);
+    }
+
+    function updateValue(triggerChange) {
+      if (triggerChange === void 0) {
+        triggerChange = true;
+      }
+
+      if (self.selectedDates.length === 0) return self.clear(triggerChange);
+
+      if (self.mobileInput !== undefined && self.mobileFormatStr) {
+        self.mobileInput.value = self.latestSelectedDateObj !== undefined ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr) : "";
+      }
+
+      self.input.value = getDateStr(self.config.dateFormat);
+
+      if (self.altInput !== undefined) {
+        self.altInput.value = getDateStr(self.config.altFormat);
+      }
+
+      if (triggerChange !== false) triggerEvent("onValueUpdate");
+    }
+
+    function onMonthNavClick(e) {
+      e.preventDefault();
+      var isPrevMonth = self.prevMonthNav.contains(e.target);
+      var isNextMonth = self.nextMonthNav.contains(e.target);
+
+      if (isPrevMonth || isNextMonth) {
+        changeMonth(isPrevMonth ? -1 : 1);
+      } else if (self.yearElements.indexOf(e.target) >= 0) {
+        e.target.select();
+      } else if (e.target.classList.contains("arrowUp")) {
+        self.changeYear(self.currentYear + 1);
+      } else if (e.target.classList.contains("arrowDown")) {
+        self.changeYear(self.currentYear - 1);
+      }
+    }
+
+    function timeWrapper(e) {
+      e.preventDefault();
+      var isKeyDown = e.type === "keydown",
+          input = e.target;
+
+      if (self.amPM !== undefined && e.target === self.amPM) {
+        self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
+      }
+
+      var min = parseFloat(input.getAttribute("data-min")),
+          max = parseFloat(input.getAttribute("data-max")),
+          step = parseFloat(input.getAttribute("data-step")),
+          curValue = parseInt(input.value, 10),
+          delta = e.delta || (isKeyDown ? e.which === 38 ? 1 : -1 : 0);
+      var newValue = curValue + step * delta;
+
+      if (typeof input.value !== "undefined" && input.value.length === 2) {
+        var isHourElem = input === self.hourElement,
+            isMinuteElem = input === self.minuteElement;
+
+        if (newValue < min) {
+          newValue = max + newValue + int(!isHourElem) + (int(isHourElem) && int(!self.amPM));
+          if (isMinuteElem) incrementNumInput(undefined, -1, self.hourElement);
+        } else if (newValue > max) {
+          newValue = input === self.hourElement ? newValue - max - int(!self.amPM) : min;
+          if (isMinuteElem) incrementNumInput(undefined, 1, self.hourElement);
+        }
+
+        if (self.amPM && isHourElem && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) {
+          self.amPM.textContent = self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
+        }
+
+        input.value = pad(newValue);
+      }
+    }
+
+    init();
+    return self;
+  }
+
+  function _flatpickr(nodeList, config) {
+    var nodes = Array.prototype.slice.call(nodeList);
+    var instances = [];
+
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+
+      try {
+        if (node.getAttribute("data-fp-omit") !== null) continue;
+
+        if (node._flatpickr !== undefined) {
+          node._flatpickr.destroy();
+
+          node._flatpickr = undefined;
+        }
+
+        node._flatpickr = FlatpickrInstance(node, config || {});
+        instances.push(node._flatpickr);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    return instances.length === 1 ? instances[0] : instances;
+  }
+
+  if (typeof HTMLElement !== "undefined") {
+    HTMLCollection.prototype.flatpickr = NodeList.prototype.flatpickr = function (config) {
+      return _flatpickr(this, config);
+    };
+
+    HTMLElement.prototype.flatpickr = function (config) {
+      return _flatpickr([this], config);
+    };
+  }
+
+  var flatpickr = function flatpickr(selector, config) {
+    if (selector instanceof NodeList) return _flatpickr(selector, config);else if (typeof selector === "string") return _flatpickr(window.document.querySelectorAll(selector), config);
+    return _flatpickr([selector], config);
+  };
+
+  flatpickr.defaultConfig = defaults;
+  flatpickr.l10ns = {
+    en: Object.assign({}, english),
+    default: Object.assign({}, english)
+  };
+
+  flatpickr.localize = function (l10n) {
+    flatpickr.l10ns.default = Object.assign({}, flatpickr.l10ns.default, l10n);
+  };
+
+  flatpickr.setDefaults = function (config) {
+    flatpickr.defaultConfig = Object.assign({}, flatpickr.defaultConfig, config);
+  };
+
+  flatpickr.parseDate = createDateParser({});
+  flatpickr.formatDate = createDateFormatter({});
+  flatpickr.compareDates = compareDates;
+
+  if (typeof jQuery !== "undefined") {
+    jQuery.fn.flatpickr = function (config) {
+      return _flatpickr(this, config);
+    };
+  }
+
+  Date.prototype.fp_incr = function (days) {
+    return new Date(this.getFullYear(), this.getMonth(), this.getDate() + (typeof days === "string" ? parseInt(days, 10) : days));
+  };
+
+  if (typeof window !== "undefined") {
+    window.flatpickr = flatpickr;
+  }
+
+  return flatpickr;
 });
 
 /***/ }),
-/* 98 */
+/* 97 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -36313,13 +36350,13 @@ var VConfig = function () {
 /* harmony default export */ __webpack_exports__["a"] = (VConfig);
 
 /***/ }),
-/* 99 */
+/* 98 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VLoads; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_urls__ = __webpack_require__(58);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__action_parameter__ = __webpack_require__(16);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__action_parameter__ = __webpack_require__(17);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -36366,15 +36403,15 @@ var VLoads = function (_VUrls) {
 }(__WEBPACK_IMPORTED_MODULE_0__utils_urls__["a" /* VUrls */]);
 
 /***/ }),
-/* 100 */
+/* 99 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPosts; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(17);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(18);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(57);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(16);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(105);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(17);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(104);
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -36710,32 +36747,32 @@ var VPosts = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
+/* 100 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(101);
+
+/***/ }),
 /* 101 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(102);
-
-/***/ }),
-/* 102 */
-/***/ (function(module, exports, __webpack_require__) {
-
+__webpack_require__(102);
 __webpack_require__(103);
-__webpack_require__(104);
 var entryUnbind = __webpack_require__(54);
 
 module.exports = entryUnbind('Array', 'flatMap');
 
 /***/ }),
-/* 103 */
+/* 102 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var $ = __webpack_require__(33);
+var $ = __webpack_require__(34);
 var flattenIntoArray = __webpack_require__(46);
 var toObject = __webpack_require__(50);
-var toLength = __webpack_require__(15);
+var toLength = __webpack_require__(16);
 var aFunction = __webpack_require__(49);
 var arraySpeciesCreate = __webpack_require__(51);
 
@@ -36748,13 +36785,13 @@ $({ target: 'Array', proto: true }, {
     var A;
     aFunction(callbackfn);
     A = arraySpeciesCreate(O, 0);
-    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments[1]);
     return A;
   }
 });
 
 /***/ }),
-/* 104 */
+/* 103 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -36764,7 +36801,7 @@ var addToUnscopables = __webpack_require__(53);
 addToUnscopables('flatMap');
 
 /***/ }),
-/* 105 */
+/* 104 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -36778,15 +36815,15 @@ function encode(value) {
 }
 
 /***/ }),
-/* 106 */
+/* 105 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VReplaces; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(16);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base__ = __webpack_require__(17);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__initialize__ = __webpack_require__(31);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__uninitialize__ = __webpack_require__(107);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(17);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base__ = __webpack_require__(18);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__initialize__ = __webpack_require__(32);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__uninitialize__ = __webpack_require__(106);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
@@ -36953,7 +36990,7 @@ var VReplaces = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */]);
 
 /***/ }),
-/* 107 */
+/* 106 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -36968,7 +37005,7 @@ function uninitialize(root) {
 }
 
 /***/ }),
-/* 108 */
+/* 107 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -41323,7 +41360,7 @@ function uninitialize(root) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 109 */
+/* 108 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41405,12 +41442,12 @@ var VToggleVisibility = function () {
 }();
 
 /***/ }),
-/* 110 */
+/* 109 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPromptIfDirty; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(17);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(18);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialog__ = __webpack_require__(60);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -41525,12 +41562,12 @@ var VPromptIfDirty = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 111 */
+/* 110 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VSnackbarEvent; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(16);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(17);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -41567,7 +41604,7 @@ var VSnackbarEvent = function () {
 }();
 
 /***/ }),
-/* 112 */
+/* 111 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41633,7 +41670,7 @@ var VClears = function () {
 }();
 
 /***/ }),
-/* 113 */
+/* 112 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41694,12 +41731,12 @@ var VRemoves = function () {
 }();
 
 /***/ }),
-/* 114 */
+/* 113 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VStepperEvent; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(17);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(18);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -41742,7 +41779,7 @@ var VStepperEvent = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 115 */
+/* 114 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41779,7 +41816,7 @@ var VNavigates = function () {
 }();
 
 /***/ }),
-/* 116 */
+/* 115 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41814,7 +41851,7 @@ var VPluginEventAction = function () {
 }();
 
 /***/ }),
-/* 117 */
+/* 116 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41829,7 +41866,7 @@ function getRoot(element) {
 }
 
 /***/ }),
-/* 118 */
+/* 117 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -42040,14 +42077,14 @@ function initLists(e) {
 }
 
 /***/ }),
-/* 119 */
+/* 118 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDrawer;
 /* unused harmony export VModalDrawer */
 /* unused harmony export VDismissibleDrawer */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(120);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(119);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_drawer__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
@@ -42127,7 +42164,7 @@ var VDismissibleDrawer = function (_VDrawer2) {
 }(VDrawer);
 
 /***/ }),
-/* 120 */
+/* 119 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -45454,13 +45491,13 @@ var VDismissibleDrawer = function (_VDrawer2) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 121 */
+/* 120 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initHeader;
 /* unused harmony export VHeader */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(122);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(121);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -45499,19 +45536,19 @@ var VHeader = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 122 */
+/* 121 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCTopAppBar; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(11);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(12);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(61);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(123);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(12);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(18);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(126);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(127);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(128);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(122);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(13);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(19);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(125);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(126);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(127);
 /* unused harmony reexport MDCTopAppBarBaseFoundation */
 /* unused harmony reexport MDCTopAppBarFoundation */
 /* unused harmony reexport MDCFixedTopAppBarFoundation */
@@ -45718,7 +45755,7 @@ var MDCTopAppBar = function (_MDCComponent) {
 
 
 /***/ }),
-/* 123 */
+/* 122 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -45726,7 +45763,7 @@ var MDCTopAppBar = function (_MDCComponent) {
 /* unused harmony export RippleCapableSurface */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(61);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(62);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(124);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(123);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(63);
 /* unused harmony reexport MDCRippleFoundation */
 /* unused harmony reexport util */
@@ -45975,13 +46012,13 @@ RippleCapableSurface.prototype.disabled;
 
 
 /***/ }),
-/* 124 */
+/* 123 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(29);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(30);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(62);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(125);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(124);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(63);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -46762,7 +46799,7 @@ var MDCRippleFoundation = function (_MDCFoundation) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCRippleFoundation);
 
 /***/ }),
-/* 125 */
+/* 124 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -46823,13 +46860,13 @@ var numbers = {
 
 
 /***/ }),
-/* 126 */
+/* 125 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(12);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(18);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__constants__ = __webpack_require__(13);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(19);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -46935,13 +46972,13 @@ var MDCFixedTopAppBarFoundation = function (_MDCTopAppBarFoundati) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCFixedTopAppBarFoundation);
 
 /***/ }),
-/* 127 */
+/* 126 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(18);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(19);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(13);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -47057,13 +47094,13 @@ var MDCShortTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCShortTopAppBarFoundation);
 
 /***/ }),
-/* 128 */
+/* 127 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(18);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(19);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(13);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -47330,15 +47367,15 @@ var MDCTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCTopAppBarFoundation);
 
 /***/ }),
-/* 129 */
+/* 128 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initIconToggles;
 /* unused harmony export VIconToggle */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(19);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(130);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(20);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(129);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -47368,7 +47405,7 @@ var VIconToggle = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 130 */
+/* 129 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -50154,16 +50191,17 @@ var VIconToggle = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 131 */
+/* 130 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSelects;
 /* unused harmony export VSelect */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(132);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(131);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_select__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__ = __webpack_require__(27);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__ = __webpack_require__(28);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_dirtyable__ = __webpack_require__(5);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -50176,13 +50214,14 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+
 function initSelects(e) {
     console.debug('\tSelects');
     Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-select', VSelect, __WEBPACK_IMPORTED_MODULE_0__material_select__["MDCSelect"]);
 }
 
-var VSelect = function (_visibilityObserverMi) {
-    _inherits(VSelect, _visibilityObserverMi);
+var VSelect = function (_dirtyableMixin) {
+    _inherits(VSelect, _dirtyableMixin);
 
     function VSelect(element, mdcComponent) {
         _classCallCheck(this, VSelect);
@@ -50192,6 +50231,7 @@ var VSelect = function (_visibilityObserverMi) {
         _this.select = element.querySelector('select');
         _this.select.vComponent = _this;
         _this.recalcWhenVisible(_this);
+        _this.originalValue = _this.value();
         return _this;
     }
 
@@ -50227,7 +50267,7 @@ var VSelect = function (_visibilityObserverMi) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.select.value = this.element.dataset.originalValue;
+            this.select.value = this.originalValue;
         }
     }, {
         key: 'setValue',
@@ -50237,15 +50277,15 @@ var VSelect = function (_visibilityObserverMi) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.value() != this.element.dataset.originalValue;
+            return this.dirtyable && this.value() !== this.originalValue;
         }
     }]);
 
     return VSelect;
-}(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
+}(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 132 */
+/* 131 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -60477,7 +60517,7 @@ var VSelect = function (_visibilityObserverMi) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 133 */
+/* 132 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -60564,7 +60604,7 @@ var VChipSet = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 134 */
+/* 133 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -60599,7 +60639,7 @@ var VCard = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 135 */
+/* 134 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -60636,13 +60676,13 @@ var VForm = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 136 */
+/* 135 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSnackbar;
 /* unused harmony export VSnackbar */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(137);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(136);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_snackbar__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -60691,7 +60731,7 @@ var VSnackbar = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 137 */
+/* 136 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -62225,18 +62265,16 @@ var VSnackbar = function (_VBaseComponent) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 138 */
+/* 137 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initCheckboxes;
 /* unused harmony export VCheckbox */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(19);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(139);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(20);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(138);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_checkbox__);
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -62264,23 +62302,11 @@ var VCheckbox = function (_VBaseToggle) {
         return _this;
     }
 
-    _createClass(VCheckbox, [{
-        key: 'isDirty',
-        value: function isDirty() {
-            // If the checkbox is cannot be dirtied, it is never dirty.
-            if (!this.element.hasAttribute('data-original-value')) {
-                return false;
-            }
-
-            return String(this.input.checked) != this.element.dataset.originalValue;
-        }
-    }]);
-
     return VCheckbox;
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 139 */
+/* 138 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -65396,18 +65422,16 @@ var VCheckbox = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 140 */
+/* 139 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSwitches;
 /* unused harmony export VSwitch */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(19);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(141);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(20);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(140);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_switch__);
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -65432,18 +65456,11 @@ var VSwitch = function (_VBaseToggle) {
         return _possibleConstructorReturn(this, (VSwitch.__proto__ || Object.getPrototypeOf(VSwitch)).call(this, element, mdcComponent));
     }
 
-    _createClass(VSwitch, [{
-        key: 'isDirty',
-        value: function isDirty() {
-            return String(this.input.checked) != this.element.dataset.originalValue;
-        }
-    }]);
-
     return VSwitch;
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 141 */
+/* 140 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -68088,7 +68105,7 @@ var VSwitch = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 142 */
+/* 141 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -68096,9 +68113,10 @@ var VSwitch = function (_VBaseToggle) {
 /* unused harmony export VRichTextArea */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(65);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(147);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(146);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_event_handler__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__ = __webpack_require__(5);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -68106,6 +68124,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 
 
 
@@ -68124,8 +68143,8 @@ function initRichTextArea(e) {
     registerBlots();
 }
 
-var VRichTextArea = function (_eventHandlerMixin) {
-    _inherits(VRichTextArea, _eventHandlerMixin);
+var VRichTextArea = function (_dirtyableMixin) {
+    _inherits(VRichTextArea, _dirtyableMixin);
 
     function VRichTextArea(element, mdcComponent) {
         _classCallCheck(this, VRichTextArea);
@@ -68138,7 +68157,7 @@ var VRichTextArea = function (_eventHandlerMixin) {
             theme: 'snow',
             placeholder: _this.quillEditorElement.dataset.placeholder
         });
-        _this.element.dataset.originalValue = _this.value();
+        _this.originalValue = _this.value();
 
         hookupCustomToolbarButtons(_this);
         return _this;
@@ -68157,8 +68176,8 @@ var VRichTextArea = function (_eventHandlerMixin) {
     }, {
         key: "value",
         value: function value() {
-            // If the quill editor is empty calling innerHTML will still return '<p><br/></p>' which it
-            // uses to represent an empty doc.
+            // If the quill editor is empty calling innerHTML will still return
+            // '<p><br/></p>' which it uses to represent an empty doc.
             var doc = this.quill.root.innerHTML;
             return doc == QUILL_EMPTY_DOC ? '' : doc;
         }
@@ -68172,7 +68191,7 @@ var VRichTextArea = function (_eventHandlerMixin) {
     }, {
         key: "reset",
         value: function reset() {
-            this.setValue(this.element.dataset.originalValue);
+            this.setValue(this.originalValue);
         }
     }, {
         key: "setValue",
@@ -68182,12 +68201,12 @@ var VRichTextArea = function (_eventHandlerMixin) {
     }, {
         key: "isDirty",
         value: function isDirty() {
-            return this.value() !== this.element.dataset.originalValue;
+            return this.dirtyable && this.value().localeCompare(this.originalValue) !== 0;
         }
     }]);
 
     return VRichTextArea;
-}(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
+}(Object(__WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */])));
 
 var blotRegistry = new WeakSet();
 
@@ -68324,7 +68343,7 @@ function configureQuill() {
 }
 
 /***/ }),
-/* 143 */
+/* 142 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -68338,9 +68357,9 @@ function configureQuill() {
 
 
 
-var base64 = __webpack_require__(144);
-var ieee754 = __webpack_require__(145);
-var isArray = __webpack_require__(146);
+var base64 = __webpack_require__(143);
+var ieee754 = __webpack_require__(144);
+var isArray = __webpack_require__(145);
 
 exports.Buffer = Buffer;
 exports.SlowBuffer = SlowBuffer;
@@ -70065,10 +70084,10 @@ function blitBuffer(src, dst, offset, length) {
 function isnan(val) {
   return val !== val; // eslint-disable-line no-self-compare
 }
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6)))
 
 /***/ }),
-/* 144 */
+/* 143 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -70195,7 +70214,7 @@ function fromByteArray(uint8) {
 }
 
 /***/ }),
-/* 145 */
+/* 144 */
 /***/ (function(module, exports) {
 
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
@@ -70284,7 +70303,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 };
 
 /***/ }),
-/* 146 */
+/* 145 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -70294,7 +70313,7 @@ module.exports = Array.isArray || function (arr) {
 };
 
 /***/ }),
-/* 147 */
+/* 146 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -70349,7 +70368,7 @@ var HorizontalRuleBlot = function (_Embed) {
 }(Embed);;
 
 /***/ }),
-/* 148 */
+/* 147 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -70429,18 +70448,16 @@ var VStepper = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 149 */
+/* 148 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRadios;
 /* unused harmony export VRadio */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(19);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(150);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(20);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(149);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_radio__);
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -70465,18 +70482,11 @@ var VRadio = function (_VBaseToggle) {
         return _possibleConstructorReturn(this, (VRadio.__proto__ || Object.getPrototypeOf(VRadio)).call(this, element, mdcComponent));
     }
 
-    _createClass(VRadio, [{
-        key: 'isDirty',
-        value: function isDirty() {
-            return String(this.input.checked) != this.element.dataset.originalValue;
-        }
-    }]);
-
     return VRadio;
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 150 */
+/* 149 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -73053,7 +73063,7 @@ var VRadio = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 151 */
+/* 150 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -73061,10 +73071,11 @@ var VRadio = function (_VBaseToggle) {
 /* unused harmony export VSlider */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(152);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(151);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_slider__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(27);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(28);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(28);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(29);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__mixins_dirtyable__ = __webpack_require__(5);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
@@ -73081,13 +73092,14 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+
 function initSliders(e) {
     console.debug('\tSliders');
     Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-slider', VSlider, __WEBPACK_IMPORTED_MODULE_2__material_slider__["MDCSlider"]);
 }
 
-var VSlider = function (_visibilityObserverMi) {
-    _inherits(VSlider, _visibilityObserverMi);
+var VSlider = function (_dirtyableMixin) {
+    _inherits(VSlider, _dirtyableMixin);
 
     function VSlider(element, mdcComponent) {
         _classCallCheck(this, VSlider);
@@ -73095,6 +73107,7 @@ var VSlider = function (_visibilityObserverMi) {
         var _this = _possibleConstructorReturn(this, (VSlider.__proto__ || Object.getPrototypeOf(VSlider)).call(this, element, mdcComponent));
 
         _this.recalcWhenVisible(_this);
+        _this.originalValue = _this.value();
         return _this;
     }
 
@@ -73121,7 +73134,7 @@ var VSlider = function (_visibilityObserverMi) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.setValue(this.element.dataset.originalValue);
+            this.setValue(this.originalValue);
         }
     }, {
         key: 'setValue',
@@ -73131,7 +73144,7 @@ var VSlider = function (_visibilityObserverMi) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.value() != this.element.dataset.originalValue;
+            return this.dirtyable && this.value() !== this.originalValue;
         }
     }, {
         key: 'initEventListener',
@@ -73155,10 +73168,10 @@ var VSlider = function (_visibilityObserverMi) {
     }]);
 
     return VSlider;
-}(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
+}(Object(__WEBPACK_IMPORTED_MODULE_5__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]))));
 
 /***/ }),
-/* 152 */
+/* 151 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -75228,13 +75241,14 @@ var VSlider = function (_visibilityObserverMi) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 153 */
+/* 152 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initHiddenFields;
 /* unused harmony export VHiddenField */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_dirtyable__ = __webpack_require__(5);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -75245,18 +75259,22 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+
 function initHiddenFields(e) {
     console.debug('\tHiddenFields');
     Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-hidden-field', VHiddenField, null);
 }
 
-var VHiddenField = function (_VBaseComponent) {
-    _inherits(VHiddenField, _VBaseComponent);
+var VHiddenField = function (_dirtyableMixin) {
+    _inherits(VHiddenField, _dirtyableMixin);
 
     function VHiddenField(element, mdcComponent) {
         _classCallCheck(this, VHiddenField);
 
-        return _possibleConstructorReturn(this, (VHiddenField.__proto__ || Object.getPrototypeOf(VHiddenField)).call(this, element, mdcComponent));
+        var _this = _possibleConstructorReturn(this, (VHiddenField.__proto__ || Object.getPrototypeOf(VHiddenField)).call(this, element, mdcComponent));
+
+        _this.originalValue = _this.value();
+        return _this;
     }
 
     // Called to collect data for submission
@@ -75285,7 +75303,7 @@ var VHiddenField = function (_VBaseComponent) {
     }, {
         key: 'reset',
         value: function reset() {
-            this.element.value = this.element.dataset.originalValue;
+            this.element.value = this.originalValue;
         }
     }, {
         key: 'setValue',
@@ -75295,15 +75313,15 @@ var VHiddenField = function (_VBaseComponent) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.value() != this.element.dataset.originalValue;
+            return this.dirtyable && this.value() !== this.originalValue;
         }
     }]);
 
     return VHiddenField;
-}(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]);
+}(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_dirtyable__["a" /* dirtyableMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 154 */
+/* 153 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75340,7 +75358,7 @@ var VContent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 155 */
+/* 154 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75391,7 +75409,7 @@ var VColumn = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 156 */
+/* 155 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75399,7 +75417,7 @@ var VColumn = function (_eventHandlerMixin2) {
 /* unused harmony export VTabBar */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(157);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(156);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_tab_bar__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -75429,7 +75447,7 @@ var VTabBar = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 157 */
+/* 156 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -81901,7 +81919,7 @@ var VTabBar = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 158 */
+/* 157 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -82031,7 +82049,7 @@ function initTables(e) {
 }
 
 /***/ }),
-/* 159 */
+/* 158 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -82039,6 +82057,7 @@ function initTables(e) {
 /* unused harmony export VFileInput */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__ = __webpack_require__(5);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -82050,13 +82069,14 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
 
+
 function initFileInputs(e) {
     console.debug('\tFile Inputs');
     Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-file-input', VFileInput, null);
 }
 
-var VFileInput = function (_eventHandlerMixin) {
-    _inherits(VFileInput, _eventHandlerMixin);
+var VFileInput = function (_dirtyableMixin) {
+    _inherits(VFileInput, _dirtyableMixin);
 
     function VFileInput(element, mdcComponent) {
         _classCallCheck(this, VFileInput);
@@ -82071,6 +82091,7 @@ var VFileInput = function (_eventHandlerMixin) {
                 return _this.handleFileSelection(e);
             }, false);
         });
+        _this.originalValue = _this.input.value;
         return _this;
     }
 
@@ -82148,7 +82169,7 @@ var VFileInput = function (_eventHandlerMixin) {
     }, {
         key: 'isDirty',
         value: function isDirty() {
-            return this.input.value != this.element.dataset.originalValue;
+            return this.dirtyable && this.input.value !== this.originalValue;
         }
 
         // From an example based on: https://www.quirksmode.org/dom/inputfile.html
@@ -82161,10 +82182,10 @@ var VFileInput = function (_eventHandlerMixin) {
     }]);
 
     return VFileInput;
-}(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
+}(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 160 */
+/* 159 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -82172,7 +82193,7 @@ var VFileInput = function (_eventHandlerMixin) {
 /* unused harmony export VFormField */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(4);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(161);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(160);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_form_field__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -82204,7 +82225,7 @@ var VFormField = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 161 */
+/* 160 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -84709,7 +84730,7 @@ var VFormField = function (_VBaseContainer) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 162 */
+/* 161 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -84754,7 +84775,7 @@ var VImage = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 163 */
+/* 162 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -84804,7 +84825,7 @@ var VTypography = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 164 */
+/* 163 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -84842,7 +84863,7 @@ var VTooltip = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 165 */
+/* 164 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -84959,14 +84980,14 @@ var VPluginComponent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 166 */
+/* 165 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initProgress;
 /* unused harmony export VProgress */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__ = __webpack_require__(167);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__ = __webpack_require__(166);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -85017,11 +85038,11 @@ var VProgress = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 167 */
+/* 166 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(168);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(167);
 /* harmony namespace reexport (by used) */ __webpack_require__.d(__webpack_exports__, "a", function() { return __WEBPACK_IMPORTED_MODULE_0__component__["a"]; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(67);
 /* unused harmony namespace reexport */
@@ -85052,13 +85073,13 @@ var VProgress = function (_VBaseComponent) {
 //# sourceMappingURL=index.js.map
 
 /***/ }),
-/* 168 */
+/* 167 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgress; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(30);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(169);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(168);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(67);
 /**
  * @license
@@ -85159,12 +85180,12 @@ var MDCLinearProgress = /** @class */function (_super) {
 //# sourceMappingURL=component.js.map
 
 /***/ }),
-/* 169 */
+/* 168 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCComponent; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(30);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(66);
 /**
  * @license
@@ -85270,7 +85291,7 @@ var MDCComponent = /** @class */function () {
 //# sourceMappingURL=component.js.map
 
 /***/ }),
-/* 170 */
+/* 169 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85363,7 +85384,7 @@ function getCorrectEventName(windowObj, eventType) {
 //# sourceMappingURL=util.js.map
 
 /***/ }),
-/* 171 */
+/* 170 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85403,7 +85424,7 @@ var strings = {
 //# sourceMappingURL=constants.js.map
 
 /***/ }),
-/* 172 */
+/* 171 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85540,7 +85561,7 @@ function initDragAndDrop(e) {
 }
 
 /***/ }),
-/* 173 */
+/* 172 */
 /***/ (function(module, exports) {
 
 /**
@@ -85563,7 +85584,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 })();
 
 /***/ }),
-/* 174 */
+/* 173 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global, setImmediate) {var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -88279,10 +88300,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }).call(this);
 
 //# sourceMappingURL=webcomponents-bundle.js.map
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5), __webpack_require__(175).setImmediate))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6), __webpack_require__(174).setImmediate))
 
 /***/ }),
-/* 175 */
+/* 174 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global) {var scope = typeof global !== "undefined" && global || typeof self !== "undefined" && self || window;
@@ -88334,16 +88355,16 @@ exports._unrefActive = exports.active = function (item) {
 };
 
 // setimmediate attaches itself to the global object
-__webpack_require__(176);
+__webpack_require__(175);
 // On some exotic environments, it's not clear which object `setimmediate` was
 // able to install onto.  Search each possibility in the same order as the
 // `setimmediate` library.
 exports.setImmediate = typeof self !== "undefined" && self.setImmediate || typeof global !== "undefined" && global.setImmediate || this && this.setImmediate;
 exports.clearImmediate = typeof self !== "undefined" && self.clearImmediate || typeof global !== "undefined" && global.clearImmediate || this && this.clearImmediate;
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6)))
 
 /***/ }),
-/* 176 */
+/* 175 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global, process) {(function (global, undefined) {
@@ -88528,10 +88549,10 @@ exports.clearImmediate = typeof self !== "undefined" && self.clearImmediate || t
     attachTo.setImmediate = setImmediate;
     attachTo.clearImmediate = clearImmediate;
 })(typeof self === "undefined" ? typeof global === "undefined" ? this : global : self);
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5), __webpack_require__(177)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6), __webpack_require__(176)))
 
 /***/ }),
-/* 177 */
+/* 176 */
 /***/ (function(module, exports) {
 
 // shim for using process in browser
@@ -88721,7 +88742,7 @@ process.umask = function () {
 };
 
 /***/ }),
-/* 178 */
+/* 177 */
 /***/ (function(module, exports) {
 
 ;(function() {

--- a/views/mdc/assets/js/components/base-toggle.js
+++ b/views/mdc/assets/js/components/base-toggle.js
@@ -1,7 +1,8 @@
 import {VBaseComponent} from './base-component';
 import {eventHandlerMixin} from './mixins/event-handler';
+import {dirtyableMixin} from './mixins/dirtyable';
 
-export class VBaseToggle extends eventHandlerMixin(VBaseComponent) {
+export class VBaseToggle extends dirtyableMixin(eventHandlerMixin(VBaseComponent)) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
 
@@ -11,6 +12,8 @@ export class VBaseToggle extends eventHandlerMixin(VBaseComponent) {
             // Revert to previous checked state on failed post.
             this.mdcComponent.checked = !this.mdcComponent.checked;
         });
+
+        this.originalValue = this.input.checked;
     }
 
     prepareSubmit(params) {
@@ -40,10 +43,14 @@ export class VBaseToggle extends eventHandlerMixin(VBaseComponent) {
     }
 
     reset() {
-        this.input.checked = this.element.dataset.originalValue;
+        this.input.checked = this.originalValue;
     }
 
     setValue(value) {
         this.input.value = value;
+    }
+
+    isDirty() {
+        return this.dirtyable && this.input.checked !== this.originalValue;
     }
 }

--- a/views/mdc/assets/js/components/checkboxes.js
+++ b/views/mdc/assets/js/components/checkboxes.js
@@ -12,13 +12,4 @@ export class VCheckbox extends VBaseToggle {
         super(element, mdcComponent);
         this.mdcComponent.indeterminate = (this.input.dataset.indeterminate === 'true');
     }
-
-    isDirty() {
-        // If the checkbox is cannot be dirtied, it is never dirty.
-        if (!this.element.hasAttribute('data-original-value')) {
-            return false;
-        }
-
-        return String(this.input.checked) != this.element.dataset.originalValue;
-    }
 }

--- a/views/mdc/assets/js/components/datetime.js
+++ b/views/mdc/assets/js/components/datetime.js
@@ -8,6 +8,7 @@ export function initDateTime(e) {
     console.debug('\tDateTime');
     hookupComponents(e, '.v-datetime', VDateTime, MDCTextField);
 }
+
 export class VDateTime extends VTextField {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
@@ -37,6 +38,7 @@ export class VDateTime extends VTextField {
         this.fp.mdc_text_field = mdcComponent;
 
         element.addEventListener('click', () => this.toggle());
+        this.originalValue = this.fp.input.value;
     }
 
     clear() {
@@ -48,7 +50,7 @@ export class VDateTime extends VTextField {
     }
 
     reset() {
-        this.fp.setDate(this.element.dataset.originalValue);
+        this.fp.setDate(this.originalValue);
     }
 
     open() {
@@ -81,8 +83,13 @@ export class VDateTime extends VTextField {
     // }
 
     isDirty() {
+        if (!this.dirtyable) {
+            return false;
+        }
+
         const currVal = new Date(this.fp.input.value);
-        const prevVal = new Date(this.element.dataset.originalValue);
+        const prevVal = new Date(this.originalValue);
+
         return currVal.getTime() !== prevVal.getTime();
     }
 }

--- a/views/mdc/assets/js/components/file-inputs.js
+++ b/views/mdc/assets/js/components/file-inputs.js
@@ -1,12 +1,13 @@
 import {VBaseComponent, hookupComponents} from './base-component';
 import {eventHandlerMixin} from './mixins/event-handler';
+import {dirtyableMixin} from './mixins/dirtyable';
 
 export function initFileInputs(e) {
     console.debug('\tFile Inputs');
     hookupComponents(e, '.v-file-input', VFileInput, null);
 }
 
-export class VFileInput extends eventHandlerMixin(VBaseComponent) {
+export class VFileInput extends dirtyableMixin(eventHandlerMixin(VBaseComponent)) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
 
@@ -17,6 +18,7 @@ export class VFileInput extends eventHandlerMixin(VBaseComponent) {
             element.addEventListener(e, (e) => this.handleFileSelection(e),
                 false);
         });
+        this.originalValue = this.input.value;
     }
 
     prepareSubmit(params) {
@@ -64,7 +66,7 @@ export class VFileInput extends eventHandlerMixin(VBaseComponent) {
     }
 
     isDirty() {
-        return this.input.value != this.element.dataset.originalValue;
+        return this.dirtyable && this.input.value !== this.originalValue;
     }
 
     // From an example based on: https://www.quirksmode.org/dom/inputfile.html

--- a/views/mdc/assets/js/components/hidden-fields.js
+++ b/views/mdc/assets/js/components/hidden-fields.js
@@ -1,13 +1,15 @@
 import {VBaseComponent, hookupComponents} from './base-component';
+import {dirtyableMixin} from './mixins/dirtyable';
 
 export function initHiddenFields(e) {
     console.debug('\tHiddenFields');
     hookupComponents(e, '.v-hidden-field', VHiddenField, null);
 }
 
-export class VHiddenField extends VBaseComponent {
+export class VHiddenField extends dirtyableMixin(VBaseComponent) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
+        this.originalValue = this.value();
     }
 
     // Called to collect data for submission
@@ -28,7 +30,7 @@ export class VHiddenField extends VBaseComponent {
     }
 
     reset() {
-        this.element.value = this.element.dataset.originalValue;
+        this.element.value = this.originalValue;
     }
 
     setValue(value) {
@@ -36,6 +38,7 @@ export class VHiddenField extends VBaseComponent {
     }
 
     isDirty() {
-        return this.value() != this.element.dataset.originalValue;
+        return this.dirtyable
+            && this.value() !== this.originalValue;
     }
 }

--- a/views/mdc/assets/js/components/mixins/dirtyable.js
+++ b/views/mdc/assets/js/components/mixins/dirtyable.js
@@ -1,0 +1,22 @@
+export const dirtyableMixin = Base => class extends Base {
+    get originalValue() {
+        return this._originalValue;
+    }
+
+    set originalValue(value) {
+        this._originalValue = value;
+    }
+
+    get dirtyable() {
+        if (!this.element) {
+            return false;
+        }
+
+        return this.element.hasAttribute('data-dirtyable');
+    }
+
+    isDirty() {
+        // Implement in extending classes.
+        throw new Error('Implement isDirty()');
+    }
+};

--- a/views/mdc/assets/js/components/radios.js
+++ b/views/mdc/assets/js/components/radios.js
@@ -11,8 +11,4 @@ export class VRadio extends VBaseToggle {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
     }
-
-    isDirty() {
-        return String(this.input.checked) != this.element.dataset.originalValue;
-    }
 }

--- a/views/mdc/assets/js/components/rich-text-area.js
+++ b/views/mdc/assets/js/components/rich-text-area.js
@@ -2,6 +2,7 @@ import Quill from "quill";
 import {HorizontalRuleBlot} from './rich-text-area/horizontal-rule-blot';
 import {hookupComponents, VBaseComponent} from "./base-component";
 import {eventHandlerMixin} from "./mixins/event-handler";
+import {dirtyableMixin} from './mixins/dirtyable';
 
 // These Blots will be registered with Quill.
 const blots = [
@@ -29,7 +30,7 @@ export function initRichTextArea(e) {
     registerBlots();
 }
 
-export class VRichTextArea extends eventHandlerMixin(VBaseComponent) {
+export class VRichTextArea extends dirtyableMixin(eventHandlerMixin(VBaseComponent)) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
 
@@ -39,7 +40,7 @@ export class VRichTextArea extends eventHandlerMixin(VBaseComponent) {
             theme: 'snow',
             placeholder: this.quillEditorElement.dataset.placeholder
         });
-        this.element.dataset.originalValue = this.value();
+        this.originalValue = this.value();
 
         hookupCustomToolbarButtons(this);
     }
@@ -53,8 +54,8 @@ export class VRichTextArea extends eventHandlerMixin(VBaseComponent) {
     }
 
     value() {
-        // If the quill editor is empty calling innerHTML will still return '<p><br/></p>' which it
-        // uses to represent an empty doc.
+        // If the quill editor is empty calling innerHTML will still return
+        // '<p><br/></p>' which it uses to represent an empty doc.
         var doc = this.quill.root.innerHTML;
         return doc == QUILL_EMPTY_DOC ? '' : doc;
     }
@@ -66,7 +67,7 @@ export class VRichTextArea extends eventHandlerMixin(VBaseComponent) {
     }
 
     reset() {
-        this.setValue(this.element.dataset.originalValue);
+        this.setValue(this.originalValue);
     }
 
     setValue(value) {
@@ -74,7 +75,8 @@ export class VRichTextArea extends eventHandlerMixin(VBaseComponent) {
     }
 
     isDirty() {
-        return this.value() !== this.element.dataset.originalValue;
+        return this.dirtyable
+            && this.value().localeCompare(this.originalValue) !== 0;
     }
 }
 

--- a/views/mdc/assets/js/components/selects.js
+++ b/views/mdc/assets/js/components/selects.js
@@ -1,18 +1,20 @@
 import {MDCSelect} from '@material/select';
 import {VBaseComponent, hookupComponents} from './base-component';
 import {visibilityObserverMixin} from "./mixins/visibility-observer";
+import {dirtyableMixin} from './mixins/dirtyable';
 
 export function initSelects(e) {
     console.debug('\tSelects');
     hookupComponents(e, '.v-select', VSelect, MDCSelect);
 }
 
-export class VSelect extends visibilityObserverMixin(VBaseComponent) {
+export class VSelect extends dirtyableMixin(visibilityObserverMixin(VBaseComponent)) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
         this.select = element.querySelector('select');
         this.select.vComponent = this;
         this.recalcWhenVisible(this);
+        this.originalValue = this.value();
     }
 
     prepareSubmit(params) {
@@ -41,7 +43,7 @@ export class VSelect extends visibilityObserverMixin(VBaseComponent) {
     }
 
     reset() {
-        this.select.value = this.element.dataset.originalValue;
+        this.select.value = this.originalValue;
     }
 
     setValue(value) {
@@ -49,6 +51,6 @@ export class VSelect extends visibilityObserverMixin(VBaseComponent) {
     }
 
     isDirty() {
-        return this.value() != this.element.dataset.originalValue;
+        return this.dirtyable && this.value() !== this.originalValue;
     }
 }

--- a/views/mdc/assets/js/components/sliders.js
+++ b/views/mdc/assets/js/components/sliders.js
@@ -3,19 +3,20 @@ import {eventHandlerMixin} from './mixins/event-handler';
 import {MDCSlider} from '@material/slider';
 import {visibilityObserverMixin} from './mixins/visibility-observer';
 import {VEvents} from './events';
+import {dirtyableMixin} from './mixins/dirtyable';
 
 export function initSliders(e) {
     console.debug('\tSliders');
     hookupComponents(e, '.v-slider', VSlider, MDCSlider);
 }
 
-export class VSlider extends visibilityObserverMixin(
-    eventHandlerMixin(VBaseComponent)) {
+export class VSlider extends dirtyableMixin(visibilityObserverMixin(
+    eventHandlerMixin(VBaseComponent))) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
         this.recalcWhenVisible(this);
+        this.originalValue = this.value();
     }
-
 
     prepareSubmit(params) {
         params.push([this.name(), this.value()]);
@@ -34,7 +35,7 @@ export class VSlider extends visibilityObserverMixin(
     }
 
     reset() {
-        this.setValue(this.element.dataset.originalValue);
+        this.setValue(this.originalValue);
     }
 
     setValue(value) {
@@ -42,7 +43,7 @@ export class VSlider extends visibilityObserverMixin(
     }
 
     isDirty() {
-        return this.value() != this.element.dataset.originalValue;
+        return this.dirtyable && this.value() !== this.originalValue;
     }
 
     initEventListener(eventName, eventHandler) {

--- a/views/mdc/assets/js/components/switches.js
+++ b/views/mdc/assets/js/components/switches.js
@@ -11,8 +11,4 @@ export class VSwitch extends VBaseToggle {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
     }
-
-    isDirty() {
-        return String(this.input.checked) != this.element.dataset.originalValue;
-    }
 }

--- a/views/mdc/assets/js/components/text-fields.js
+++ b/views/mdc/assets/js/components/text-fields.js
@@ -2,6 +2,7 @@ import {MDCTextField} from '@material/textfield';
 import {VBaseComponent, hookupComponents} from './base-component';
 import {eventHandlerMixin} from './mixins/event-handler';
 import {visibilityObserverMixin} from './mixins/visibility-observer';
+import {dirtyableMixin} from './mixins/dirtyable';
 
 const AFTER_INPUT_EVENT = 'after_input';
 const AFTER_INPUT_TIMEOUT = 500; // ms
@@ -11,8 +12,9 @@ export function initTextFields(e) {
     hookupComponents(e, '.v-text-field', VTextField, MDCTextField);
 }
 
-export class VTextField extends visibilityObserverMixin(
-    eventHandlerMixin(VBaseComponent)) {
+export class VTextField extends dirtyableMixin(
+    visibilityObserverMixin(
+    eventHandlerMixin(VBaseComponent))) {
     constructor(element, mdcComponent) {
         super(element, mdcComponent);
 
@@ -28,6 +30,8 @@ export class VTextField extends visibilityObserverMixin(
                 this.element.dispatchEvent(new Event(AFTER_INPUT_EVENT));
             }, AFTER_INPUT_TIMEOUT)
         });
+
+        this.originalValue = this.value();
     }
 
     // Called whenever a form is about to be submitted.
@@ -90,7 +94,7 @@ export class VTextField extends visibilityObserverMixin(
     }
 
     reset() {
-        this.input.value = this.element.dataset.originalValue;
+        this.input.value = this.originalValue;
     }
 
     setValue(value) {
@@ -98,7 +102,8 @@ export class VTextField extends visibilityObserverMixin(
     }
 
     isDirty() {
-        return this.value() !== this.element.dataset.originalValue;
+        return this.dirtyable
+            && this.value().localeCompare(this.originalValue) !== 0;
     }
 
     onShow() {

--- a/views/mdc/components/checkbox.erb
+++ b/views/mdc/components/checkbox.erb
@@ -2,7 +2,7 @@
 <div class="v-form-field mdc-form-field">
   <div id="<%= comp.id %>"
        <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-       <% if comp.dirtyable %>data-original-value="<%=comp.checked%>"<% end %>
+       <% if comp.dirtyable %>data-dirtyable<% end %>
        class="v-checkbox mdc-checkbox v-input">
     <input type="checkbox"
            id="<%= comp.id %>-input"

--- a/views/mdc/components/datetime.erb
+++ b/views/mdc/components/datetime.erb
@@ -3,7 +3,7 @@
 %>
 <div id="<%= comp.id %>"
      <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-     <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
+     <% if comp.dirtyable %>data-dirtyable<% end %>
      class="v-input v-datetime mdc-text-field mdc-text-field--outlined
             <%= 'mdc-text-field--with-trailing-icon' if comp.clear_icon %>
             <%= 'mdc-text-field--disabled' if comp.disabled %>

--- a/views/mdc/components/file_input.erb
+++ b/views/mdc/components/file_input.erb
@@ -2,7 +2,7 @@
   <div id="<%= comp.id %>" class="v-input v-file-input"
        data-preview=<%= JSON.generate(Array(comp.preview)) %>
            data-accept="<%= comp.accept %>"
-       <% if comp.dirtyable %>data-original-value="<%= comp.value %>"<% end %>
+       <% if comp.dirtyable %>data-dirtyable<% end %>
 
 
        <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} %>>

--- a/views/mdc/components/hidden_field.erb
+++ b/views/mdc/components/hidden_field.erb
@@ -1,5 +1,5 @@
 <input class="v-input v-hidden-field"
        type="hidden"
        <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-       <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
+       <% if comp.dirtyable %>data-dirtyable<% end %>
        id="<%= comp.id %>" name="<%= comp.name %>" value="<%= comp.value %>"/>

--- a/views/mdc/components/radio_button.erb
+++ b/views/mdc/components/radio_button.erb
@@ -1,7 +1,7 @@
 <div class="v-form-field mdc-form-field">
   <div id="<%= comp.id %>"
        <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-       <% if comp.dirtyable %>data-original-value="<%=comp.checked%>"<% end %>
+       <% if comp.dirtyable %>data-dirtyable<% end %>
        class="v-radio mdc-radio v-input">
     <input class="mdc-radio__native-control"
            type="radio"

--- a/views/mdc/components/rich_text_area.erb
+++ b/views/mdc/components/rich_text_area.erb
@@ -1,7 +1,7 @@
 <div class="v-rich-text-area-container v-input"
      id="<%= comp.id %>"
      <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-     <% if comp.dirtyable %>data-original-value="<%= h(comp.value) %>"><% end %>
+     <% if comp.dirtyable %>data-dirtyable<% end %>>
   <label for="<%= comp.id %>-rta"><%= expand_text(comp.label) %></label>
   <div class="v-rich-text-area"
        id="<%= comp.id %>-rta"

--- a/views/mdc/components/select.erb
+++ b/views/mdc/components/select.erb
@@ -3,7 +3,7 @@
 %>
   <div class="mdc-select <%= 'mdc-select--outlined' if comp.outlined %> v-select v-input"
        <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-       <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
+       <% if comp.dirtyable %>data-dirtyable<% end %>
        <%= 'style="width: 100%;"' if comp.full_width %>>
     <i class="mdc-select__dropdown-icon"></i>
     <select id="<%= comp.id %>"

--- a/views/mdc/components/slider.erb
+++ b/views/mdc/components/slider.erb
@@ -11,7 +11,7 @@
      <% if comp.step %>
      data-step="<%= comp.step %>"
      <% end %>
-     <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
+     <% if comp.dirtyable %>data-dirtyable<% end %>
      aria-valuemin="<%= comp.value_min %>"
      aria-valuemax="<%= comp.value_max %>"
      aria-valuenow="<%= comp.value unless comp.value.nil? %>"

--- a/views/mdc/components/switch.erb
+++ b/views/mdc/components/switch.erb
@@ -4,7 +4,7 @@
 <div class="v-form-field mdc-form-field">
   <div id="<%= comp.id %>"
        <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-       <% if comp.dirtyable %>data-original-value="<%=comp.checked%>"<% end %>
+       <% if comp.dirtyable %>data-dirtyable<% end %>
        class="v-switch v-input mdc-switch
       <%= 'mdc-switch--disabled' if comp.disabled %>
       <%= class_name %>">

--- a/views/mdc/components/text_area.erb
+++ b/views/mdc/components/text_area.erb
@@ -1,7 +1,7 @@
 <div id="<%= comp.id %>" class="v-input v-text-field mdc-text-field mdc-text-field--textarea
             <%= ' is-invalid is-dirty' if comp.error %>"
      <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-     <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
+     <% if comp.dirtyable %>data-dirtyable<% end %>
      style="<%= 'width:100%' if comp.full_width %>">
   <textarea id="<%= comp.id %>-input"
             name="<%= comp.name %>"

--- a/views/mdc/components/text_field.erb
+++ b/views/mdc/components/text_field.erb
@@ -5,7 +5,7 @@
 %>
   <div id="<%= comp.id %>"
        <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
-       <% if comp.dirtyable %>data-original-value="<%=comp.value%>"<% end %>
+       <% if comp.dirtyable %>data-dirtyable<% end %>
        class="v-input v-text-field v-focusable mdc-text-field mdc-text-field--outlined
             <%= 'mdc-text-field--with-leading-icon' if leading_icon %>
             <%= 'mdc-text-field--with-trailing-icon' if trailing_icon %>


### PR DESCRIPTION
Previously, the values for the `data-original-value` attributes of
dirtyable elements was a plain string. This caused issues if the value
contained quotes, and was especially noticeable for text areas and rich
text areas.

With this change, the original values for dirtyable elements are stored
as a property of the component instance instead of as an attribute of
the component's DOM element with a DOMString-serialized value. This
removes the need to serialize the values at all, resolving the above
issue.

Additionally, dirtyable elements now implement the `dirtyableMixin`,
compartmentalizing much of the nonspecific original value and dirtyable
logic.

The dirtyable check implemented in 5b6828f was only affecting
checkboxes. This check has been extended to include all dirtyable
elements.

Finally, text areas, rich text areas, and text fields now use `localeCompare`
instead of a strict equality check when determining whether they are dirty.

Fixes #189.