### PR TITLE
Let yield_to accept arguments

### DIFF
--- a/lib/voom/presenters/dsl/components/mixins/append.rb
+++ b/lib/voom/presenters/dsl/components/mixins/append.rb
@@ -9,8 +9,8 @@ module Voom
               @components << comp
             end
 
-            def yield_to(&block)
-              instance_eval(&block) if block
+            def yield_to(*args, &block)
+              instance_exec(*args, &block) if block_given?
             end
           end
         end

--- a/lib/voom/presenters/dsl/components/mixins/yield_to.rb
+++ b/lib/voom/presenters/dsl/components/mixins/yield_to.rb
@@ -4,8 +4,8 @@ module Voom
       module Components
         module Mixins
           module YieldTo
-            def yield_to(&block)
-              instance_eval(&block) if block
+            def yield_to(*args, &block)
+              instance_exec(*args, &block) if block_given?
             end
           end
         end


### PR DESCRIPTION
This allows for:

```ruby
# foo.pom
def helper(&block)
  some_collection.each do |item|
    yield_to(item, &block)
  end
end

# ...

helper do |item|
  # do something with item
end
```