### PR TITLE
Add attributes to menu items

### DIFF
--- a/lib/voom/presenters/dsl/components/menu.rb
+++ b/lib/voom/presenters/dsl/components/menu.rb
@@ -41,29 +41,8 @@ module Voom
 
           private
 
-          class Item < EventBase
-            include Mixins::Tooltips
-            include Mixins::Typography
-
-            attr_accessor :text, :disabled, :selected, :position, :size, :color
-
-            def initialize(**attribs_, &block)
-              super(type: :item, **attribs_, &block)
-              @text = attribs.delete(:text)
-              @disabled = attribs.delete(:disabled)
-              @selected = attribs.delete(:selected) {false}
-              @position = validate_position(attribs.delete(:position) { :top })
-              @size = validate_size(attribs.delete(:size) { :normal })
-              @color = attribs.delete(:color) { :primary }
-              @components = []
-              expand!
-            end
-
-            def icon(icon=nil, **attribs, &block)
-              return @icon if locked?
-              @icon = Icon.new(parent: self, icon: icon,
-                               **attribs, &block)
-            end
+          module BaseMenuItem
+            attr_reader :position, :size, :color
 
             private
 
@@ -97,15 +76,49 @@ module Voom
             end
           end
 
+          class Item < EventBase
+            include Mixins::Tooltips
+            include Mixins::Typography
+            include BaseMenuItem
+
+            attr_accessor :text, :disabled, :selected
+
+            def initialize(**attribs_, &block)
+              super(type: :item, **attribs_, &block)
+              @text = attribs.delete(:text)
+              @disabled = attribs.delete(:disabled)
+              @selected = attribs.delete(:selected) {false}
+              @position = validate_position(attribs.delete(:position) { :top })
+              @size = validate_size(attribs.delete(:size) { :normal })
+              @color = attribs.delete(:color) { :primary }
+              @components = []
+              expand!
+            end
+
+            def icon(icon=nil, **attribs, &block)
+              return @icon if locked?
+              @icon = Icon.new(parent: self, icon: icon,
+                               **attribs, &block)
+            end
+          end
+
           class Label < Item
             def initialize(**attribs, &block)
               super(type: :label, **attribs, &block)
+              @position = validate_position(attribs.delete(:position) { :top })
+              @size = validate_size(attribs.delete(:size) { :normal })
+              @color = attribs.delete(:color) { :primary }
             end
           end
 
           class Divider < Base
+            include BaseMenuItem
+
             def initialize(**attribs, &block)
               super(type: :divider, **attribs, &block)
+              @position = validate_position(attribs.delete(:position) { :top })
+              @size = validate_size(attribs.delete(:size) { :normal })
+              @color = attribs.delete(:color) { :primary }
             end
           end
         end

--- a/lib/voom/presenters/dsl/components/menu.rb
+++ b/lib/voom/presenters/dsl/components/menu.rb
@@ -45,13 +45,16 @@ module Voom
             include Mixins::Tooltips
             include Mixins::Typography
 
-            attr_accessor :text, :disabled, :selected
+            attr_accessor :text, :disabled, :selected, :position, :size, :color
 
             def initialize(**attribs_, &block)
               super(type: :item, **attribs_, &block)
               @text = attribs.delete(:text)
               @disabled = attribs.delete(:disabled)
               @selected = attribs.delete(:selected) {false}
+              @position = validate_position(attribs.delete(:position) { :top })
+              @size = validate_size(attribs.delete(:size) { :normal })
+              @color = attribs.delete(:color) { :primary }
               @components = []
               expand!
             end
@@ -60,6 +63,37 @@ module Voom
               return @icon if locked?
               @icon = Icon.new(parent: self, icon: icon,
                                **attribs, &block)
