### PR TITLE
Non action dialog buttons

### DIFF
--- a/lib/voom/presenters/dsl/components/button.rb
+++ b/lib/voom/presenters/dsl/components/button.rb
@@ -12,7 +12,7 @@ module Voom
 
           BUTTON_TYPES = %i(raised flat fab icon)
 
-          attr_accessor :text, :icon, :button_type, :color, :disabled, :size, :position, :full_width, :hidden
+          attr_accessor :text, :icon, :button_type, :color, :disabled, :size, :position, :full_width, :hidden, :wrap_text
 
           def initialize(type: nil, **attribs_, &block)
             @button_type = h(type) || ((attribs_[:icon] && !attribs_[:text]) ? :icon : nil) || :flat
@@ -24,6 +24,7 @@ module Voom
             @hidden = attribs.delete(:hidden) {false}
             @size = attribs.delete(:size)
             @full_width = attribs.delete(:full_width) {false}
+            @wrap_text = attribs.delete(:wrap_text) {true}
             @position = Array(default_position).compact
             expand!
             @event_parent_id = self.parent(:form)&.id || id

--- a/lib/voom/presenters/dsl/components/table.rb
+++ b/lib/voom/presenters/dsl/components/table.rb
@@ -12,11 +12,12 @@ module Voom
         class Table < Base
           include Mixins::Common
           include Mixins::Event
-          attr_accessor :header, :rows, :selectable
+          attr_accessor :header, :rows, :selectable, :width
 
           def initialize(**attribs_, &block)
             super(type: :table, **attribs_, &block)
             @selectable = attribs.delete(:selectable)
+            @width = attribs.delete(:width)
             @rows = []
             expand!
           end

--- a/lib/voom/presenters/dsl/components/table.rb
+++ b/lib/voom/presenters/dsl/components/table.rb
@@ -68,6 +68,7 @@ module Voom
               include Mixins::Chipset
               include Mixins::Selects
               include Mixins::Icons
+              include Mixins::Content
 
               attr_accessor :numeric, :color, :components
 

--- a/public/bundle.css
+++ b/public/bundle.css
@@ -17663,6 +17663,9 @@ i:focus.v-datetime--clear {
   display: none;
   visibility: hidden; }
 