+            end
+
+            private
+
+            VALID_POSITIONS = %i[top bottom].freeze
+            VALID_SIZES = %i[normal small].freeze
+
+            def validate_position(value)
+              return unless value
+
+              v = value.to_sym
+
+              unless VALID_POSITIONS.include?(v)
+                raise Errors::ParameterValidation,
+                      "Invalid item position! Valid positions include #{VALID_POSITIONS.join(', ')}"
+              end
+
+              v
+            end
+
+            def validate_size(value)
+              return unless value
+
+              v = value.to_sym
+
+              unless VALID_SIZES.include?(v)
+                raise Errors::ParameterValidation,
+                      "Invalid item size! Valid sizes include #{VALID_SIZES.join(', ')}"
+              end
+
+              v
             end
           end
 

--- a/lib/voom/presenters/web_client/app.rb
+++ b/lib/voom/presenters/web_client/app.rb
@@ -85,8 +85,11 @@ module Voom
           end
 
           def color_classname(comp)
+            return unless comp&.color
+
             return "v-#{comp.type}__primary" if eq(comp.color, :primary)
             return "v-#{comp.type}__secondary" if eq(comp.color, :secondary)
+
             "v-color__#{comp.color}"
           end
 

--- a/public/bundle.css
+++ b/public/bundle.css
@@ -11831,6 +11831,28 @@ a.mdc-list-item {
       margin-left: 256px;
       margin-right: 0; } }
 
+.v-drawer .mdc-drawer__content .v-list {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column; }
+
+.v-drawer.v-drawer--full-height.mdc-drawer--modal {
+  top: 0; }
+
+.v-drawer.v-drawer--full-height .mdc-drawer__content .v-list.v-list--full-height {
+  height: 100%; }
+
+.v-drawer .mdc-drawer__content .v-list .v-list--bottom-wrapper {
+  margin-top: auto; }
+
+.mdc-drawer.v-drawer .v-list-item--size-small {
+  font-size: 0.80rem; }
+
+.v-drawer .v-list-item.v-item__secondary {
+  color: rgba(0, 0, 0, 0.54);
+  /* @alternate */
+  color: var(--mdc-theme-text-secondary-on-background, rgba(0, 0, 0, 0.54)); }
+
 .mdc-icon-toggle {
   --mdc-ripple-fg-size: 0;
   --mdc-ripple-left: 0;

--- a/public/bundle.css
+++ b/public/bundle.css
@@ -11836,19 +11836,19 @@ a.mdc-list-item {
   display: flex;
   flex-direction: column; }
 
-.v-drawer.v-drawer--full-height.mdc-drawer--modal {
+.mdc-drawer.v-drawer.mdc-drawer--modal {
   top: 0; }
 
-.v-drawer.v-drawer--full-height .mdc-drawer__content .v-list.v-list--full-height {
-  height: 100%; }
+.mdc-drawer.v-drawer.v-drawer--full-height .mdc-drawer__content .v-list.v-list--full-height {
+  min-height: 100%; }
 
-.v-drawer .mdc-drawer__content .v-list .v-list--bottom-wrapper {
+.mdc-drawer.v-drawer .mdc-drawer__content .v-list .v-list--bottom-wrapper {
   margin-top: auto; }
 
 .mdc-drawer.v-drawer .v-list-item--size-small {
   font-size: 0.80rem; }
 
-.v-drawer .v-list-item.v-item__secondary {
+.mdc-drawer.v-drawer .v-list-item.v-item__secondary:not(.mdc-list-item--activated) {
   color: rgba(0, 0, 0, 0.54);
   /* @alternate */
   color: var(--mdc-theme-text-secondary-on-background, rgba(0, 0, 0, 0.54)); }

--- a/views/mdc/assets/scss/components/drawer.scss
+++ b/views/mdc/assets/scss/components/drawer.scss
@@ -54,3 +54,29 @@
     margin-right: 0;
    }
 }
+
+.v-drawer .mdc-drawer__content .v-list {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.v-drawer.v-drawer--full-height.mdc-drawer--modal {
+  top: 0;
+}
+
+.v-drawer.v-drawer--full-height .mdc-drawer__content .v-list.v-list--full-height {
+  height: 100%;
+}
+
+.v-drawer .mdc-drawer__content .v-list .v-list--bottom-wrapper {
+  margin-top: auto;
+}
+
+.mdc-drawer.v-drawer .v-list-item--size-small {
+  font-size: 0.80rem;
+}
+
+.v-drawer .v-list-item.v-item__secondary {
+  @include mdc-list-item-primary-text-ink-color(text-secondary-on-background);
+}

--- a/views/mdc/assets/scss/components/drawer.scss
+++ b/views/mdc/assets/scss/components/drawer.scss
@@ -65,11 +65,11 @@
   top: 0;
 }
 
-.v-drawer.v-drawer--full-height .mdc-drawer__content .v-list.v-list--full-height {
-  height: 100%;
+.mdc-drawer.v-drawer.v-drawer--full-height .mdc-drawer__content .v-list.v-list--full-height {
+  min-height: 100%;
 }
 
-.v-drawer .mdc-drawer__content .v-list .v-list--bottom-wrapper {
+.mdc-drawer.v-drawer .mdc-drawer__content .v-list .v-list--bottom-wrapper {
   margin-top: auto;
 }
 

--- a/views/mdc/assets/scss/components/drawer.scss
+++ b/views/mdc/assets/scss/components/drawer.scss
@@ -61,7 +61,7 @@
   flex-direction: column;
 }
 
-.v-drawer.v-drawer--full-height.mdc-drawer--modal {
+.mdc-drawer.v-drawer.mdc-drawer--modal {
   top: 0;
 }
 

--- a/views/mdc/assets/scss/components/drawer.scss
+++ b/views/mdc/assets/scss/components/drawer.scss
@@ -77,6 +77,6 @@
   font-size: 0.80rem;
 }
 
-.v-drawer .v-list-item.v-item__secondary {
+.mdc-drawer.v-drawer .v-list-item.v-item__secondary:not(.mdc-list-item--activated) {
   @include mdc-list-item-primary-text-ink-color(text-secondary-on-background);
 }

--- a/views/mdc/assets/scss/components/list.scss
+++ b/views/mdc/assets/scss/components/list.scss
@@ -41,6 +41,3 @@
 .v-list__border {
   border: 1px solid rgba(0,0,0,.1);
 }
-
-
-

--- a/views/mdc/body/dismissable-drawer.erb
+++ b/views/mdc/body/dismissable-drawer.erb
@@ -1,4 +1,8 @@
-<aside id="<%= drawer.id %>" class="v-drawer v-drawer__dismissible mdc-drawer mdc-drawer--dismissible mdc-drawer--open">
+<%
+  top_items = drawer.menu&.items&.select { |i| eq(i.position, :top) }
+  bottom_items = drawer.menu&.items&.select { |i| eq(i.position, :bottom) }
+%> 
+<aside id="<%= drawer.id %>" class="v-drawer <% if bottom_items.any? %>v-drawer--full-height<% end %> v-drawer__dismissible mdc-drawer mdc-drawer--dismissible mdc-drawer--open">
   <% if drawer.title || drawer.subtitle %>
     <div class="mdc-drawer__header">
   <% end %>
@@ -12,12 +16,19 @@
     </div>
   <% end %>
   <div class="mdc-drawer__content">
-      <nav class="mdc-list">
-      <% drawer.menu&.items&.each do |item|%>
+    <nav class="mdc-list v-list <% if bottom_items.any? %>v-list--full-height<% end %>">
+      <% top_items.each do |item| %>
         <%= erb :"body/drawer/#{item.type}", :locals => {item: item} %>
+      <% end %>
+
+      <% if bottom_items.any? %>
+        <div class="v-list--bottom-wrapper">
+          <% bottom_items.each do |item| %>
+            <%= erb :"body/drawer/#{item.type}", :locals => {item: item} %>
+          <% end %>
+        </div>
       <% end %>
     </nav>
     <%= erb :"components/render", :locals => {:components => drawer.components, :scope => nil} %>
   </div>
 </aside>
-

--- a/views/mdc/body/drawer/item.erb
+++ b/views/mdc/body/drawer/item.erb
@@ -1,9 +1,13 @@
 <a id="<%= item.id %>"
-         class="mdc-list-item <%= 'mdc-list-item--activated' if item.selected %>"
-         href="javascript:void(0)"
-         tabindex="0"
-         aria-selected="true"
-          <%= erb :"components/event", :locals => {comp: item, events: item.events, parent_id: item.event_parent_id} %>>
-         <%= erb :"components/icon", :locals => {comp: item.icon, class_name: 'mdc-list-item__graphic'} %>
-         <%= expand_text item.text %>
-        </a>
+   class="mdc-list-item v-list-item
+          <% if item.selected %>mdc-list-item--activated<% end %>
+          <% if item.size %>v-list-item--size-<%= item.size %><% end %>
+          <%= color_classname(item) %>"
+   href="javascript:void(0)"
+   tabindex="0"
+   aria-selected="<%= item.selected %>"
+   style="<%= color_style(item) %>"
+  <%= erb :"components/event", :locals => {comp: item, events: item.events, parent_id: item.event_parent_id} %>>
+  <%= erb :"components/icon", :locals => {comp: item.icon, class_name: 'mdc-list-item__graphic'} %>
+  <%= expand_text item.text %>
+</a>

--- a/views/mdc/body/modal-drawer.erb
+++ b/views/mdc/body/modal-drawer.erb
@@ -1,4 +1,8 @@
-<aside id="<%= drawer.id %>" class="v-drawer v-drawer__modal mdc-drawer mdc-drawer--modal">
+<%
+  top_items = drawer.menu&.items&.select { |i| eq(i.position, :top) }
+  bottom_items = drawer.menu&.items&.select { |i| eq(i.position, :bottom) }
+%> 
+<aside id="<%= drawer.id %>" class="v-drawer <% if bottom_items.any? %>v-drawer--full-height<% end %> v-drawer__modal mdc-drawer mdc-drawer--modal">
   <% if drawer.title || drawer.subtitle %>
     <div class="mdc-drawer__header">
   <% end %>
@@ -12,12 +16,20 @@
     </div>
   <% end %>
   <div class="mdc-drawer__content">
-        <nav class="mdc-list">
-        <% drawer.menu&.items&.each do |item|%>
-          <%= erb :"body/drawer/#{item.type}", :locals => {item: item} %>
-        <% end %>
-      </nav>
-      <%= erb :"components/render", :locals => {:components => drawer.components, :scope => nil} %>
+    <nav class="mdc-list v-list <% if bottom_items.any? %>v-list--full-height<% end %>">
+      <% top_items.each do |item| %>
+        <%= erb :"body/drawer/#{item.type}", :locals => {item: item} %>
+      <% end %>
+
+      <% if bottom_items.any? %>
+        <div class="v-list--bottom-wrapper">
+          <% bottom_items.each do |item| %>
+            <%= erb :"body/drawer/#{item.type}", :locals => {item: item} %>
+          <% end %>
+        </div>
+      <% end %>
+    </nav>
+    <%= erb :"components/render", :locals => {:components => drawer.components, :scope => nil} %>
   </div>
 </aside>
 <div class="mdc-drawer-scrim"></div>


### PR DESCRIPTION
* `position`: `:top` (default) or `:bottom`
  * bottom-positioned menu items are visually grouped and placed at the
    bottom of menus, separate from other menu items
* `size`: `:normal` (default) or `:small`
  * small menu items have a smaller font size
* `color`: `:primary` (default), `:secondary`, or a user-specified value