+.v-nowrap {
+  white-space: nowrap; }
+
 .incompatible-browser .compatibility-wrapper * {
   display: none; }
 

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -44901,9 +44901,13 @@ var VDialog = function (_eventHandlerMixin) {
             // A successful run-to-completion of an event chain should always
             // attempt to close the dialog.
             this.shouldNotifyClosing = false;
-            this.canClose = true;
 
-            this.close(vEvent.event.detail.action);
+            // We should only be closing the dialog for components that are marked as mdcDialogActions
+            var dialogAction = vEvent.vComponent.element.dataset.mdcDialogAction;
+            if (dialogAction !== undefined) {
+                this.canClose = true;
+                this.close(vEvent.event.detail.action);
+            }
             _get(VDialog.prototype.__proto__ || Object.getPrototypeOf(VDialog.prototype), 'actionsSucceeded', this).call(this, vEvent); // Bubble up
         }
     }, {

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -44902,8 +44902,8 @@ var VDialog = function (_eventHandlerMixin) {
             // attempt to close the dialog.
             this.shouldNotifyClosing = false;
 
-            // We should only be closing the dialog for components that are marked as mdcDialogActions
-            var dialogAction = vEvent.vComponent.element.dataset.mdcDialogAction;
+            // We should only be closing the dialog for components marked as autoClose
+            var dialogAction = vEvent.vComponent.element.dataset.autoClose;
             if (dialogAction !== undefined) {
                 this.canClose = true;
                 this.close(vEvent.event.detail.action);

--- a/public/wc.js
+++ b/public/wc.js
@@ -30242,9 +30242,13 @@ var VDialog = function (_eventHandlerMixin) {
             // A successful run-to-completion of an event chain should always
             // attempt to close the dialog.
             this.shouldNotifyClosing = false;
-            this.canClose = true;
 
-            this.close(vEvent.event.detail.action);
+            // We should only be closing the dialog for components that are marked as mdcDialogActions
+            var dialogAction = vEvent.vComponent.element.dataset.mdcDialogAction;
+            if (dialogAction !== undefined) {
+                this.canClose = true;
+                this.close(vEvent.event.detail.action);
+            }
             _get(VDialog.prototype.__proto__ || Object.getPrototypeOf(VDialog.prototype), 'actionsSucceeded', this).call(this, vEvent); // Bubble up
         }
     }, {

--- a/public/wc.js
+++ b/public/wc.js
@@ -30243,8 +30243,8 @@ var VDialog = function (_eventHandlerMixin) {
             // attempt to close the dialog.
             this.shouldNotifyClosing = false;
 
-            // We should only be closing the dialog for components that are marked as mdcDialogActions
-            var dialogAction = vEvent.vComponent.element.dataset.mdcDialogAction;
+            // We should only be closing the dialog for components marked as autoClose
+            var dialogAction = vEvent.vComponent.element.dataset.autoClose;
             if (dialogAction !== undefined) {
                 this.canClose = true;
                 this.close(vEvent.event.detail.action);

--- a/views/mdc/assets/js/components/dialogs.js
+++ b/views/mdc/assets/js/components/dialogs.js
@@ -95,9 +95,14 @@ export class VDialog extends eventHandlerMixin(VBaseContainer) {
         // A successful run-to-completion of an event chain should always
         // attempt to close the dialog.
         this.shouldNotifyClosing = false;
-        this.canClose = true;
 
-        this.close(vEvent.event.detail.action);
+
+        // We should only be closing the dialog for components that are marked as mdcDialogActions
+        let dialogAction = vEvent.vComponent.element.dataset.mdcDialogAction;
+        if (dialogAction !== undefined) {
+            this.canClose = true;
+            this.close(vEvent.event.detail.action);
+        }
         super.actionsSucceeded(vEvent); // Bubble up
     }
 

--- a/views/mdc/assets/js/components/dialogs.js
+++ b/views/mdc/assets/js/components/dialogs.js
@@ -96,9 +96,8 @@ export class VDialog extends eventHandlerMixin(VBaseContainer) {
         // attempt to close the dialog.
         this.shouldNotifyClosing = false;
 
-
-        // We should only be closing the dialog for components that are marked as mdcDialogActions
-        let dialogAction = vEvent.vComponent.element.dataset.mdcDialogAction;
+        // We should only be closing the dialog for components marked as autoClose
+        let dialogAction = vEvent.vComponent.element.dataset.autoClose;
         if (dialogAction !== undefined) {
             this.canClose = true;
             this.close(vEvent.event.detail.action);

--- a/views/mdc/assets/scss/styles.scss
+++ b/views/mdc/assets/scss/styles.scss
@@ -14,6 +14,11 @@
     display: none;
     visibility: hidden;
 }
+
+.v-nowrap {
+    white-space: nowrap;
+}
+
 .incompatible-browser .compatibility-wrapper * {
     display: none;
 }

--- a/views/mdc/components/buttons/button.erb
+++ b/views/mdc/components/buttons/button.erb
@@ -10,7 +10,8 @@
          <%= 'v-secondary-filled-button' if eq(comp.button_type, :raised) && eq(comp.color, :secondary) %>
          <%= 'v-secondary-text-button' if eq(comp.button_type, :flat) && eq(comp.color, :secondary) %>
          <%=  position_classes %>
-         <%= 'v-menu-click' if comp.menu%>"
+         <%= 'v-menu-click' if comp.menu%>
+         <%= 'v-nowrap' unless comp.wrap_text%>"
          style = "<%= color_style(comp) %>"
          <%= data_attributes %>
         <%= 'disabled' if comp.disabled %>

--- a/views/mdc/components/dialog.erb
+++ b/views/mdc/components/dialog.erb
@@ -54,7 +54,7 @@
                 <%= erb :"components/button",
                         :locals => {:comp => button,
                                     :class_name => "mdc-dialog__button",
-                                    :data_attributes => "data-mdc-dialog-action='#{button.id}'"} %>
+                                    :data_attributes => "data-mdc-dialog-action='#{button.id}' data-auto-close"} %>
               <% end %>
             </footer>
           <% end %>

--- a/views/mdc/components/table.erb
+++ b/views/mdc/components/table.erb
@@ -1,4 +1,5 @@
 <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp"
+       style="<%= "width:#{comp.width};" if comp.width %>"
   <%= erb :"components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id}%>>
   <% if comp.header %>
     <thead>


### PR DESCRIPTION
Added logic to the `actionsSucceeded` handler to auto close the dialog only if the element is marked as with data-mdc-dialog-action. Per the MDC spec buttons marked in this manner are to close the dialog. This allows for the use of other buttons within the form that will not auto close the dialog.