### PR TITLE
Drag-n-drop `dropped` event

### DIFF
--- a/app/demo/patterns/drag_drop.pom
+++ b/app/demo/patterns/drag_drop.pom
@@ -46,6 +46,10 @@ Voom::Presenters.define(:drag_drop) do
                 posts '_dragon_drop_change_order_', target_id: dragon.id
                 loads :drag_drop
               end
+
+              event :dropped do
+                snackbar "Dropped the #{dragon.name}. Whoops!"
+              end
             end
           end
         end

--- a/lib/voom/presenters/dsl/components/chipset.rb
+++ b/lib/voom/presenters/dsl/components/chipset.rb
@@ -1,10 +1,11 @@
 require 'voom/presenters/dsl/components/mixins/chips'
+require 'voom/presenters/dsl/components/mixins/event'
 
 module Voom
   module Presenters
     module DSL
       module Components
-        class Chipset < Base
+        class Chipset < EventBase
           include Mixins::Chips
           attr_reader :variant, :components
 

--- a/public/bundle.css
+++ b/public/bundle.css
@@ -15192,13 +15192,13 @@ button.mdc-chip {
   -moz-user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
-  cursor: move; }
+  cursor: move !important; }
 
 .v-dnd-draggable {
-  cursor: grab; }
+  cursor: grab !important; }
 
 .v-dnd-over {
-  border: 2px dashed #000; }
+  outline: 2px dashed #000 !important; }
 
 .v-expansion {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12); }

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -60,7 +60,11 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
+<<<<<<< HEAD
 /******/ 	return __webpack_require__(__webpack_require__.s = 197);
+=======
+/******/ 	return __webpack_require__(__webpack_require__.s = 199);
+>>>>>>> Ensure chips have a name before submitting values
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -561,7 +565,11 @@ var global = __webpack_require__(3);
 var hide = __webpack_require__(14);
 var has = __webpack_require__(17);
 var SRC = __webpack_require__(37)('src');
+<<<<<<< HEAD
 var $toString = __webpack_require__(208);
+=======
+var $toString = __webpack_require__(210);
+>>>>>>> Ensure chips have a name before submitting values
 var TO_STRING = 'toString';
 var TPL = ('' + $toString).split(TO_STRING);
 
@@ -2624,7 +2632,11 @@ var strings = {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(202);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(204);
+>>>>>>> Ensure chips have a name before submitting values
 
 
 /* harmony default export */ __webpack_exports__["a"] = (new __WEBPACK_IMPORTED_MODULE_0__utils_config__["a" /* default */]({
@@ -3152,7 +3164,11 @@ module.exports = function (it) {
 
 var global = __webpack_require__(26);
 var setGlobal = __webpack_require__(118);
+<<<<<<< HEAD
 var IS_PURE = __webpack_require__(414);
+=======
+var IS_PURE = __webpack_require__(416);
+>>>>>>> Ensure chips have a name before submitting values
 
 var SHARED = '__core-js_shared__';
 var store = global[SHARED] || setGlobal(SHARED, {});
@@ -3291,6 +3307,225 @@ function expandParams(results, params) {
 }
 
 /***/ }),
+<<<<<<< HEAD
+=======
+/* 85 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(163);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(439);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(115);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(188);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+
+
+
+
+
+var VBase = function (_VUrls) {
+    _inherits(VBase, _VUrls);
+
+    function VBase(options, root) {
+        _classCallCheck(this, VBase);
+
+        var _this = _possibleConstructorReturn(this, (VBase.__proto__ || Object.getPrototypeOf(VBase)).call(this));
+
+        _this.options = options;
+        _this.root = root;
+        return _this;
+    }
+
+    _createClass(VBase, [{
+        key: 'clearErrors',
+        value: function clearErrors() {
+            new __WEBPACK_IMPORTED_MODULE_2__errors__["a" /* VErrors */](this.root).clearErrors();
+        }
+    }, {
+        key: 'parentElement',
+        value: function parentElement() {
+            return this.root.getElementById(this.options.__parent_id__);
+        }
+
+        /**
+         * taggedInputs retrieves all components matching this event's input_tag
+         * value.
+         * @return {NodeList}
+         */
+
+    }, {
+        key: 'taggedInputs',
+        value: function taggedInputs() {
+            var inputTag = this.options.input_tag;
+
+            if (!inputTag) {
+                return [];
+            }
+
+            var selector = '[data-input-tag="' + inputTag + '"]';
+            var inputs = this.root.querySelectorAll(selector);
+
+            if (inputs.length < 1) {
+                console.warn('input_tag ' + inputTag + ' matched 0 elements. Are you sure' + 'you\'ve specified the correct value?');
+            }
+
+            return inputs;
+        }
+
+        /**
+         * inputs retrieves relevant input elements for this event.
+         *
+         * - If an `input_tag` has been provided, all matching tagged elements are
+         *   included.
+         * - If this component is a input element, it is included.
+         * - If this component has input elements, its input elements are included.
+         *   If not, the input elements of the nearest container (dialog or content)
+         *   are included.
+         * @return {Array<HTMLElement>}
+         */
+
+    }, {
+        key: 'inputs',
+        value: function inputs() {
+            var components = [];
+
+            // Collect tagged components, if applicable:
+            if (this.options.input_tag) {
+                var taggedComponents = Array.from(this.taggedInputs()).filter(function (element) {
+                    return element.vComponent;
+                }).map(function (element) {
+                    return element.vComponent;
+                });
+
+                components.push(taggedComponents);
+            }
+
+            var comp = this.component();
+
+            if (comp) {
+                // Include ourselves if we're a form field component, but not a
+                // container:
+                if (comp.respondTo('prepareSubmit') && !comp.respondTo('inputs')) {
+                    components.push(comp);
+                } else if (!comp.respondTo('inputs')) {
+                    // Defer to the component's closest container (card, content,
+                    // dialog, or form) if the component itself does not respond to
+                    // `inputs`:
+                    comp = this.closestContainer();
+                }
+            }
+
+            if (comp && comp.respondTo('inputs')) {
+                components.push(comp);
+            }
+
+            // Map components to elements.
+            // Containers are mapped to their child elements.
+            // Form field components are mapped to their own element.
+            var elements = components.flat().flatMap(function (comp) {
+                if (comp.respondTo('inputs')) {
+                    return Array.from(comp.inputs());
+                } else if (comp.respondTo('prepareSubmit')) {
+                    return comp.element;
+                }
+            });
+
+            // Deduplicate:
+            return Array.from(new Set(elements));
+        }
+
+        /**
+         * inputComponents retrieves the Component for each of this event's
+         * relevant input elements.
+         * @return {Array<VBaseComponent>}
+         */
+
+    }, {
+        key: 'inputComponents',
+        value: function inputComponents() {
+            return this.inputs().filter(function (element) {
+                return element.vComponent;
+            }).map(function (element) {
+                return element.vComponent;
+            });
+        }
+
+        /**
+         * inputValues retrieves submit values for each of this event's relevant
+         * input elements.
+         * @return {Array}
+         */
+
+    }, {
+        key: 'inputValues',
+        value: function inputValues() {
+            var params = [];
+
+            this.inputComponents().filter(function (comp) {
+                return comp.respondTo('prepareSubmit');
+            }).map(function (comp) {
+                return comp.prepareSubmit(params);
+            });
+
+            return params;
+        }
+    }, {
+        key: 'component',
+        value: function component() {
+            var parent = this.parentElement();
+
+            return parent ? parent.vComponent : null;
+        }
+    }, {
+        key: 'validate',
+        value: function validate() {
+            var comp = this.component();
+
+            if (comp) {
+                return comp.validate();
+            }
+
+            return [];
+        }
+    }, {
+        key: 'closestContainer',
+        value: function closestContainer() {
+            var element = this.closestContainerElement();
+
+            if (!element) {
+                return null;
+            }
+
+            return element.vComponent;
+        }
+    }, {
+        key: 'closestContainerElement',
+        value: function closestContainerElement() {
+            var comp = this.component();
+
+            if (!(comp && comp.element)) {
+                return null;
+            }
+
+            return comp.element.closest('[data-is-container]');
+        }
+    }]);
+
+    return VBase;
+}(__WEBPACK_IMPORTED_MODULE_3__utils_urls__["a" /* VUrls */]);
+
+/***/ }),
+>>>>>>> Ensure chips have a name before submitting values
 /* 86 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
@@ -3864,7 +4099,11 @@ module.exports = __webpack_require__(21).getIteratorMethod = function (it) {
 /***/ (function(module, exports, __webpack_require__) {
 
 // 9.4.2.3 ArraySpeciesCreate(originalArray, length)
+<<<<<<< HEAD
 var speciesConstructor = __webpack_require__(297);
+=======
+var speciesConstructor = __webpack_require__(299);
+>>>>>>> Ensure chips have a name before submitting values
 
 module.exports = function (original, length) {
   return new (speciesConstructor(original))(length);
@@ -4786,7 +5025,11 @@ var VErrors = function () {
 /***/ (function(module, exports, __webpack_require__) {
 
 // toObject with fallback for non-array-like ES3 strings
+<<<<<<< HEAD
 var IndexedObject = __webpack_require__(412);
+=======
+var IndexedObject = __webpack_require__(414);
+>>>>>>> Ensure chips have a name before submitting values
 var requireObjectCoercible = __webpack_require__(168);
 
 module.exports = function (it) {
@@ -4929,21 +5172,28 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VEvents; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = initEvents;
 /* harmony export (immutable) */ __webpack_exports__["c"] = removeEvents;
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(435);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(441);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(443);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(189);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(437);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(438);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(444);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(190);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(115);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(446);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(447);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(448);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(449);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(450);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(451);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(452);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(453);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(454);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(509);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(447);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(448);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(449);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(450);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(451);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(452);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(453);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(454);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(455);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(191);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -6702,6 +6952,7 @@ module.exports = Math.scale || function scale(x, inLow, inHigh, outLow, outHigh)
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony export (immutable) */ __webpack_exports__["initialize"] = initialize;
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(407);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(431);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(433);
@@ -6736,6 +6987,42 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(502);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(503);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(509);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(409);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(433);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(435);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(187);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(456);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(457);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(459);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(467);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(189);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(469);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(471);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(472);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(473);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(474);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(476);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(478);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(480);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(486);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(487);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(489);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(491);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(492);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(493);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(494);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(496);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(497);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(498);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(500);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(501);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(502);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(503);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(504);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(191);
+>>>>>>> Ensure chips have a name before submitting values
 
 
 
@@ -6821,7 +7108,11 @@ function initialize(root, setRoot) {
 /* 163 */
 /***/ (function(module, exports, __webpack_require__) {
 
+<<<<<<< HEAD
 module.exports = __webpack_require__(409);
+=======
+module.exports = __webpack_require__(411);
+>>>>>>> Ensure chips have a name before submitting values
 
 /***/ }),
 /* 164 */
@@ -6832,10 +7123,17 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 var global = __webpack_require__(26);
 var getOwnPropertyDescriptor = __webpack_require__(165).f;
 var hide = __webpack_require__(62);
+<<<<<<< HEAD
 var redefine = __webpack_require__(413);
 var setGlobal = __webpack_require__(118);
 var copyConstructorProperties = __webpack_require__(417);
 var isForced = __webpack_require__(424);
+=======
+var redefine = __webpack_require__(415);
+var setGlobal = __webpack_require__(118);
+var copyConstructorProperties = __webpack_require__(419);
+var isForced = __webpack_require__(426);
+>>>>>>> Ensure chips have a name before submitting values
 
 /*
   options.target      - name of the target object
@@ -6889,7 +7187,11 @@ module.exports = function (options, source) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(58);
+<<<<<<< HEAD
 var propertyIsEnumerableModule = __webpack_require__(411);
+=======
+var propertyIsEnumerableModule = __webpack_require__(413);
+>>>>>>> Ensure chips have a name before submitting values
 var createPropertyDescriptor = __webpack_require__(166);
 var toIndexedObject = __webpack_require__(116);
 var toPrimitive = __webpack_require__(169);
@@ -7030,7 +7332,11 @@ module.exports = function (key) {
 /* 175 */
 /***/ (function(module, exports, __webpack_require__) {
 
+<<<<<<< HEAD
 var path = __webpack_require__(419);
+=======
+var path = __webpack_require__(421);
+>>>>>>> Ensure chips have a name before submitting values
 var global = __webpack_require__(26);
 
 var aFunction = function aFunction(variable) {
@@ -7047,7 +7353,11 @@ module.exports = function (namespace, method) {
 
 var has = __webpack_require__(61);
 var toIndexedObject = __webpack_require__(116);
+<<<<<<< HEAD
 var indexOf = __webpack_require__(421).indexOf;
+=======
+var indexOf = __webpack_require__(423).indexOf;
+>>>>>>> Ensure chips have a name before submitting values
 var hiddenKeys = __webpack_require__(119);
 
 module.exports = function (object, names) {
@@ -7202,7 +7512,11 @@ module.exports = function (originalArray, length) {
 var global = __webpack_require__(26);
 var shared = __webpack_require__(83);
 var uid = __webpack_require__(174);
+<<<<<<< HEAD
 var NATIVE_SYMBOL = __webpack_require__(425);
+=======
+var NATIVE_SYMBOL = __webpack_require__(427);
+>>>>>>> Ensure chips have a name before submitting values
 
 var _Symbol = global.Symbol;
 var store = shared('wks');
@@ -7216,7 +7530,11 @@ module.exports = function (name) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var wellKnownSymbol = __webpack_require__(183);
+<<<<<<< HEAD
 var create = __webpack_require__(427);
+=======
+var create = __webpack_require__(429);
+>>>>>>> Ensure chips have a name before submitting values
 var hide = __webpack_require__(62);
 
 var UNSCOPABLES = wellKnownSymbol('unscopables');
@@ -13861,7 +14179,7 @@ var VTextField = function (_dirtyableMixin) {
 /* harmony export (immutable) */ __webpack_exports__["b"] = uninitMenus;
 /* harmony export (immutable) */ __webpack_exports__["a"] = initMenus;
 /* unused harmony export VMenu */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(445);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(446);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_menu__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
@@ -14030,6 +14348,213 @@ var VDialog = function () {
 
 /***/ }),
 /* 190 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return DRAG_DATA_MIME_TYPE; });
+/* unused harmony export EVENT_DROPPED */
+/* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/*
+    A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
+    three modes:
+
+    1. read/write, during a `dragstart` event: items can be read and added
+    2. read-only, during a `drop` event: items can be read, but not added
+    3. protected, during all other types of DragEvent: items cannot be read
+       or added.
+
+    (see https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw)
+
+    Thus, attempting to mutate the store during events other than `dragstart`
+    fails silently: no error is raised, but items are not added.
+
+
+    To read items in protected mode, serialize data as a string and store it as
+    a key instead of as a value. This makes it accessible via
+    `dataTransfer.types`:
+
+    // in a dragstart handler:
+    event.dataTransfer.setData(JSON.stringify(foo), '');
+
+    // in a later read-only or protected DragEvent handler:
+    const json = event.dataTransfer.types[someIndex];
+    const foo = JSON.stringify(json);
+
+
+    There is no workaround for attempting mutating a drag data store not in
+    read/write mode.
+ */
+
+
+
+var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
+var EVENT_DROPPED = 'dropped';
+
+var ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
+
+function createDragStartHandler(root, element) {
+    return function (event) {
+        var dragParamData = event.target.dataset.drag_params;
+
+        if (dragParamData) {
+            event.dataTransfer.setData(DRAG_DATA_MIME_TYPE, dragParamData);
+
+            var zone = JSON.parse(dragParamData).zone;
+
+            if (zone) {
+                event.dataTransfer.setData(zone, '');
+            }
+
+            event.dataTransfer.effectAllowed = 'move';
+            event.target.classList.remove('v-dnd-draggable');
+            event.target.classList.add('v-dnd-moving');
+
+            event.dataTransfer.setData(ELEMENT_ID_MIME_TYPE, element.id);
+        }
+    };
+}
+
+function createDragOverHandler(root, element) {
+    return function (event) {
+        var dropZone = element.dataset.dropzone;
+
+        if (dropZone == null || event.dataTransfer.types.includes(dropZone)) {
+            if (event.preventDefault) {
+                event.preventDefault();
+            }
+            element.classList.add('v-dnd-over');
+        } else {
+            element.classList.remove('v-dnd-over');
+        }
+    };
+}
+
+function createDragLeaveHandler(root, element) {
+    return function (event) {
+        element.classList.remove('v-dnd-over');
+    };
+}
+
+function createDropHandler(root, element) {
+    // When an element is upgraded to a Voom component after being replaced via
+    // `replaces`, root may refer to the replaced element itself instead of the
+    // element's root node.
+    // Since a valid drop zone may exist anywhere on the page, it is not
+    // guaranteed that root contains the element being dragged.
+    // getRootNode will fetch `root`'s actual root node (document or shadow
+    // DOM root).
+    var trueRoot = Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* getRootNode */])(root);
+
+    return function (event) {
+        event.stopPropagation();
+        event.preventDefault();
+
+        var id = event.dataTransfer.getData(ELEMENT_ID_MIME_TYPE);
+        var draggedElement = id ? trueRoot.querySelector('#' + id) : null;
+        var dragParams = {};
+
+        if (draggedElement) {
+            dragParams = JSON.parse(draggedElement.dataset.drag_params);
+        }
+
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
+
+        // Emit a "dropped" event for the element being dragged:
+        // The drag_params of the dragged element are merged with the
+        // drop_params of the drop zone.
+        var dropZoneParams = JSON.parse(element.dataset.drop_params);
+        var params = Object.assign({}, dragParams, dropZoneParams);
+        var droppedEvent = new CustomEvent(EVENT_DROPPED, { detail: params });
+
+        draggedElement.dispatchEvent(droppedEvent);
+
+        return false;
+    };
+}
+
+function createDragEndHandler(root, element) {
+    return function (event) {
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
+    };
+}
+
+var DRAGGABLE_SELECTOR = '[draggable=true]';
+var DROP_ZONE_SELECTOR = '[data-dropzone]';
+
+function initDragAndDrop(root) {
+    var draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
+        console.log('root matches DRAGGABLE_SELECTOR');
+        draggables.unshift(root);
+    }
+
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+        for (var _iterator = draggables[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var elem = _step.value;
+
+            elem.addEventListener('dragstart', createDragStartHandler(root, elem));
+            elem.addEventListener('dragend', createDragEndHandler(root, elem));
+        }
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator.return) {
+                _iterator.return();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
+            }
+        }
+    }
+
+    var dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
+        console.log('root matches DROP_ZONE_SELECTOR');
+        dropZones.unshift(root);
+    }
+
+    var _iteratorNormalCompletion2 = true;
+    var _didIteratorError2 = false;
+    var _iteratorError2 = undefined;
+
+    try {
+        for (var _iterator2 = dropZones[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+            var _elem = _step2.value;
+
+            _elem.addEventListener('dragover', createDragOverHandler(root, _elem));
+            _elem.addEventListener('drop', createDropHandler(root, _elem));
+            _elem.addEventListener('dragleave', createDragLeaveHandler(root, _elem));
+        }
+    } catch (err) {
+        _didIteratorError2 = true;
+        _iteratorError2 = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                _iterator2.return();
+            }
+        } finally {
+            if (_didIteratorError2) {
+                throw _iteratorError2;
+            }
+        }
+    }
+}
+
+/***/ }),
+/* 192 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14207,7 +14732,11 @@ var MDCComponent = function () {
 /* harmony default export */ __webpack_exports__["a"] = (MDCComponent);
 
 /***/ }),
+<<<<<<< HEAD
 /* 191 */
+=======
+/* 193 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14388,7 +14917,11 @@ var MDCRippleAdapter = function () {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCRippleAdapter);
 
 /***/ }),
+<<<<<<< HEAD
 /* 192 */
+=======
+/* 194 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14569,7 +15102,11 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 
 
 /***/ }),
+<<<<<<< HEAD
 /* 193 */
+=======
+/* 195 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -18152,7 +18689,11 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 194 */
+=======
+/* 196 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(Buffer, module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof2 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -31079,10 +31620,14 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
     /******/)["default"]
   );
 });
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(480).Buffer, __webpack_require__(12)(module)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(481).Buffer, __webpack_require__(12)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 195 */
+=======
+/* 197 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -31167,15 +31712,25 @@ var MDCFoundation = /** @class */function () {
 //# sourceMappingURL=foundation.js.map
 
 /***/ }),
+<<<<<<< HEAD
 /* 196 */
+=======
+/* 198 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgressFoundation; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(507);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(195);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(508);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(508);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(197);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(509);
+>>>>>>> Ensure chips have a name before submitting values
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -31303,6 +31858,7 @@ var MDCLinearProgressFoundation = /** @class */function (_super) {
 //# sourceMappingURL=foundation.js.map
 
 /***/ }),
+<<<<<<< HEAD
 /* 197 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -31311,12 +31867,27 @@ module.exports = __webpack_require__(198);
 
 /***/ }),
 /* 198 */
+=======
+/* 199 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(200);
+
+
+/***/ }),
+/* 200 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_compatibility__ = __webpack_require__(199);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(66);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_compatibility__ = __webpack_require__(201);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(65);
+>>>>>>> Ensure chips have a name before submitting values
 
 
 
@@ -31332,9 +31903,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
     document.documentElement.classList.remove('incompatible-browser');
 
+<<<<<<< HEAD
     __webpack_require__(203);
     __webpack_require__(204);
     __webpack_require__(205);
+=======
+    __webpack_require__(205);
+    __webpack_require__(206);
+    __webpack_require__(207);
+>>>>>>> Ensure chips have a name before submitting values
 
     __webpack_require__(162).initialize(document, true);
 
@@ -31350,11 +31927,19 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 199 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser__ = __webpack_require__(200);
+=======
+/* 201 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser__ = __webpack_require__(202);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_detect_browser__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(66);
 
@@ -31368,7 +31953,11 @@ var isCompatible = browser && incompatibleList.indexOf(name) < 0;
 /* harmony default export */ __webpack_exports__["a"] = (isCompatible);
 
 /***/ }),
+<<<<<<< HEAD
 /* 200 */
+=======
+/* 202 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(process) {function detect() {
@@ -31452,10 +32041,17 @@ module.exports = {
   getNodeVersion: getNodeVersion,
   parseUserAgent: parseUserAgent
 };
+<<<<<<< HEAD
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(201)))
 
 /***/ }),
 /* 201 */
+=======
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(203)))
+
+/***/ }),
+/* 203 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports) {
 
 // shim for using process in browser
@@ -31645,7 +32241,11 @@ process.umask = function () {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 202 */
+=======
+/* 204 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -31747,7 +32347,11 @@ var VConfig = function () {
 /* harmony default export */ __webpack_exports__["a"] = (VConfig);
 
 /***/ }),
+<<<<<<< HEAD
 /* 203 */
+=======
+/* 205 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports) {
 
 ;(function() {
@@ -35749,7 +36353,11 @@ componentHandler.register({
 
 
 /***/ }),
+<<<<<<< HEAD
 /* 204 */
+=======
+/* 206 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports) {
 
 /*
@@ -36864,17 +37472,27 @@ componentHandler.register({
 /******/]);
 
 /***/ }),
+<<<<<<< HEAD
 /* 205 */
+=======
+/* 207 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 /* WEBPACK VAR INJECTION */(function(global) {
 
+<<<<<<< HEAD
 __webpack_require__(206);
 
 __webpack_require__(403);
+=======
+__webpack_require__(208);
+>>>>>>> Ensure chips have a name before submitting values
 
 __webpack_require__(404);
+
+__webpack_require__(406);
 
 if (global._babelPolyfill) {
   throw new Error("only one instance of babel-polyfill is allowed");
@@ -36899,12 +37517,19 @@ define(String.prototype, "padRight", "".padEnd);
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(67)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 206 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(207);
 __webpack_require__(210);
 __webpack_require__(211);
+=======
+/* 208 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(209);
+>>>>>>> Ensure chips have a name before submitting values
 __webpack_require__(212);
 __webpack_require__(213);
 __webpack_require__(214);
@@ -36979,17 +37604,29 @@ __webpack_require__(282);
 __webpack_require__(283);
 __webpack_require__(284);
 __webpack_require__(285);
+<<<<<<< HEAD
 __webpack_require__(287);
 __webpack_require__(288);
 __webpack_require__(290);
 __webpack_require__(291);
+=======
+__webpack_require__(286);
+__webpack_require__(287);
+__webpack_require__(289);
+__webpack_require__(290);
+>>>>>>> Ensure chips have a name before submitting values
 __webpack_require__(292);
 __webpack_require__(293);
 __webpack_require__(294);
 __webpack_require__(295);
 __webpack_require__(296);
+<<<<<<< HEAD
 __webpack_require__(298);
 __webpack_require__(299);
+=======
+__webpack_require__(297);
+__webpack_require__(298);
+>>>>>>> Ensure chips have a name before submitting values
 __webpack_require__(300);
 __webpack_require__(301);
 __webpack_require__(302);
@@ -37001,21 +37638,38 @@ __webpack_require__(307);
 __webpack_require__(308);
 __webpack_require__(309);
 __webpack_require__(310);
+<<<<<<< HEAD
 __webpack_require__(108);
 __webpack_require__(311);
 __webpack_require__(145);
 __webpack_require__(312);
 __webpack_require__(146);
 __webpack_require__(313);
+=======
+__webpack_require__(311);
+__webpack_require__(312);
+__webpack_require__(108);
+__webpack_require__(313);
+__webpack_require__(145);
+>>>>>>> Ensure chips have a name before submitting values
 __webpack_require__(314);
+__webpack_require__(146);
 __webpack_require__(315);
 __webpack_require__(316);
 __webpack_require__(317);
+<<<<<<< HEAD
 __webpack_require__(149);
 __webpack_require__(151);
 __webpack_require__(152);
 __webpack_require__(318);
 __webpack_require__(319);
+=======
+__webpack_require__(318);
+__webpack_require__(319);
+__webpack_require__(149);
+__webpack_require__(151);
+__webpack_require__(152);
+>>>>>>> Ensure chips have a name before submitting values
 __webpack_require__(320);
 __webpack_require__(321);
 __webpack_require__(322);
@@ -37099,10 +37753,19 @@ __webpack_require__(399);
 __webpack_require__(400);
 __webpack_require__(401);
 __webpack_require__(402);
+<<<<<<< HEAD
 module.exports = __webpack_require__(21);
 
 /***/ }),
 /* 207 */
+=======
+__webpack_require__(403);
+__webpack_require__(404);
+module.exports = __webpack_require__(21);
+
+/***/ }),
+/* 209 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -37124,8 +37787,13 @@ var uid = __webpack_require__(37);
 var wks = __webpack_require__(6);
 var wksExt = __webpack_require__(127);
 var wksDefine = __webpack_require__(89);
+<<<<<<< HEAD
 var enumKeys = __webpack_require__(209);
 var isArray = __webpack_require__(70);
+=======
+var enumKeys = __webpack_require__(211);
+var isArray = __webpack_require__(69);
+>>>>>>> Ensure chips have a name before submitting values
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
 var toObject = __webpack_require__(10);
@@ -37366,13 +38034,21 @@ setToStringTag(Math, 'Math', true);
 setToStringTag(global.JSON, 'JSON', true);
 
 /***/ }),
+<<<<<<< HEAD
 /* 208 */
+=======
+/* 210 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(53)('native-function-to-string', Function.toString);
 
 /***/ }),
+<<<<<<< HEAD
 /* 209 */
+=======
+/* 211 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // all enumerable object keys, includes symbols
@@ -37394,7 +38070,11 @@ module.exports = function (it) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 210 */
+=======
+/* 212 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -37402,7 +38082,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Object', { create: __webpack_require__(40) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 211 */
+=======
+/* 213 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -37410,7 +38094,11 @@ var $export = __webpack_require__(0);
 $export($export.S + $export.F * !__webpack_require__(8), 'Object', { defineProperty: __webpack_require__(9).f });
 
 /***/ }),
+<<<<<<< HEAD
 /* 212 */
+=======
+/* 214 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -37418,7 +38106,11 @@ var $export = __webpack_require__(0);
 $export($export.S + $export.F * !__webpack_require__(8), 'Object', { defineProperties: __webpack_require__(129) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 213 */
+=======
+/* 215 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.6 Object.getOwnPropertyDescriptor(O, P)
@@ -37432,7 +38124,11 @@ __webpack_require__(29)('getOwnPropertyDescriptor', function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 214 */
+=======
+/* 216 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.9 Object.getPrototypeOf(O)
@@ -37446,7 +38142,11 @@ __webpack_require__(29)('getPrototypeOf', function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 215 */
+=======
+/* 217 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.14 Object.keys(O)
@@ -37460,7 +38160,11 @@ __webpack_require__(29)('keys', function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 216 */
+=======
+/* 218 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.7 Object.getOwnPropertyNames(O)
@@ -37469,7 +38173,11 @@ __webpack_require__(29)('getOwnPropertyNames', function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 217 */
+=======
+/* 219 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.5 Object.freeze(O)
@@ -37483,7 +38191,11 @@ __webpack_require__(29)('freeze', function ($freeze) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 218 */
+=======
+/* 220 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.17 Object.seal(O)
@@ -37497,7 +38209,11 @@ __webpack_require__(29)('seal', function ($seal) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 219 */
+=======
+/* 221 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.15 Object.preventExtensions(O)
@@ -37511,7 +38227,11 @@ __webpack_require__(29)('preventExtensions', function ($preventExtensions) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 220 */
+=======
+/* 222 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.12 Object.isFrozen(O)
@@ -37524,7 +38244,11 @@ __webpack_require__(29)('isFrozen', function ($isFrozen) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 221 */
+=======
+/* 223 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.13 Object.isSealed(O)
@@ -37537,7 +38261,11 @@ __webpack_require__(29)('isSealed', function ($isSealed) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 222 */
+=======
+/* 224 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.11 Object.isExtensible(O)
@@ -37550,7 +38278,11 @@ __webpack_require__(29)('isExtensible', function ($isExtensible) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 223 */
+=======
+/* 225 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.1 Object.assign(target, source)
@@ -37559,7 +38291,11 @@ var $export = __webpack_require__(0);
 $export($export.S + $export.F, 'Object', { assign: __webpack_require__(131) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 224 */
+=======
+/* 226 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.10 Object.is(value1, value2)
@@ -37567,7 +38303,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Object', { is: __webpack_require__(132) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 225 */
+=======
+/* 227 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.19 Object.setPrototypeOf(O, proto)
@@ -37575,7 +38315,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Object', { setPrototypeOf: __webpack_require__(93).set });
 
 /***/ }),
+<<<<<<< HEAD
 /* 226 */
+=======
+/* 228 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -37592,7 +38336,11 @@ if (test + '' != '[object z]') {
 }
 
 /***/ }),
+<<<<<<< HEAD
 /* 227 */
+=======
+/* 229 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.2.3.2 / 15.3.4.5 Function.prototype.bind(thisArg, args...)
@@ -37601,7 +38349,11 @@ var $export = __webpack_require__(0);
 $export($export.P, 'Function', { bind: __webpack_require__(133) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 228 */
+=======
+/* 230 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var dP = __webpack_require__(9).f;
@@ -37622,7 +38374,11 @@ NAME in FProto || __webpack_require__(8) && dP(FProto, NAME, {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 229 */
+=======
+/* 231 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -37643,7 +38399,11 @@ if (!(HAS_INSTANCE in FunctionProto)) __webpack_require__(9).f(FunctionProto, HA
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 230 */
+=======
+/* 232 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -37652,7 +38412,11 @@ var $parseInt = __webpack_require__(135);
 $export($export.G + $export.F * (parseInt != $parseInt), { parseInt: $parseInt });
 
 /***/ }),
+<<<<<<< HEAD
 /* 231 */
+=======
+/* 233 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -37661,7 +38425,11 @@ var $parseFloat = __webpack_require__(136);
 $export($export.G + $export.F * (parseFloat != $parseFloat), { parseFloat: $parseFloat });
 
 /***/ }),
+<<<<<<< HEAD
 /* 232 */
+=======
+/* 234 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -37739,7 +38507,11 @@ if (!$Number(' 0o1') || !$Number('0b1') || $Number('+0x1')) {
 }
 
 /***/ }),
+<<<<<<< HEAD
 /* 233 */
+=======
+/* 235 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -37855,7 +38627,11 @@ $export($export.P + $export.F * (!!$toFixed && (0.00008.toFixed(3) !== '0.000' |
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 234 */
+=======
+/* 236 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -37880,7 +38656,11 @@ $export($export.P + $export.F * ($fails(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 235 */
+=======
+/* 237 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.1 Number.EPSILON
@@ -37889,7 +38669,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { EPSILON: Math.pow(2, -52) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 236 */
+=======
+/* 238 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.2 Number.isFinite(number)
@@ -37903,7 +38687,11 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 237 */
+=======
+/* 239 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.3 Number.isInteger(number)
@@ -37912,7 +38700,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { isInteger: __webpack_require__(138) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 238 */
+=======
+/* 240 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.4 Number.isNaN(number)
@@ -37926,7 +38718,11 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 239 */
+=======
+/* 241 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.5 Number.isSafeInteger(number)
@@ -37941,7 +38737,11 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 240 */
+=======
+/* 242 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.6 Number.MAX_SAFE_INTEGER
@@ -37950,7 +38750,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { MAX_SAFE_INTEGER: 0x1fffffffffffff });
 
 /***/ }),
+<<<<<<< HEAD
 /* 241 */
+=======
+/* 243 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.10 Number.MIN_SAFE_INTEGER
@@ -37959,7 +38763,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { MIN_SAFE_INTEGER: -0x1fffffffffffff });
 
 /***/ }),
+<<<<<<< HEAD
 /* 242 */
+=======
+/* 244 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -37968,7 +38776,11 @@ var $parseFloat = __webpack_require__(136);
 $export($export.S + $export.F * (Number.parseFloat != $parseFloat), 'Number', { parseFloat: $parseFloat });
 
 /***/ }),
+<<<<<<< HEAD
 /* 243 */
+=======
+/* 245 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -37977,7 +38789,11 @@ var $parseInt = __webpack_require__(135);
 $export($export.S + $export.F * (Number.parseInt != $parseInt), 'Number', { parseInt: $parseInt });
 
 /***/ }),
+<<<<<<< HEAD
 /* 244 */
+=======
+/* 246 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.3 Math.acosh(x)
@@ -37997,7 +38813,11 @@ $export($export.S + $export.F * !($acosh
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 245 */
+=======
+/* 247 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.5 Math.asinh(x)
@@ -38012,7 +38832,11 @@ function asinh(x) {
 $export($export.S + $export.F * !($asinh && 1 / $asinh(0) > 0), 'Math', { asinh: asinh });
 
 /***/ }),
+<<<<<<< HEAD
 /* 246 */
+=======
+/* 248 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.7 Math.atanh(x)
@@ -38027,7 +38851,11 @@ $export($export.S + $export.F * !($atanh && 1 / $atanh(-0) < 0), 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 247 */
+=======
+/* 249 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.9 Math.cbrt(x)
@@ -38041,7 +38869,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 248 */
+=======
+/* 250 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.11 Math.clz32(x)
@@ -38054,7 +38886,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 249 */
+=======
+/* 251 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.12 Math.cosh(x)
@@ -38068,7 +38904,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 250 */
+=======
+/* 252 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.14 Math.expm1(x)
@@ -38078,7 +38918,11 @@ var $expm1 = __webpack_require__(98);
 $export($export.S + $export.F * ($expm1 != Math.expm1), 'Math', { expm1: $expm1 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 251 */
+=======
+/* 253 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.16 Math.fround(x)
@@ -38087,7 +38931,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { fround: __webpack_require__(140) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 252 */
+=======
+/* 254 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.17 Math.hypot([value1[, value2[, … ]]])
@@ -38118,7 +38966,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 253 */
+=======
+/* 255 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.18 Math.imul(x, y)
@@ -38140,7 +38992,11 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 254 */
+=======
+/* 256 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.21 Math.log10(x)
@@ -38153,7 +39009,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 255 */
+=======
+/* 257 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.20 Math.log1p(x)
@@ -38162,7 +39022,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { log1p: __webpack_require__(139) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 256 */
+=======
+/* 258 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.22 Math.log2(x)
@@ -38175,7 +39039,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 257 */
+=======
+/* 259 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.28 Math.sign(x)
@@ -38184,7 +39052,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { sign: __webpack_require__(97) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 258 */
+=======
+/* 260 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.30 Math.sinh(x)
@@ -38202,7 +39074,11 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 259 */
+=======
+/* 261 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.33 Math.tanh(x)
@@ -38219,7 +39095,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 260 */
+=======
+/* 262 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.34 Math.trunc(x)
@@ -38232,7 +39112,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 261 */
+=======
+/* 263 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38258,7 +39142,11 @@ $export($export.S + $export.F * (!!$fromCodePoint && $fromCodePoint.length != 1)
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 262 */
+=======
+/* 264 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38281,7 +39169,11 @@ $export($export.S, 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 263 */
+=======
+/* 265 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38295,7 +39187,11 @@ __webpack_require__(51)('trim', function ($trim) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 264 */
+=======
+/* 266 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38319,7 +39215,11 @@ __webpack_require__(99)(String, 'String', function (iterated) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 265 */
+=======
+/* 267 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38335,7 +39235,11 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 266 */
+=======
+/* 268 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38360,7 +39264,11 @@ $export($export.P + $export.F * __webpack_require__(102)(ENDS_WITH), 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 267 */
+=======
+/* 269 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38378,7 +39286,11 @@ $export($export.P + $export.F * __webpack_require__(102)(INCLUDES), 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 268 */
+=======
+/* 270 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38389,7 +39301,11 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 269 */
+=======
+/* 271 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38412,7 +39328,11 @@ $export($export.P + $export.F * __webpack_require__(102)(STARTS_WITH), 'String',
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 270 */
+=======
+/* 272 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38426,7 +39346,11 @@ __webpack_require__(16)('anchor', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 271 */
+=======
+/* 273 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38440,7 +39364,11 @@ __webpack_require__(16)('big', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 272 */
+=======
+/* 274 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38454,7 +39382,11 @@ __webpack_require__(16)('blink', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 273 */
+=======
+/* 275 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38468,7 +39400,11 @@ __webpack_require__(16)('bold', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 274 */
+=======
+/* 276 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38482,7 +39418,11 @@ __webpack_require__(16)('fixed', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 275 */
+=======
+/* 277 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38496,7 +39436,11 @@ __webpack_require__(16)('fontcolor', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 276 */
+=======
+/* 278 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38510,7 +39454,11 @@ __webpack_require__(16)('fontsize', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 277 */
+=======
+/* 279 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38524,7 +39472,11 @@ __webpack_require__(16)('italics', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 278 */
+=======
+/* 280 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38538,7 +39490,11 @@ __webpack_require__(16)('link', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 279 */
+=======
+/* 281 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38552,7 +39508,11 @@ __webpack_require__(16)('small', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 280 */
+=======
+/* 282 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38566,7 +39526,11 @@ __webpack_require__(16)('strike', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 281 */
+=======
+/* 283 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38580,7 +39544,11 @@ __webpack_require__(16)('sub', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 282 */
+=======
+/* 284 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38594,7 +39562,11 @@ __webpack_require__(16)('sup', function (createHTML) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 283 */
+=======
+/* 285 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.3.3.1 / 15.9.4.4 Date.now()
@@ -38605,7 +39577,11 @@ $export($export.S, 'Date', { now: function now() {
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 284 */
+=======
+/* 286 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38629,12 +39605,20 @@ $export($export.P + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 285 */
+=======
+/* 287 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.3.4.36 / 15.9.5.43 Date.prototype.toISOString()
 var $export = __webpack_require__(0);
+<<<<<<< HEAD
 var toISOString = __webpack_require__(286);
+=======
+var toISOString = __webpack_require__(288);
+>>>>>>> Ensure chips have a name before submitting values
 
 // PhantomJS / old WebKit has a broken implementations
 $export($export.P + $export.F * (Date.prototype.toISOString !== toISOString), 'Date', {
@@ -38642,7 +39626,11 @@ $export($export.P + $export.F * (Date.prototype.toISOString !== toISOString), 'D
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 286 */
+=======
+/* 288 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38672,7 +39660,11 @@ module.exports = fails(function () {
 } : $toISOString;
 
 /***/ }),
+<<<<<<< HEAD
 /* 287 */
+=======
+/* 289 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var DateProto = Date.prototype;
@@ -38689,16 +39681,27 @@ if (new Date(NaN) + '' != INVALID_DATE) {
 }
 
 /***/ }),
+<<<<<<< HEAD
 /* 288 */
+=======
+/* 290 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var TO_PRIMITIVE = __webpack_require__(6)('toPrimitive');
 var proto = Date.prototype;
 
+<<<<<<< HEAD
 if (!(TO_PRIMITIVE in proto)) __webpack_require__(14)(proto, TO_PRIMITIVE, __webpack_require__(289));
 
 /***/ }),
 /* 289 */
+=======
+if (!(TO_PRIMITIVE in proto)) __webpack_require__(14)(proto, TO_PRIMITIVE, __webpack_require__(291));
+
+/***/ }),
+/* 291 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38714,7 +39717,11 @@ module.exports = function (hint) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 290 */
+=======
+/* 292 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.2.2 / 15.4.3.2 Array.isArray(arg)
@@ -38723,7 +39730,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Array', { isArray: __webpack_require__(70) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 291 */
+=======
+/* 293 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38769,7 +39780,11 @@ $export($export.S + $export.F * !__webpack_require__(73)(function (iter) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 292 */
+=======
+/* 294 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38796,7 +39811,11 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 293 */
+=======
+/* 295 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38815,7 +39834,11 @@ $export($export.P + $export.F * (__webpack_require__(54) != Object || !__webpack
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 294 */
+=======
+/* 296 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38849,7 +39872,11 @@ $export($export.P + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 295 */
+=======
+/* 297 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38877,7 +39904,11 @@ $export($export.P + $export.F * (fails(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 296 */
+=======
+/* 298 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38895,7 +39926,11 @@ $export($export.P + $export.F * !STRICT, 'Array', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 297 */
+=======
+/* 299 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(5);
@@ -38916,7 +39951,11 @@ module.exports = function (original) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 298 */
+=======
+/* 300 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38933,7 +39972,11 @@ $export($export.P + $export.F * !__webpack_require__(25)([].map, true), 'Array',
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 299 */
+=======
+/* 301 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38950,7 +39993,11 @@ $export($export.P + $export.F * !__webpack_require__(25)([].filter, true), 'Arra
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 300 */
+=======
+/* 302 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38967,7 +40014,11 @@ $export($export.P + $export.F * !__webpack_require__(25)([].some, true), 'Array'
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 301 */
+=======
+/* 303 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38984,7 +40035,11 @@ $export($export.P + $export.F * !__webpack_require__(25)([].every, true), 'Array
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 302 */
+=======
+/* 304 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39001,7 +40056,11 @@ $export($export.P + $export.F * !__webpack_require__(25)([].reduce, true), 'Arra
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 303 */
+=======
+/* 305 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39018,7 +40077,11 @@ $export($export.P + $export.F * !__webpack_require__(25)([].reduceRight, true), 
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 304 */
+=======
+/* 306 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39039,7 +40102,11 @@ $export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(25)($nati
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 305 */
+=======
+/* 307 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39069,7 +40136,11 @@ $export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(25)($nati
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 306 */
+=======
+/* 308 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.3.3 Array.prototype.copyWithin(target, start, end = this.length)
@@ -39080,7 +40151,11 @@ $export($export.P, 'Array', { copyWithin: __webpack_require__(143) });
 __webpack_require__(35)('copyWithin');
 
 /***/ }),
+<<<<<<< HEAD
 /* 307 */
+=======
+/* 309 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.3.6 Array.prototype.fill(value, start = 0, end = this.length)
@@ -39091,7 +40166,11 @@ $export($export.P, 'Array', { fill: __webpack_require__(107) });
 __webpack_require__(35)('fill');
 
 /***/ }),
+<<<<<<< HEAD
 /* 308 */
+=======
+/* 310 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39114,7 +40193,11 @@ $export($export.P + $export.F * forced, 'Array', {
 __webpack_require__(35)(KEY);
 
 /***/ }),
+<<<<<<< HEAD
 /* 309 */
+=======
+/* 311 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39137,13 +40220,21 @@ $export($export.P + $export.F * forced, 'Array', {
 __webpack_require__(35)(KEY);
 
 /***/ }),
+<<<<<<< HEAD
 /* 310 */
+=======
+/* 312 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(42)('Array');
 
 /***/ }),
+<<<<<<< HEAD
 /* 311 */
+=======
+/* 313 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
@@ -39192,7 +40283,11 @@ if (__webpack_require__(8) && (!CORRECT_NEW || __webpack_require__(4)(function (
 __webpack_require__(42)('RegExp');
 
 /***/ }),
+<<<<<<< HEAD
 /* 312 */
+=======
+/* 314 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39225,7 +40320,11 @@ if (__webpack_require__(4)(function () {
 }
 
 /***/ }),
+<<<<<<< HEAD
 /* 313 */
+=======
+/* 315 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39270,7 +40369,11 @@ __webpack_require__(75)('match', 1, function (defined, MATCH, $match, maybeCallN
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 314 */
+=======
+/* 316 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39397,7 +40500,11 @@ __webpack_require__(75)('replace', 2, function (defined, REPLACE, $replace, mayb
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 315 */
+=======
+/* 317 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39433,7 +40540,11 @@ __webpack_require__(75)('search', 1, function (defined, SEARCH, $search, maybeCa
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 316 */
+=======
+/* 318 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39556,7 +40667,11 @@ __webpack_require__(75)('split', 2, function (defined, SPLIT, $split, maybeCallN
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 317 */
+=======
+/* 319 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39846,7 +40961,11 @@ $export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(73)(function
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 318 */
+=======
+/* 320 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39869,7 +40988,11 @@ __webpack_require__(77)(WEAK_SET, function (get) {
 }, weak, false, true);
 
 /***/ }),
+<<<<<<< HEAD
 /* 319 */
+=======
+/* 321 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39922,7 +41045,11 @@ $export($export.P + $export.U + $export.F * __webpack_require__(4)(function () {
 __webpack_require__(42)(ARRAY_BUFFER);
 
 /***/ }),
+<<<<<<< HEAD
 /* 320 */
+=======
+/* 322 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -39931,7 +41058,11 @@ $export($export.G + $export.W + $export.F * !__webpack_require__(78).ABV, {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 321 */
+=======
+/* 323 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Int8', 1, function (init) {
@@ -39941,7 +41072,11 @@ __webpack_require__(31)('Int8', 1, function (init) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 322 */
+=======
+/* 324 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Uint8', 1, function (init) {
@@ -39951,7 +41086,11 @@ __webpack_require__(31)('Uint8', 1, function (init) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 323 */
+=======
+/* 325 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Uint8', 1, function (init) {
@@ -39961,7 +41100,11 @@ __webpack_require__(31)('Uint8', 1, function (init) {
 }, true);
 
 /***/ }),
+<<<<<<< HEAD
 /* 324 */
+=======
+/* 326 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Int16', 2, function (init) {
@@ -39971,7 +41114,11 @@ __webpack_require__(31)('Int16', 2, function (init) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 325 */
+=======
+/* 327 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Uint16', 2, function (init) {
@@ -39981,7 +41128,11 @@ __webpack_require__(31)('Uint16', 2, function (init) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 326 */
+=======
+/* 328 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Int32', 4, function (init) {
@@ -39991,7 +41142,11 @@ __webpack_require__(31)('Int32', 4, function (init) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 327 */
+=======
+/* 329 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Uint32', 4, function (init) {
@@ -40001,7 +41156,11 @@ __webpack_require__(31)('Uint32', 4, function (init) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 328 */
+=======
+/* 330 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Float32', 4, function (init) {
@@ -40011,7 +41170,11 @@ __webpack_require__(31)('Float32', 4, function (init) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 329 */
+=======
+/* 331 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Float64', 8, function (init) {
@@ -40021,7 +41184,11 @@ __webpack_require__(31)('Float64', 8, function (init) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 330 */
+=======
+/* 332 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.1 Reflect.apply(target, thisArgument, argumentsList)
@@ -40042,7 +41209,11 @@ $export($export.S + $export.F * !__webpack_require__(4)(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 331 */
+=======
+/* 333 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.2 Reflect.construct(target, argumentsList [, newTarget])
@@ -40099,7 +41270,11 @@ $export($export.S + $export.F * (NEW_TARGET_BUG || ARGS_BUG), 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 332 */
+=======
+/* 334 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.3 Reflect.defineProperty(target, propertyKey, attributes)
@@ -40127,7 +41302,11 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 333 */
+=======
+/* 335 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.4 Reflect.deleteProperty(target, propertyKey)
@@ -40143,7 +41322,11 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 334 */
+=======
+/* 336 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40178,7 +41361,11 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 335 */
+=======
+/* 337 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.6 Reflect.get(target, propertyKey [, receiver])
@@ -40200,7 +41387,11 @@ function get(target, propertyKey /* , receiver */) {
 $export($export.S, 'Reflect', { get: get });
 
 /***/ }),
+<<<<<<< HEAD
 /* 336 */
+=======
+/* 338 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.7 Reflect.getOwnPropertyDescriptor(target, propertyKey)
@@ -40215,7 +41406,11 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 337 */
+=======
+/* 339 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.8 Reflect.getPrototypeOf(target)
@@ -40230,7 +41425,11 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 338 */
+=======
+/* 340 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.9 Reflect.has(target, propertyKey)
@@ -40243,7 +41442,11 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 339 */
+=======
+/* 341 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.10 Reflect.isExtensible(target)
@@ -40259,7 +41462,11 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 340 */
+=======
+/* 342 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.11 Reflect.ownKeys(target)
@@ -40268,7 +41475,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Reflect', { ownKeys: __webpack_require__(155) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 341 */
+=======
+/* 343 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.12 Reflect.preventExtensions(target)
@@ -40289,7 +41500,11 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 342 */
+=======
+/* 344 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.13 Reflect.set(target, propertyKey, V [, receiver])
@@ -40327,7 +41542,11 @@ function set(target, propertyKey, V /* , receiver */) {
 $export($export.S, 'Reflect', { set: set });
 
 /***/ }),
+<<<<<<< HEAD
 /* 343 */
+=======
+/* 345 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.14 Reflect.setPrototypeOf(target, proto)
@@ -40347,7 +41566,11 @@ if (setProto) $export($export.S, 'Reflect', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 344 */
+=======
+/* 346 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40366,7 +41589,11 @@ $export($export.P, 'Array', {
 __webpack_require__(35)('includes');
 
 /***/ }),
+<<<<<<< HEAD
 /* 345 */
+=======
+/* 347 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40395,7 +41622,11 @@ $export($export.P, 'Array', {
 __webpack_require__(35)('flatMap');
 
 /***/ }),
+<<<<<<< HEAD
 /* 346 */
+=======
+/* 348 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40423,7 +41654,11 @@ $export($export.P, 'Array', {
 __webpack_require__(35)('flatten');
 
 /***/ }),
+<<<<<<< HEAD
 /* 347 */
+=======
+/* 349 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40440,7 +41675,11 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 348 */
+=======
+/* 350 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40461,7 +41700,11 @@ $export($export.P + $export.F * WEBKIT_BUG, 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 349 */
+=======
+/* 351 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40482,7 +41725,11 @@ $export($export.P + $export.F * WEBKIT_BUG, 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 350 */
+=======
+/* 352 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40496,7 +41743,11 @@ __webpack_require__(51)('trimLeft', function ($trim) {
 }, 'trimStart');
 
 /***/ }),
+<<<<<<< HEAD
 /* 351 */
+=======
+/* 353 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40510,7 +41761,11 @@ __webpack_require__(51)('trimRight', function ($trim) {
 }, 'trimEnd');
 
 /***/ }),
+<<<<<<< HEAD
 /* 352 */
+=======
+/* 354 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40547,19 +41802,31 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 353 */
+=======
+/* 355 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(89)('asyncIterator');
 
 /***/ }),
+<<<<<<< HEAD
 /* 354 */
+=======
+/* 356 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(89)('observable');
 
 /***/ }),
+<<<<<<< HEAD
 /* 355 */
+=======
+/* 357 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-getownpropertydescriptors
@@ -40586,7 +41853,11 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 356 */
+=======
+/* 358 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-values-entries
@@ -40600,7 +41871,11 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 357 */
+=======
+/* 359 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-values-entries
@@ -40614,7 +41889,11 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 358 */
+=======
+/* 360 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40633,7 +41912,11 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(79), 'Object',
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 359 */
+=======
+/* 361 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40652,7 +41935,11 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(79), 'Object',
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 360 */
+=======
+/* 362 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40677,7 +41964,11 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(79), 'Object',
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 361 */
+=======
+/* 363 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40702,7 +41993,11 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(79), 'Object',
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 362 */
+=======
+/* 364 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
@@ -40711,7 +42006,11 @@ var $export = __webpack_require__(0);
 $export($export.P + $export.R, 'Map', { toJSON: __webpack_require__(159)('Map') });
 
 /***/ }),
+<<<<<<< HEAD
 /* 363 */
+=======
+/* 365 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
@@ -40720,63 +42019,99 @@ var $export = __webpack_require__(0);
 $export($export.P + $export.R, 'Set', { toJSON: __webpack_require__(159)('Set') });
 
 /***/ }),
+<<<<<<< HEAD
 /* 364 */
+=======
+/* 366 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-map.of
 __webpack_require__(80)('Map');
 
 /***/ }),
+<<<<<<< HEAD
 /* 365 */
+=======
+/* 367 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-set.of
 __webpack_require__(80)('Set');
 
 /***/ }),
+<<<<<<< HEAD
 /* 366 */
+=======
+/* 368 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.of
 __webpack_require__(80)('WeakMap');
 
 /***/ }),
+<<<<<<< HEAD
 /* 367 */
+=======
+/* 369 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.of
 __webpack_require__(80)('WeakSet');
 
 /***/ }),
+<<<<<<< HEAD
 /* 368 */
+=======
+/* 370 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-map.from
 __webpack_require__(81)('Map');
 
 /***/ }),
+<<<<<<< HEAD
 /* 369 */
+=======
+/* 371 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-set.from
 __webpack_require__(81)('Set');
 
 /***/ }),
+<<<<<<< HEAD
 /* 370 */
+=======
+/* 372 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.from
 __webpack_require__(81)('WeakMap');
 
 /***/ }),
+<<<<<<< HEAD
 /* 371 */
+=======
+/* 373 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.from
 __webpack_require__(81)('WeakSet');
 
 /***/ }),
+<<<<<<< HEAD
 /* 372 */
+=======
+/* 374 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-global
@@ -40785,7 +42120,11 @@ var $export = __webpack_require__(0);
 $export($export.G, { global: __webpack_require__(3) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 373 */
+=======
+/* 375 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-global
@@ -40794,7 +42133,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'System', { global: __webpack_require__(3) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 374 */
+=======
+/* 376 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/ljharb/proposal-is-error
@@ -40808,7 +42151,11 @@ $export($export.S, 'Error', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 375 */
+=======
+/* 377 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -40821,7 +42168,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 376 */
+=======
+/* 378 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -40830,7 +42181,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { DEG_PER_RAD: Math.PI / 180 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 377 */
+=======
+/* 379 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -40844,7 +42199,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 378 */
+=======
+/* 380 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -40859,7 +42218,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 379 */
+=======
+/* 381 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -40875,7 +42238,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 380 */
+=======
+/* 382 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -40891,7 +42258,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 381 */
+=======
+/* 383 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -40912,7 +42283,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 382 */
+=======
+/* 384 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -40921,7 +42296,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { RAD_PER_DEG: 180 / Math.PI });
 
 /***/ }),
+<<<<<<< HEAD
 /* 383 */
+=======
+/* 385 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -40935,7 +42314,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 384 */
+=======
+/* 386 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -40944,7 +42327,11 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { scale: __webpack_require__(161) });
 
 /***/ }),
+<<<<<<< HEAD
 /* 385 */
+=======
+/* 387 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -40965,7 +42352,11 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 386 */
+=======
+/* 388 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // http://jfbastien.github.io/papers/Math.signbit.html
@@ -40977,7 +42368,11 @@ $export($export.S, 'Math', { signbit: function signbit(x) {
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 387 */
+=======
+/* 389 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41005,7 +42400,11 @@ $export($export.P + $export.R, 'Promise', { 'finally': function _finally(onFinal
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 388 */
+=======
+/* 390 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41024,7 +42423,11 @@ $export($export.S, 'Promise', { 'try': function _try(callbackfn) {
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 389 */
+=======
+/* 391 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -41037,7 +42440,11 @@ metadata.exp({ defineMetadata: function defineMetadata(metadataKey, metadataValu
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 390 */
+=======
+/* 392 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -41057,7 +42464,11 @@ metadata.exp({ deleteMetadata: function deleteMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 391 */
+=======
+/* 393 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -41079,7 +42490,11 @@ metadata.exp({ getMetadata: function getMetadata(metadataKey, target /* , target
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 392 */
+=======
+/* 394 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var Set = __webpack_require__(151);
@@ -41103,7 +42518,11 @@ metadata.exp({ getMetadataKeys: function getMetadataKeys(target /* , targetKey *
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 393 */
+=======
+/* 395 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -41116,7 +42535,11 @@ metadata.exp({ getOwnMetadata: function getOwnMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 394 */
+=======
+/* 396 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -41129,7 +42552,11 @@ metadata.exp({ getOwnMetadataKeys: function getOwnMetadataKeys(target /* , targe
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 395 */
+=======
+/* 397 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -41150,7 +42577,11 @@ metadata.exp({ hasMetadata: function hasMetadata(metadataKey, target /* , target
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 396 */
+=======
+/* 398 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -41163,7 +42594,11 @@ metadata.exp({ hasOwnMetadata: function hasOwnMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 397 */
+=======
+/* 399 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $metadata = __webpack_require__(32);
@@ -41179,7 +42614,11 @@ $metadata.exp({ metadata: function metadata(metadataKey, metadataValue) {
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 398 */
+=======
+/* 400 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-09/sept-25.md#510-globalasap-for-enqueuing-a-microtask
@@ -41196,7 +42635,11 @@ $export($export.G, {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 399 */
+=======
+/* 401 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41412,7 +42855,11 @@ $export($export.G, { Observable: $Observable });
 __webpack_require__(42)('Observable');
 
 /***/ }),
+<<<<<<< HEAD
 /* 400 */
+=======
+/* 402 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // ie9- setTimeout & setInterval additional parameters fix
@@ -41437,7 +42884,11 @@ $export($export.G + $export.B + $export.F * MSIE, {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 401 */
+=======
+/* 403 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -41448,7 +42899,11 @@ $export($export.G + $export.B, {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 402 */
+=======
+/* 404 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var $iterators = __webpack_require__(108);
@@ -41513,7 +42968,11 @@ for (var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++
 }
 
 /***/ }),
+<<<<<<< HEAD
 /* 403 */
+=======
+/* 405 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global, module) {var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -42223,6 +43682,7 @@ for (var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(67), __webpack_require__(12)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 404 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -42231,18 +43691,36 @@ module.exports = __webpack_require__(21).RegExp.escape;
 
 /***/ }),
 /* 405 */
+=======
+/* 406 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(407);
+module.exports = __webpack_require__(21).RegExp.escape;
+
+/***/ }),
+/* 407 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/benjamingr/RexExp.escape
 var $export = __webpack_require__(0);
+<<<<<<< HEAD
 var $re = __webpack_require__(406)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+=======
+var $re = __webpack_require__(408)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+>>>>>>> Ensure chips have a name before submitting values
 
 $export($export.S, 'RegExp', { escape: function escape(it) {
     return $re(it);
   } });
 
 /***/ }),
+<<<<<<< HEAD
 /* 406 */
+=======
+/* 408 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports) {
 
 module.exports = function (regExp, replace) {
@@ -42255,13 +43733,21 @@ module.exports = function (regExp, replace) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 407 */
+=======
+/* 409 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initButtons;
 /* unused harmony export VButton */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(408);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(410);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_ripple__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
@@ -42360,7 +43846,11 @@ var VButton = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
+<<<<<<< HEAD
 /* 408 */
+=======
+/* 410 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -44312,17 +45802,29 @@ var VButton = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 409 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(410);
 __webpack_require__(426);
+=======
+/* 411 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(412);
+__webpack_require__(428);
+>>>>>>> Ensure chips have a name before submitting values
 var entryUnbind = __webpack_require__(185);
 
 module.exports = entryUnbind('Array', 'flat');
 
 /***/ }),
+<<<<<<< HEAD
 /* 410 */
+=======
+/* 412 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -44349,7 +45851,11 @@ $({ target: 'Array', proto: true }, {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 411 */
+=======
+/* 413 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -44369,7 +45875,11 @@ exports.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
 } : nativePropertyIsEnumerable;
 
 /***/ }),
+<<<<<<< HEAD
 /* 412 */
+=======
+/* 414 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(59);
@@ -44387,7 +45897,11 @@ module.exports = fails(function () {
 } : Object;
 
 /***/ }),
+<<<<<<< HEAD
 /* 413 */
+=======
+/* 415 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
@@ -44396,7 +45910,11 @@ var hide = __webpack_require__(62);
 var has = __webpack_require__(61);
 var setGlobal = __webpack_require__(118);
 var nativeFunctionToString = __webpack_require__(172);
+<<<<<<< HEAD
 var InternalStateModule = __webpack_require__(415);
+=======
+var InternalStateModule = __webpack_require__(417);
+>>>>>>> Ensure chips have a name before submitting values
 
 var getInternalState = InternalStateModule.get;
 var enforceInternalState = InternalStateModule.enforce;
@@ -44429,16 +45947,27 @@ shared('inspectSource', function (it) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 414 */
+=======
+/* 416 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports) {
 
 module.exports = false;
 
 /***/ }),
+<<<<<<< HEAD
 /* 415 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var NATIVE_WEAK_MAP = __webpack_require__(416);
+=======
+/* 417 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var NATIVE_WEAK_MAP = __webpack_require__(418);
+>>>>>>> Ensure chips have a name before submitting values
 var global = __webpack_require__(26);
 var isObject = __webpack_require__(60);
 var hide = __webpack_require__(62);
@@ -44501,7 +46030,11 @@ module.exports = {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 416 */
+=======
+/* 418 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
@@ -44512,11 +46045,19 @@ var WeakMap = global.WeakMap;
 module.exports = typeof WeakMap === 'function' && /native code/.test(nativeFunctionToString.call(WeakMap));
 
 /***/ }),
+<<<<<<< HEAD
 /* 417 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var has = __webpack_require__(61);
 var ownKeys = __webpack_require__(418);
+=======
+/* 419 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var has = __webpack_require__(61);
+var ownKeys = __webpack_require__(420);
+>>>>>>> Ensure chips have a name before submitting values
 var getOwnPropertyDescriptorModule = __webpack_require__(165);
 var definePropertyModule = __webpack_require__(117);
 
@@ -44531,6 +46072,7 @@ module.exports = function (target, source) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 418 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -44538,6 +46080,15 @@ var getBuiltIn = __webpack_require__(175);
 var getOwnPropertyNamesModule = __webpack_require__(420);
 var getOwnPropertySymbolsModule = __webpack_require__(423);
 var anObject = __webpack_require__(82);
+=======
+/* 420 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var getBuiltIn = __webpack_require__(175);
+var getOwnPropertyNamesModule = __webpack_require__(422);
+var getOwnPropertySymbolsModule = __webpack_require__(425);
+var anObject = __webpack_require__(81);
+>>>>>>> Ensure chips have a name before submitting values
 
 // all object keys, includes non-enumerable and symbols
 module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
@@ -44547,13 +46098,21 @@ module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 419 */
+=======
+/* 421 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(26);
 
 /***/ }),
+<<<<<<< HEAD
 /* 420 */
+=======
+/* 422 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var internalObjectKeys = __webpack_require__(176);
@@ -44568,12 +46127,21 @@ exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 421 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var toIndexedObject = __webpack_require__(116);
 var toLength = __webpack_require__(84);
 var toAbsoluteIndex = __webpack_require__(422);
+=======
+/* 423 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var toIndexedObject = __webpack_require__(116);
+var toLength = __webpack_require__(83);
+var toAbsoluteIndex = __webpack_require__(424);
+>>>>>>> Ensure chips have a name before submitting values
 
 // `Array.prototype.{ indexOf, includes }` methods implementation
 var createMethod = function createMethod(IS_INCLUDES) {
@@ -44605,7 +46173,11 @@ module.exports = {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 422 */
+=======
+/* 424 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var toInteger = __webpack_require__(120);
@@ -44622,13 +46194,21 @@ module.exports = function (index, length) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 423 */
+=======
+/* 425 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 /***/ }),
+<<<<<<< HEAD
 /* 424 */
+=======
+/* 426 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(59);
@@ -44651,7 +46231,11 @@ var POLYFILL = isForced.POLYFILL = 'P';
 module.exports = isForced;
 
 /***/ }),
+<<<<<<< HEAD
 /* 425 */
+=======
+/* 427 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(59);
@@ -44663,7 +46247,11 @@ module.exports = !!Object.getOwnPropertySymbols && !fails(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 426 */
+=======
+/* 428 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -44673,6 +46261,7 @@ var addToUnscopables = __webpack_require__(184);
 addToUnscopables('flat');
 
 /***/ }),
+<<<<<<< HEAD
 /* 427 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -44681,6 +46270,16 @@ var defineProperties = __webpack_require__(428);
 var enumBugKeys = __webpack_require__(121);
 var hiddenKeys = __webpack_require__(119);
 var html = __webpack_require__(430);
+=======
+/* 429 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var anObject = __webpack_require__(81);
+var defineProperties = __webpack_require__(430);
+var enumBugKeys = __webpack_require__(121);
+var hiddenKeys = __webpack_require__(119);
+var html = __webpack_require__(432);
+>>>>>>> Ensure chips have a name before submitting values
 var documentCreateElement = __webpack_require__(171);
 var sharedKey = __webpack_require__(173);
 var IE_PROTO = sharedKey('IE_PROTO');
@@ -44728,13 +46327,22 @@ module.exports = Object.create || function create(O, Properties) {
 hiddenKeys[IE_PROTO] = true;
 
 /***/ }),
+<<<<<<< HEAD
 /* 428 */
+=======
+/* 430 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(58);
 var definePropertyModule = __webpack_require__(117);
+<<<<<<< HEAD
 var anObject = __webpack_require__(82);
 var objectKeys = __webpack_require__(429);
+=======
+var anObject = __webpack_require__(81);
+var objectKeys = __webpack_require__(431);
+>>>>>>> Ensure chips have a name before submitting values
 
 // `Object.defineProperties` method
 // https://tc39.github.io/ecma262/#sec-object.defineproperties
@@ -44750,7 +46358,11 @@ module.exports = DESCRIPTORS ? Object.defineProperties : function defineProperti
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 429 */
+=======
+/* 431 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var internalObjectKeys = __webpack_require__(176);
@@ -44763,7 +46375,11 @@ module.exports = Object.keys || function keys(O) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 430 */
+=======
+/* 432 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var getBuiltIn = __webpack_require__(175);
@@ -44771,7 +46387,11 @@ var getBuiltIn = __webpack_require__(175);
 module.exports = getBuiltIn('document', 'documentElement');
 
 /***/ }),
+<<<<<<< HEAD
 /* 431 */
+=======
+/* 433 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -44780,7 +46400,11 @@ module.exports = getBuiltIn('document', 'documentElement');
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(47);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(432);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(434);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3__material_dialog__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -44950,7 +46574,11 @@ var VDialog = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
+<<<<<<< HEAD
 /* 432 */
+=======
+/* 434 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -48568,13 +50196,21 @@ var VDialog = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 433 */
+=======
+/* 435 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDateTime;
 /* unused harmony export VDateTime */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(434);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(436);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield__ = __webpack_require__(186);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__material_textfield__);
@@ -48700,7 +50336,11 @@ var VDateTime = function (_VTextField) {
 }(__WEBPACK_IMPORTED_MODULE_2__text_fields__["a" /* VTextField */]);
 
 /***/ }),
+<<<<<<< HEAD
 /* 434 */
+=======
+/* 436 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -50889,7 +52529,11 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = 
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 435 */
+=======
+/* 437 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -50980,6 +52624,7 @@ var VLoads = function (_VBase) {
 module.exports = __webpack_require__(437);
 
 /***/ }),
+<<<<<<< HEAD
 /* 437 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -51152,14 +52797,24 @@ var VUrls = function () {
 
 /***/ }),
 /* 441 */
+=======
+/* 438 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPosts; });
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(63);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(66);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(85);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(442);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(85);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(65);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(84);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(443);
+>>>>>>> Ensure chips have a name before submitting values
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -51495,7 +53150,65 @@ var VPosts = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
+<<<<<<< HEAD
 /* 442 */
+=======
+/* 439 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(440);
+
+/***/ }),
+/* 440 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(441);
+__webpack_require__(442);
+var entryUnbind = __webpack_require__(185);
+
+module.exports = entryUnbind('Array', 'flatMap');
+
+/***/ }),
+/* 441 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var $ = __webpack_require__(164);
+var flattenIntoArray = __webpack_require__(177);
+var toObject = __webpack_require__(181);
+var toLength = __webpack_require__(83);
+var aFunction = __webpack_require__(180);
+var arraySpeciesCreate = __webpack_require__(182);
+
+// `Array.prototype.flatMap` method
+// https://github.com/tc39/proposal-flatMap
+$({ target: 'Array', proto: true }, {
+  flatMap: function flatMap(callbackfn /* , thisArg */) {
+    var O = toObject(this);
+    var sourceLen = toLength(O.length);
+    var A;
+    aFunction(callbackfn);
+    A = arraySpeciesCreate(O, 0);
+    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+    return A;
+  }
+});
+
+/***/ }),
+/* 442 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// this method was added to unscopables after implementation
+// in popular engines, so it's moved to a separate module
+var addToUnscopables = __webpack_require__(184);
+
+addToUnscopables('flatMap');
+
+/***/ }),
+/* 443 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -51509,7 +53222,7 @@ function encode(value) {
 }
 
 /***/ }),
-/* 443 */
+/* 444 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -51517,7 +53230,7 @@ function encode(value) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(85);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base__ = __webpack_require__(63);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__initialize__ = __webpack_require__(162);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__uninitialize__ = __webpack_require__(444);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__uninitialize__ = __webpack_require__(445);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
@@ -51684,7 +53397,7 @@ var VReplaces = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */]);
 
 /***/ }),
-/* 444 */
+/* 445 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -51699,7 +53412,7 @@ function uninitialize(root) {
 }
 
 /***/ }),
-/* 445 */
+/* 446 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -56054,7 +57767,7 @@ function uninitialize(root) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 446 */
+/* 447 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56136,7 +57849,7 @@ var VToggleVisibility = function () {
 }();
 
 /***/ }),
-/* 447 */
+/* 448 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56256,7 +57969,7 @@ var VPromptIfDirty = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 448 */
+/* 449 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56298,7 +58011,7 @@ var VSnackbarEvent = function () {
 }();
 
 /***/ }),
-/* 449 */
+/* 450 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56364,7 +58077,7 @@ var VClears = function () {
 }();
 
 /***/ }),
-/* 450 */
+/* 451 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56425,7 +58138,7 @@ var VRemoves = function () {
 }();
 
 /***/ }),
-/* 451 */
+/* 452 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56473,7 +58186,7 @@ var VStepperEvent = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 452 */
+/* 453 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56510,7 +58223,7 @@ var VNavigates = function () {
 }();
 
 /***/ }),
-/* 453 */
+/* 454 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56545,7 +58258,7 @@ var VPluginEventAction = function () {
 }();
 
 /***/ }),
-/* 454 */
+/* 455 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56560,7 +58273,7 @@ function getRoot(element) {
 }
 
 /***/ }),
-/* 455 */
+/* 456 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -56771,14 +58484,14 @@ function initLists(e) {
 }
 
 /***/ }),
-/* 456 */
+/* 457 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDrawer;
 /* unused harmony export VModalDrawer */
 /* unused harmony export VDismissibleDrawer */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(457);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(458);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_drawer__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
@@ -56858,7 +58571,7 @@ var VDismissibleDrawer = function (_VDrawer2) {
 }(VDrawer);
 
 /***/ }),
-/* 457 */
+/* 458 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -60185,13 +61898,13 @@ var VDismissibleDrawer = function (_VDrawer2) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 458 */
+/* 459 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initHeader;
 /* unused harmony export VHeader */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(459);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(460);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -60230,19 +61943,26 @@ var VHeader = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 459 */
+/* 460 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCTopAppBar; });
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(64);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(190);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(460);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(65);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(192);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(461);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(64);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(86);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(463);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(464);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(465);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(464);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(465);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(466);
 /* unused harmony reexport MDCTopAppBarBaseFoundation */
 /* unused harmony reexport MDCTopAppBarFoundation */
 /* unused harmony reexport MDCFixedTopAppBarFoundation */
@@ -60449,16 +62169,23 @@ var MDCTopAppBar = function (_MDCComponent) {
 
 
 /***/ }),
-/* 460 */
+/* 461 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCRipple; });
 /* unused harmony export RippleCapableSurface */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(190);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(191);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(461);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(192);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(192);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(193);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(462);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(194);
+>>>>>>> Ensure chips have a name before submitting values
 /* unused harmony reexport MDCRippleFoundation */
 /* unused harmony reexport util */
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -60706,14 +62433,20 @@ RippleCapableSurface.prototype.disabled;
 
 
 /***/ }),
-/* 461 */
+/* 462 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(124);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(191);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(462);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(192);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(193);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(463);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(194);
+>>>>>>> Ensure chips have a name before submitting values
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -61493,7 +63226,7 @@ var MDCRippleFoundation = function (_MDCFoundation) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCRippleFoundation);
 
 /***/ }),
-/* 462 */
+/* 463 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -61554,7 +63287,7 @@ var numbers = {
 
 
 /***/ }),
-/* 463 */
+/* 464 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -61666,7 +63399,7 @@ var MDCFixedTopAppBarFoundation = function (_MDCTopAppBarFoundati) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCFixedTopAppBarFoundation);
 
 /***/ }),
-/* 464 */
+/* 465 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -61788,7 +63521,7 @@ var MDCShortTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCShortTopAppBarFoundation);
 
 /***/ }),
-/* 465 */
+/* 466 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -62061,7 +63794,7 @@ var MDCTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCTopAppBarFoundation);
 
 /***/ }),
-/* 466 */
+/* 467 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -62069,7 +63802,7 @@ var MDCTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* unused harmony export VIconToggle */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(87);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(467);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(468);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -62099,7 +63832,7 @@ var VIconToggle = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 467 */
+/* 468 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -64885,13 +66618,13 @@ var VIconToggle = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 468 */
+/* 469 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSelects;
 /* unused harmony export VSelect */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(469);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(470);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_select__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__ = __webpack_require__(122);
@@ -64979,7 +66712,7 @@ var VSelect = function (_dirtyableMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 469 */
+/* 470 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -75211,7 +76944,7 @@ var VSelect = function (_dirtyableMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 470 */
+/* 471 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75221,7 +76954,11 @@ var VSelect = function (_dirtyableMixin) {
 /* harmony export (immutable) */ __webpack_exports__["a"] = initChips;
 /* unused harmony export VChip */
 /* unused harmony export VChipSet */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(193);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(195);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_chips__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
@@ -75290,7 +77027,7 @@ var VChip = function (_eventHandlerMixin) {
 
         // Called to collect data for submission
         value: function prepareSubmit(params) {
-            if (this.shouldSubmitParams) {
+            if (this.shouldSubmitParams()) {
                 params.push([this.name(), this.value()]);
             }
         }
@@ -75315,16 +77052,16 @@ var VChip = function (_eventHandlerMixin) {
             this.element.setAttribute('data-value', value);
         }
     }, {
+        key: 'shouldSubmitParams',
+        value: function shouldSubmitParams() {
+            // Selectable chips (those within a :filter or :choice chipset) which
+            // are not currently selected do not submit their value.
+            return this.name() && this.value() && (!this.selectable || this.mdcComponent.selected);
+        }
+    }, {
         key: 'trailingIcon',
         get: function get() {
             return this.element.querySelector('.mdc-chip__icon.mdc-chip__icon--trailing');
-        }
-    }, {
-        key: 'shouldSubmitParams',
-        get: function get() {
-            // Selectable chips (those within a :filter or :choice chipset) which
-            // are not currently selected do not submit their value.
-            return this.value() && (!this.selectable || this.mdcComponent.selected);
         }
     }, {
         key: 'selectable',
@@ -75359,7 +77096,7 @@ var VChipSet = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 471 */
+/* 472 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75394,7 +77131,7 @@ var VCard = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 472 */
+/* 473 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75431,13 +77168,13 @@ var VForm = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 473 */
+/* 474 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSnackbar;
 /* unused harmony export VSnackbar */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(474);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(475);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_snackbar__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -75486,7 +77223,7 @@ var VSnackbar = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 474 */
+/* 475 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -77020,7 +78757,7 @@ var VSnackbar = function (_VBaseComponent) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 475 */
+/* 476 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -77028,7 +78765,7 @@ var VSnackbar = function (_VBaseComponent) {
 /* unused harmony export VCheckbox */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(87);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(476);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(477);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_checkbox__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -77061,7 +78798,7 @@ var VCheckbox = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 476 */
+/* 477 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -80177,7 +81914,7 @@ var VCheckbox = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 477 */
+/* 478 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -80185,7 +81922,7 @@ var VCheckbox = function (_VBaseToggle) {
 /* unused harmony export VSwitch */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(87);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(478);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(479);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_switch__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -80215,7 +81952,7 @@ var VSwitch = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 478 */
+/* 479 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -82860,15 +84597,19 @@ var VSwitch = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 479 */
+/* 480 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRichTextArea;
 /* unused harmony export VRichTextArea */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(194);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(196);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(484);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(485);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_event_handler__ = __webpack_require__(11);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__ = __webpack_require__(48);
@@ -83191,7 +84932,7 @@ function getListLevel(el) {
 }
 
 /***/ }),
-/* 480 */
+/* 481 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -83205,9 +84946,9 @@ function getListLevel(el) {
 
 
 
-var base64 = __webpack_require__(481);
-var ieee754 = __webpack_require__(482);
-var isArray = __webpack_require__(483);
+var base64 = __webpack_require__(482);
+var ieee754 = __webpack_require__(483);
+var isArray = __webpack_require__(484);
 
 exports.Buffer = Buffer;
 exports.SlowBuffer = SlowBuffer;
@@ -84935,7 +86676,7 @@ function isnan(val) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(67)))
 
 /***/ }),
-/* 481 */
+/* 482 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -85062,7 +86803,7 @@ function fromByteArray(uint8) {
 }
 
 /***/ }),
-/* 482 */
+/* 483 */
 /***/ (function(module, exports) {
 
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
@@ -85151,7 +86892,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 };
 
 /***/ }),
-/* 483 */
+/* 484 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -85161,12 +86902,16 @@ module.exports = Array.isArray || function (arr) {
 };
 
 /***/ }),
-/* 484 */
+/* 485 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return HorizontalRuleBlot; });
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(194);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(196);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -85216,7 +86961,7 @@ var HorizontalRuleBlot = function (_Embed) {
 }(Embed);;
 
 /***/ }),
-/* 485 */
+/* 486 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85296,7 +87041,7 @@ var VStepper = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 486 */
+/* 487 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85304,7 +87049,7 @@ var VStepper = function (_eventHandlerMixin) {
 /* unused harmony export VRadio */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(87);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(487);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(488);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_radio__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -85334,7 +87079,7 @@ var VRadio = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 487 */
+/* 488 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -87911,7 +89656,7 @@ var VRadio = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 488 */
+/* 489 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -87919,7 +89664,7 @@ var VRadio = function (_VBaseToggle) {
 /* unused harmony export VSlider */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(489);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(490);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_slider__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(122);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(123);
@@ -88019,7 +89764,7 @@ var VSlider = function (_dirtyableMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_5__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]))));
 
 /***/ }),
-/* 489 */
+/* 490 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -90089,7 +91834,7 @@ var VSlider = function (_dirtyableMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 490 */
+/* 491 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -90169,7 +91914,7 @@ var VHiddenField = function (_dirtyableMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_dirtyable__["a" /* dirtyableMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 491 */
+/* 492 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -90206,7 +91951,7 @@ var VContent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 492 */
+/* 493 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -90257,7 +92002,7 @@ var VColumn = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 493 */
+/* 494 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -90265,7 +92010,7 @@ var VColumn = function (_eventHandlerMixin2) {
 /* unused harmony export VTabBar */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(494);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(495);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_tab_bar__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -90329,7 +92074,7 @@ var VTabBar = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 494 */
+/* 495 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -96801,7 +98546,7 @@ var VTabBar = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 495 */
+/* 496 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -96931,7 +98676,7 @@ function initTables(e) {
 }
 
 /***/ }),
-/* 496 */
+/* 497 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -97067,7 +98812,7 @@ var VFileInput = function (_dirtyableMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 497 */
+/* 498 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -97075,7 +98820,7 @@ var VFileInput = function (_dirtyableMixin) {
 /* unused harmony export VFormField */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(47);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(498);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(499);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_form_field__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -97107,7 +98852,7 @@ var VFormField = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 498 */
+/* 499 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -99612,7 +101357,7 @@ var VFormField = function (_VBaseContainer) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-/* 499 */
+/* 500 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99657,7 +101402,7 @@ var VImage = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 500 */
+/* 501 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99707,7 +101452,7 @@ var VTypography = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 501 */
+/* 502 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99745,7 +101490,7 @@ var VTooltip = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 502 */
+/* 503 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -99862,14 +101607,14 @@ var VPluginComponent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 503 */
+/* 504 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initProgress;
 /* unused harmony export VProgress */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__ = __webpack_require__(504);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__ = __webpack_require__(505);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -99923,13 +101668,17 @@ var VProgress = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 504 */
+/* 505 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(505);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(506);
 /* harmony namespace reexport (by used) */ __webpack_require__.d(__webpack_exports__, "a", function() { return __WEBPACK_IMPORTED_MODULE_0__component__["a"]; });
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(196);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(198);
+>>>>>>> Ensure chips have a name before submitting values
 /* unused harmony namespace reexport */
 /**
  * @license
@@ -99958,14 +101707,19 @@ var VProgress = function (_VBaseComponent) {
 //# sourceMappingURL=index.js.map
 
 /***/ }),
-/* 505 */
+/* 506 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgress; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(506);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(196);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(507);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(198);
+>>>>>>> Ensure chips have a name before submitting values
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -100065,13 +101819,17 @@ var MDCLinearProgress = /** @class */function (_super) {
 //# sourceMappingURL=component.js.map
 
 /***/ }),
-/* 506 */
+/* 507 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCComponent; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(195);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(197);
+>>>>>>> Ensure chips have a name before submitting values
 /**
  * @license
  * Copyright 2016 Google Inc.
@@ -100176,7 +101934,7 @@ var MDCComponent = /** @class */function () {
 //# sourceMappingURL=component.js.map
 
 /***/ }),
-/* 507 */
+/* 508 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -100269,7 +102027,7 @@ function getCorrectEventName(windowObj, eventType) {
 //# sourceMappingURL=util.js.map
 
 /***/ }),
-/* 508 */
+/* 509 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -100307,213 +102065,6 @@ var strings = {
     PRIMARY_BAR_SELECTOR: '.mdc-linear-progress__primary-bar'
 };
 //# sourceMappingURL=constants.js.map
-
-/***/ }),
-/* 509 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return DRAG_DATA_MIME_TYPE; });
-/* unused harmony export EVENT_DROPPED */
-/* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
-/*
-    A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
-    three modes:
-
-    1. read/write, during a `dragstart` event: items can be read and added
-    2. read-only, during a `drop` event: items can be read, but not added
-    3. protected, during all other types of DragEvent: items cannot be read
-       or added.
-
-    (see https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw)
-
-    Thus, attempting to mutate the store during events other than `dragstart`
-    fails silently: no error is raised, but items are not added.
-
-
-    To read items in protected mode, serialize data as a string and store it as
-    a key instead of as a value. This makes it accessible via
-    `dataTransfer.types`:
-
-    // in a dragstart handler:
-    event.dataTransfer.setData(JSON.stringify(foo), '');
-
-    // in a later read-only or protected DragEvent handler:
-    const json = event.dataTransfer.types[someIndex];
-    const foo = JSON.stringify(json);
-
-
-    There is no workaround for attempting mutating a drag data store not in
-    read/write mode.
- */
-
-
-
-var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
-var EVENT_DROPPED = 'dropped';
-
-var ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
-
-function createDragStartHandler(root, element) {
-    return function (event) {
-        var dragParamData = event.target.dataset.drag_params;
-
-        if (dragParamData) {
-            event.dataTransfer.setData(DRAG_DATA_MIME_TYPE, dragParamData);
-
-            var zone = JSON.parse(dragParamData).zone;
-
-            if (zone) {
-                event.dataTransfer.setData(zone, '');
-            }
-
-            event.dataTransfer.effectAllowed = 'move';
-            event.target.classList.remove('v-dnd-draggable');
-            event.target.classList.add('v-dnd-moving');
-
-            event.dataTransfer.setData(ELEMENT_ID_MIME_TYPE, element.id);
-        }
-    };
-}
-
-function createDragOverHandler(root, element) {
-    return function (event) {
-        var dropZone = element.dataset.dropzone;
-
-        if (dropZone == null || event.dataTransfer.types.includes(dropZone)) {
-            if (event.preventDefault) {
-                event.preventDefault();
-            }
-            element.classList.add('v-dnd-over');
-        } else {
-            element.classList.remove('v-dnd-over');
-        }
-    };
-}
-
-function createDragLeaveHandler(root, element) {
-    return function (event) {
-        element.classList.remove('v-dnd-over');
-    };
-}
-
-function createDropHandler(root, element) {
-    // When an element is upgraded to a Voom component after being replaced via
-    // `replaces`, root may refer to the replaced element itself instead of the
-    // element's root node.
-    // Since a valid drop zone may exist anywhere on the page, it is not
-    // guaranteed that root contains the element being dragged.
-    // getRootNode will fetch `root`'s actual root node (document or shadow
-    // DOM root).
-    var trueRoot = Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* getRootNode */])(root);
-
-    return function (event) {
-        event.stopPropagation();
-        event.preventDefault();
-
-        var id = event.dataTransfer.getData(ELEMENT_ID_MIME_TYPE);
-        var draggedElement = id ? trueRoot.querySelector('#' + id) : null;
-        var dragParams = {};
-
-        if (draggedElement) {
-            dragParams = JSON.parse(draggedElement.dataset.drag_params);
-        }
-
-        element.classList.remove('v-dnd-over', 'v-dnd-moving');
-        element.classList.add('v-dnd-draggable');
-
-        // Emit a "dropped" event for the element being dragged:
-        // The drag_params of the dragged element are merged with the
-        // drop_params of the drop zone.
-        var dropZoneParams = JSON.parse(element.dataset.drop_params);
-        var params = Object.assign({}, dragParams, dropZoneParams);
-        var droppedEvent = new CustomEvent(EVENT_DROPPED, { detail: params });
-
-        draggedElement.dispatchEvent(droppedEvent);
-
-        return false;
-    };
-}
-
-function createDragEndHandler(root, element) {
-    return function (event) {
-        element.classList.remove('v-dnd-over', 'v-dnd-moving');
-        element.classList.add('v-dnd-draggable');
-    };
-}
-
-var DRAGGABLE_SELECTOR = '[draggable=true]';
-var DROP_ZONE_SELECTOR = '[data-dropzone]';
-
-function initDragAndDrop(root) {
-    var draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
-
-    if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
-        console.log('root matches DRAGGABLE_SELECTOR');
-        draggables.unshift(root);
-    }
-
-    var _iteratorNormalCompletion = true;
-    var _didIteratorError = false;
-    var _iteratorError = undefined;
-
-    try {
-        for (var _iterator = draggables[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-            var elem = _step.value;
-
-            elem.addEventListener('dragstart', createDragStartHandler(root, elem));
-            elem.addEventListener('dragend', createDragEndHandler(root, elem));
-        }
-    } catch (err) {
-        _didIteratorError = true;
-        _iteratorError = err;
-    } finally {
-        try {
-            if (!_iteratorNormalCompletion && _iterator.return) {
-                _iterator.return();
-            }
-        } finally {
-            if (_didIteratorError) {
-                throw _iteratorError;
-            }
-        }
-    }
-
-    var dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
-
-    if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
-        console.log('root matches DROP_ZONE_SELECTOR');
-        dropZones.unshift(root);
-    }
-
-    var _iteratorNormalCompletion2 = true;
-    var _didIteratorError2 = false;
-    var _iteratorError2 = undefined;
-
-    try {
-        for (var _iterator2 = dropZones[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-            var _elem = _step2.value;
-
-            _elem.addEventListener('dragover', createDragOverHandler(root, _elem));
-            _elem.addEventListener('drop', createDropHandler(root, _elem));
-            _elem.addEventListener('dragleave', createDragLeaveHandler(root, _elem));
-        }
-    } catch (err) {
-        _didIteratorError2 = true;
-        _iteratorError2 = err;
-    } finally {
-        try {
-            if (!_iteratorNormalCompletion2 && _iterator2.return) {
-                _iterator2.return();
-            }
-        } finally {
-            if (_didIteratorError2) {
-                throw _iteratorError2;
-            }
-        }
-    }
-}
 
 /***/ })
 /******/ ]);

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -76980,6 +76980,8 @@ var EVENT_DESELECT = 'deselect';
 var EVENT_TRAILING_ICON_CLICK = 'trailing_icon_click';
 
 var SELECTABLE_VARIANT_CLASS = 'v-chip-set--selectable-variant';
+var CHIP_BEHAVIOR_AUTO_REMOVE = 'auto_remove';
+var CHIP_BEHAVIOR_NO_AUTO_REMOVE = 'no_auto_remove';
 
 function initChips(e) {
     console.debug('\tChips');
@@ -76992,8 +76994,7 @@ function initChips(e) {
     // call for chips is not needed.
 
     Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["d" /* hookupComponentsManually */])(e, '.v-chip-set', function (element) {
-        var selectable = element.classList.contains(SELECTABLE_VARIANT_CLASS);
-        var chipFactory = voomChipFactoryFactory(selectable);
+        var chipFactory = voomChipFactoryFactory(CHIP_BEHAVIOR_NO_AUTO_REMOVE);
         var mdcComponent = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["MDCChipSet"](element, undefined, chipFactory);
 
         return new VChipSet(element, mdcComponent);
@@ -77074,10 +77075,14 @@ var VChip = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
 
 // Returns a function which constructs VChip components.
-function voomChipFactoryFactory(selectable) {
+function voomChipFactoryFactory() {
+    var behavior = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : CHIP_BEHAVIOR_AUTO_REMOVE;
+
+    var autoRemove = behavior === CHIP_BEHAVIOR_AUTO_REMOVE;
+
     return function (element) {
         var mdcComponent = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["MDCChip"](element);
-        mdcComponent.shouldRemoveOnTrailingIconClick = !selectable;
+        mdcComponent.shouldRemoveOnTrailingIconClick = autoRemove;
 
         return new VChip(element, mdcComponent);
     };

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -60,11 +60,7 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-<<<<<<< HEAD
-/******/ 	return __webpack_require__(__webpack_require__.s = 197);
-=======
-/******/ 	return __webpack_require__(__webpack_require__.s = 199);
->>>>>>> Ensure chips have a name before submitting values
+/******/ 	return __webpack_require__(__webpack_require__.s = 198);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -565,11 +561,7 @@ var global = __webpack_require__(3);
 var hide = __webpack_require__(14);
 var has = __webpack_require__(17);
 var SRC = __webpack_require__(37)('src');
-<<<<<<< HEAD
-var $toString = __webpack_require__(208);
-=======
-var $toString = __webpack_require__(210);
->>>>>>> Ensure chips have a name before submitting values
+var $toString = __webpack_require__(209);
 var TO_STRING = 'toString';
 var TPL = ('' + $toString).split(TO_STRING);
 
@@ -2196,10 +2188,10 @@ module.exports = DESCRIPTORS ? function (object, key, value) {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(163);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(436);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(437);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(115);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(440);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(441);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -2632,11 +2624,7 @@ var strings = {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(202);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(204);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(203);
 
 
 /* harmony default export */ __webpack_exports__["a"] = (new __WEBPACK_IMPORTED_MODULE_0__utils_config__["a" /* default */]({
@@ -3164,11 +3152,7 @@ module.exports = function (it) {
 
 var global = __webpack_require__(26);
 var setGlobal = __webpack_require__(118);
-<<<<<<< HEAD
-var IS_PURE = __webpack_require__(414);
-=======
-var IS_PURE = __webpack_require__(416);
->>>>>>> Ensure chips have a name before submitting values
+var IS_PURE = __webpack_require__(415);
 
 var SHARED = '__core-js_shared__';
 var store = global[SHARED] || setGlobal(SHARED, {});
@@ -3307,225 +3291,6 @@ function expandParams(results, params) {
 }
 
 /***/ }),
-<<<<<<< HEAD
-=======
-/* 85 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(163);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(439);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(115);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(188);
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-
-
-
-
-
-var VBase = function (_VUrls) {
-    _inherits(VBase, _VUrls);
-
-    function VBase(options, root) {
-        _classCallCheck(this, VBase);
-
-        var _this = _possibleConstructorReturn(this, (VBase.__proto__ || Object.getPrototypeOf(VBase)).call(this));
-
-        _this.options = options;
-        _this.root = root;
-        return _this;
-    }
-
-    _createClass(VBase, [{
-        key: 'clearErrors',
-        value: function clearErrors() {
-            new __WEBPACK_IMPORTED_MODULE_2__errors__["a" /* VErrors */](this.root).clearErrors();
-        }
-    }, {
-        key: 'parentElement',
-        value: function parentElement() {
-            return this.root.getElementById(this.options.__parent_id__);
-        }
-
-        /**
-         * taggedInputs retrieves all components matching this event's input_tag
-         * value.
-         * @return {NodeList}
-         */
-
-    }, {
-        key: 'taggedInputs',
-        value: function taggedInputs() {
-            var inputTag = this.options.input_tag;
-
-            if (!inputTag) {
-                return [];
-            }
-
-            var selector = '[data-input-tag="' + inputTag + '"]';
-            var inputs = this.root.querySelectorAll(selector);
-
-            if (inputs.length < 1) {
-                console.warn('input_tag ' + inputTag + ' matched 0 elements. Are you sure' + 'you\'ve specified the correct value?');
-            }
-
-            return inputs;
-        }
-
-        /**
-         * inputs retrieves relevant input elements for this event.
-         *
-         * - If an `input_tag` has been provided, all matching tagged elements are
-         *   included.
-         * - If this component is a input element, it is included.
-         * - If this component has input elements, its input elements are included.
-         *   If not, the input elements of the nearest container (dialog or content)
-         *   are included.
-         * @return {Array<HTMLElement>}
-         */
-
-    }, {
-        key: 'inputs',
-        value: function inputs() {
-            var components = [];
-
-            // Collect tagged components, if applicable:
-            if (this.options.input_tag) {
-                var taggedComponents = Array.from(this.taggedInputs()).filter(function (element) {
-                    return element.vComponent;
-                }).map(function (element) {
-                    return element.vComponent;
-                });
-
-                components.push(taggedComponents);
-            }
-
-            var comp = this.component();
-
-            if (comp) {
-                // Include ourselves if we're a form field component, but not a
-                // container:
-                if (comp.respondTo('prepareSubmit') && !comp.respondTo('inputs')) {
-                    components.push(comp);
-                } else if (!comp.respondTo('inputs')) {
-                    // Defer to the component's closest container (card, content,
-                    // dialog, or form) if the component itself does not respond to
-                    // `inputs`:
-                    comp = this.closestContainer();
-                }
-            }
-
-            if (comp && comp.respondTo('inputs')) {
-                components.push(comp);
-            }
-
-            // Map components to elements.
-            // Containers are mapped to their child elements.
-            // Form field components are mapped to their own element.
-            var elements = components.flat().flatMap(function (comp) {
-                if (comp.respondTo('inputs')) {
-                    return Array.from(comp.inputs());
-                } else if (comp.respondTo('prepareSubmit')) {
-                    return comp.element;
-                }
-            });
-
-            // Deduplicate:
-            return Array.from(new Set(elements));
-        }
-
-        /**
-         * inputComponents retrieves the Component for each of this event's
-         * relevant input elements.
-         * @return {Array<VBaseComponent>}
-         */
-
-    }, {
-        key: 'inputComponents',
-        value: function inputComponents() {
-            return this.inputs().filter(function (element) {
-                return element.vComponent;
-            }).map(function (element) {
-                return element.vComponent;
-            });
-        }
-
-        /**
-         * inputValues retrieves submit values for each of this event's relevant
-         * input elements.
-         * @return {Array}
-         */
-
-    }, {
-        key: 'inputValues',
-        value: function inputValues() {
-            var params = [];
-
-            this.inputComponents().filter(function (comp) {
-                return comp.respondTo('prepareSubmit');
-            }).map(function (comp) {
-                return comp.prepareSubmit(params);
-            });
-
-            return params;
-        }
-    }, {
-        key: 'component',
-        value: function component() {
-            var parent = this.parentElement();
-
-            return parent ? parent.vComponent : null;
-        }
-    }, {
-        key: 'validate',
-        value: function validate() {
-            var comp = this.component();
-
-            if (comp) {
-                return comp.validate();
-            }
-
-            return [];
-        }
-    }, {
-        key: 'closestContainer',
-        value: function closestContainer() {
-            var element = this.closestContainerElement();
-
-            if (!element) {
-                return null;
-            }
-
-            return element.vComponent;
-        }
-    }, {
-        key: 'closestContainerElement',
-        value: function closestContainerElement() {
-            var comp = this.component();
-
-            if (!(comp && comp.element)) {
-                return null;
-            }
-
-            return comp.element.closest('[data-is-container]');
-        }
-    }]);
-
-    return VBase;
-}(__WEBPACK_IMPORTED_MODULE_3__utils_urls__["a" /* VUrls */]);
-
-/***/ }),
->>>>>>> Ensure chips have a name before submitting values
 /* 86 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
@@ -4099,11 +3864,7 @@ module.exports = __webpack_require__(21).getIteratorMethod = function (it) {
 /***/ (function(module, exports, __webpack_require__) {
 
 // 9.4.2.3 ArraySpeciesCreate(originalArray, length)
-<<<<<<< HEAD
-var speciesConstructor = __webpack_require__(297);
-=======
-var speciesConstructor = __webpack_require__(299);
->>>>>>> Ensure chips have a name before submitting values
+var speciesConstructor = __webpack_require__(298);
 
 module.exports = function (original, length) {
   return new (speciesConstructor(original))(length);
@@ -5025,11 +4786,7 @@ var VErrors = function () {
 /***/ (function(module, exports, __webpack_require__) {
 
 // toObject with fallback for non-array-like ES3 strings
-<<<<<<< HEAD
-var IndexedObject = __webpack_require__(412);
-=======
-var IndexedObject = __webpack_require__(414);
->>>>>>> Ensure chips have a name before submitting values
+var IndexedObject = __webpack_require__(413);
 var requireObjectCoercible = __webpack_require__(168);
 
 module.exports = function (it) {
@@ -5172,17 +4929,10 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VEvents; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = initEvents;
 /* harmony export (immutable) */ __webpack_exports__["c"] = removeEvents;
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(435);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(441);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(443);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(189);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(437);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(438);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(436);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(442);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(444);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(190);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(189);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(115);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(447);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(448);
@@ -5193,7 +4943,7 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(453);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(454);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(455);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(191);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(190);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -6952,52 +6702,16 @@ module.exports = Math.scale || function scale(x, inLow, inHigh, outLow, outHigh)
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony export (immutable) */ __webpack_exports__["initialize"] = initialize;
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(407);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(431);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(433);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(187);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(123);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(455);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(456);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(458);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(466);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(188);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(468);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(470);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(471);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(472);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(473);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(475);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(477);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(479);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(485);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(486);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(488);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(490);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(491);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(492);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(493);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(495);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(496);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(497);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(499);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(500);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(501);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(502);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(503);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(509);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(409);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(433);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(435);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(408);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(432);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(434);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(187);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(123);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(456);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(457);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(459);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(467);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(189);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(188);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(469);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(471);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(472);
@@ -7021,8 +6735,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(502);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(503);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(504);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(191);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(190);
 
 
 
@@ -7108,11 +6821,7 @@ function initialize(root, setRoot) {
 /* 163 */
 /***/ (function(module, exports, __webpack_require__) {
 
-<<<<<<< HEAD
-module.exports = __webpack_require__(409);
-=======
-module.exports = __webpack_require__(411);
->>>>>>> Ensure chips have a name before submitting values
+module.exports = __webpack_require__(410);
 
 /***/ }),
 /* 164 */
@@ -7123,17 +6832,10 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 var global = __webpack_require__(26);
 var getOwnPropertyDescriptor = __webpack_require__(165).f;
 var hide = __webpack_require__(62);
-<<<<<<< HEAD
-var redefine = __webpack_require__(413);
+var redefine = __webpack_require__(414);
 var setGlobal = __webpack_require__(118);
-var copyConstructorProperties = __webpack_require__(417);
-var isForced = __webpack_require__(424);
-=======
-var redefine = __webpack_require__(415);
-var setGlobal = __webpack_require__(118);
-var copyConstructorProperties = __webpack_require__(419);
-var isForced = __webpack_require__(426);
->>>>>>> Ensure chips have a name before submitting values
+var copyConstructorProperties = __webpack_require__(418);
+var isForced = __webpack_require__(425);
 
 /*
   options.target      - name of the target object
@@ -7187,11 +6889,7 @@ module.exports = function (options, source) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(58);
-<<<<<<< HEAD
-var propertyIsEnumerableModule = __webpack_require__(411);
-=======
-var propertyIsEnumerableModule = __webpack_require__(413);
->>>>>>> Ensure chips have a name before submitting values
+var propertyIsEnumerableModule = __webpack_require__(412);
 var createPropertyDescriptor = __webpack_require__(166);
 var toIndexedObject = __webpack_require__(116);
 var toPrimitive = __webpack_require__(169);
@@ -7332,11 +7030,7 @@ module.exports = function (key) {
 /* 175 */
 /***/ (function(module, exports, __webpack_require__) {
 
-<<<<<<< HEAD
-var path = __webpack_require__(419);
-=======
-var path = __webpack_require__(421);
->>>>>>> Ensure chips have a name before submitting values
+var path = __webpack_require__(420);
 var global = __webpack_require__(26);
 
 var aFunction = function aFunction(variable) {
@@ -7353,11 +7047,7 @@ module.exports = function (namespace, method) {
 
 var has = __webpack_require__(61);
 var toIndexedObject = __webpack_require__(116);
-<<<<<<< HEAD
-var indexOf = __webpack_require__(421).indexOf;
-=======
-var indexOf = __webpack_require__(423).indexOf;
->>>>>>> Ensure chips have a name before submitting values
+var indexOf = __webpack_require__(422).indexOf;
 var hiddenKeys = __webpack_require__(119);
 
 module.exports = function (object, names) {
@@ -7512,11 +7202,7 @@ module.exports = function (originalArray, length) {
 var global = __webpack_require__(26);
 var shared = __webpack_require__(83);
 var uid = __webpack_require__(174);
-<<<<<<< HEAD
-var NATIVE_SYMBOL = __webpack_require__(425);
-=======
-var NATIVE_SYMBOL = __webpack_require__(427);
->>>>>>> Ensure chips have a name before submitting values
+var NATIVE_SYMBOL = __webpack_require__(426);
 
 var _Symbol = global.Symbol;
 var store = shared('wks');
@@ -7530,11 +7216,7 @@ module.exports = function (name) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var wellKnownSymbol = __webpack_require__(183);
-<<<<<<< HEAD
-var create = __webpack_require__(427);
-=======
-var create = __webpack_require__(429);
->>>>>>> Ensure chips have a name before submitting values
+var create = __webpack_require__(428);
 var hide = __webpack_require__(62);
 
 var UNSCOPABLES = wellKnownSymbol('unscopables');
@@ -14554,7 +14236,7 @@ function initDragAndDrop(root) {
 }
 
 /***/ }),
-/* 192 */
+/* 191 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14732,11 +14414,7 @@ var MDCComponent = function () {
 /* harmony default export */ __webpack_exports__["a"] = (MDCComponent);
 
 /***/ }),
-<<<<<<< HEAD
-/* 191 */
-=======
-/* 193 */
->>>>>>> Ensure chips have a name before submitting values
+/* 192 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -14917,11 +14595,7 @@ var MDCRippleAdapter = function () {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCRippleAdapter);
 
 /***/ }),
-<<<<<<< HEAD
-/* 192 */
-=======
-/* 194 */
->>>>>>> Ensure chips have a name before submitting values
+/* 193 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -15102,11 +14776,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 
 
 /***/ }),
-<<<<<<< HEAD
-/* 193 */
-=======
-/* 195 */
->>>>>>> Ensure chips have a name before submitting values
+/* 194 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -18689,11 +18359,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 194 */
-=======
-/* 196 */
->>>>>>> Ensure chips have a name before submitting values
+/* 195 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(Buffer, module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof2 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -31623,11 +31289,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(481).Buffer, __webpack_require__(12)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 195 */
-=======
-/* 197 */
->>>>>>> Ensure chips have a name before submitting values
+/* 196 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -31712,25 +31374,15 @@ var MDCFoundation = /** @class */function () {
 //# sourceMappingURL=foundation.js.map
 
 /***/ }),
-<<<<<<< HEAD
-/* 196 */
-=======
-/* 198 */
->>>>>>> Ensure chips have a name before submitting values
+/* 197 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgressFoundation; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(507);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(195);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(508);
-=======
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(508);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(197);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(196);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(509);
->>>>>>> Ensure chips have a name before submitting values
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -31858,36 +31510,20 @@ var MDCLinearProgressFoundation = /** @class */function (_super) {
 //# sourceMappingURL=foundation.js.map
 
 /***/ }),
-<<<<<<< HEAD
-/* 197 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(198);
-
-
-/***/ }),
 /* 198 */
-=======
-/* 199 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(200);
+module.exports = __webpack_require__(199);
 
 
 /***/ }),
-/* 200 */
->>>>>>> Ensure chips have a name before submitting values
+/* 199 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_compatibility__ = __webpack_require__(199);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_compatibility__ = __webpack_require__(200);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(66);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_compatibility__ = __webpack_require__(201);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(65);
->>>>>>> Ensure chips have a name before submitting values
 
 
 
@@ -31903,15 +31539,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     document.documentElement.classList.remove('incompatible-browser');
 
-<<<<<<< HEAD
-    __webpack_require__(203);
     __webpack_require__(204);
     __webpack_require__(205);
-=======
-    __webpack_require__(205);
     __webpack_require__(206);
-    __webpack_require__(207);
->>>>>>> Ensure chips have a name before submitting values
 
     __webpack_require__(162).initialize(document, true);
 
@@ -31927,19 +31557,11 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 199 */
+/* 200 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser__ = __webpack_require__(200);
-=======
-/* 201 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser__ = __webpack_require__(202);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser__ = __webpack_require__(201);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_detect_browser___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_detect_browser__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(66);
 
@@ -31953,11 +31575,7 @@ var isCompatible = browser && incompatibleList.indexOf(name) < 0;
 /* harmony default export */ __webpack_exports__["a"] = (isCompatible);
 
 /***/ }),
-<<<<<<< HEAD
-/* 200 */
-=======
-/* 202 */
->>>>>>> Ensure chips have a name before submitting values
+/* 201 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(process) {function detect() {
@@ -32041,17 +31659,10 @@ module.exports = {
   getNodeVersion: getNodeVersion,
   parseUserAgent: parseUserAgent
 };
-<<<<<<< HEAD
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(201)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(202)))
 
 /***/ }),
-/* 201 */
-=======
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(203)))
-
-/***/ }),
-/* 203 */
->>>>>>> Ensure chips have a name before submitting values
+/* 202 */
 /***/ (function(module, exports) {
 
 // shim for using process in browser
@@ -32241,11 +31852,7 @@ process.umask = function () {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 202 */
-=======
-/* 204 */
->>>>>>> Ensure chips have a name before submitting values
+/* 203 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -32347,11 +31954,7 @@ var VConfig = function () {
 /* harmony default export */ __webpack_exports__["a"] = (VConfig);
 
 /***/ }),
-<<<<<<< HEAD
-/* 203 */
-=======
-/* 205 */
->>>>>>> Ensure chips have a name before submitting values
+/* 204 */
 /***/ (function(module, exports) {
 
 ;(function() {
@@ -36353,11 +35956,7 @@ componentHandler.register({
 
 
 /***/ }),
-<<<<<<< HEAD
-/* 204 */
-=======
-/* 206 */
->>>>>>> Ensure chips have a name before submitting values
+/* 205 */
 /***/ (function(module, exports) {
 
 /*
@@ -37472,27 +37071,17 @@ componentHandler.register({
 /******/]);
 
 /***/ }),
-<<<<<<< HEAD
-/* 205 */
-=======
-/* 207 */
->>>>>>> Ensure chips have a name before submitting values
+/* 206 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 /* WEBPACK VAR INJECTION */(function(global) {
 
-<<<<<<< HEAD
-__webpack_require__(206);
-
-__webpack_require__(403);
-=======
-__webpack_require__(208);
->>>>>>> Ensure chips have a name before submitting values
+__webpack_require__(207);
 
 __webpack_require__(404);
 
-__webpack_require__(406);
+__webpack_require__(405);
 
 if (global._babelPolyfill) {
   throw new Error("only one instance of babel-polyfill is allowed");
@@ -37517,19 +37106,11 @@ define(String.prototype, "padRight", "".padEnd);
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(67)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 206 */
+/* 207 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(207);
-__webpack_require__(210);
+__webpack_require__(208);
 __webpack_require__(211);
-=======
-/* 208 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(209);
->>>>>>> Ensure chips have a name before submitting values
 __webpack_require__(212);
 __webpack_require__(213);
 __webpack_require__(214);
@@ -37604,29 +37185,17 @@ __webpack_require__(282);
 __webpack_require__(283);
 __webpack_require__(284);
 __webpack_require__(285);
-<<<<<<< HEAD
-__webpack_require__(287);
-__webpack_require__(288);
-__webpack_require__(290);
-__webpack_require__(291);
-=======
 __webpack_require__(286);
-__webpack_require__(287);
+__webpack_require__(288);
 __webpack_require__(289);
-__webpack_require__(290);
->>>>>>> Ensure chips have a name before submitting values
+__webpack_require__(291);
 __webpack_require__(292);
 __webpack_require__(293);
 __webpack_require__(294);
 __webpack_require__(295);
 __webpack_require__(296);
-<<<<<<< HEAD
-__webpack_require__(298);
-__webpack_require__(299);
-=======
 __webpack_require__(297);
-__webpack_require__(298);
->>>>>>> Ensure chips have a name before submitting values
+__webpack_require__(299);
 __webpack_require__(300);
 __webpack_require__(301);
 __webpack_require__(302);
@@ -37638,38 +37207,21 @@ __webpack_require__(307);
 __webpack_require__(308);
 __webpack_require__(309);
 __webpack_require__(310);
-<<<<<<< HEAD
-__webpack_require__(108);
 __webpack_require__(311);
-__webpack_require__(145);
+__webpack_require__(108);
 __webpack_require__(312);
+__webpack_require__(145);
+__webpack_require__(313);
 __webpack_require__(146);
-__webpack_require__(313);
-=======
-__webpack_require__(311);
-__webpack_require__(312);
-__webpack_require__(108);
-__webpack_require__(313);
-__webpack_require__(145);
->>>>>>> Ensure chips have a name before submitting values
 __webpack_require__(314);
-__webpack_require__(146);
 __webpack_require__(315);
 __webpack_require__(316);
 __webpack_require__(317);
-<<<<<<< HEAD
+__webpack_require__(318);
 __webpack_require__(149);
 __webpack_require__(151);
 __webpack_require__(152);
-__webpack_require__(318);
 __webpack_require__(319);
-=======
-__webpack_require__(318);
-__webpack_require__(319);
-__webpack_require__(149);
-__webpack_require__(151);
-__webpack_require__(152);
->>>>>>> Ensure chips have a name before submitting values
 __webpack_require__(320);
 __webpack_require__(321);
 __webpack_require__(322);
@@ -37753,19 +37305,11 @@ __webpack_require__(399);
 __webpack_require__(400);
 __webpack_require__(401);
 __webpack_require__(402);
-<<<<<<< HEAD
-module.exports = __webpack_require__(21);
-
-/***/ }),
-/* 207 */
-=======
 __webpack_require__(403);
-__webpack_require__(404);
 module.exports = __webpack_require__(21);
 
 /***/ }),
-/* 209 */
->>>>>>> Ensure chips have a name before submitting values
+/* 208 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -37787,13 +37331,8 @@ var uid = __webpack_require__(37);
 var wks = __webpack_require__(6);
 var wksExt = __webpack_require__(127);
 var wksDefine = __webpack_require__(89);
-<<<<<<< HEAD
-var enumKeys = __webpack_require__(209);
+var enumKeys = __webpack_require__(210);
 var isArray = __webpack_require__(70);
-=======
-var enumKeys = __webpack_require__(211);
-var isArray = __webpack_require__(69);
->>>>>>> Ensure chips have a name before submitting values
 var anObject = __webpack_require__(1);
 var isObject = __webpack_require__(5);
 var toObject = __webpack_require__(10);
@@ -38034,21 +37573,13 @@ setToStringTag(Math, 'Math', true);
 setToStringTag(global.JSON, 'JSON', true);
 
 /***/ }),
-<<<<<<< HEAD
-/* 208 */
-=======
-/* 210 */
->>>>>>> Ensure chips have a name before submitting values
+/* 209 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(53)('native-function-to-string', Function.toString);
 
 /***/ }),
-<<<<<<< HEAD
-/* 209 */
-=======
-/* 211 */
->>>>>>> Ensure chips have a name before submitting values
+/* 210 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // all enumerable object keys, includes symbols
@@ -38070,11 +37601,7 @@ module.exports = function (it) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 210 */
-=======
-/* 212 */
->>>>>>> Ensure chips have a name before submitting values
+/* 211 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38082,11 +37609,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Object', { create: __webpack_require__(40) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 211 */
-=======
-/* 213 */
->>>>>>> Ensure chips have a name before submitting values
+/* 212 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38094,11 +37617,7 @@ var $export = __webpack_require__(0);
 $export($export.S + $export.F * !__webpack_require__(8), 'Object', { defineProperty: __webpack_require__(9).f });
 
 /***/ }),
-<<<<<<< HEAD
-/* 212 */
-=======
-/* 214 */
->>>>>>> Ensure chips have a name before submitting values
+/* 213 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38106,11 +37625,7 @@ var $export = __webpack_require__(0);
 $export($export.S + $export.F * !__webpack_require__(8), 'Object', { defineProperties: __webpack_require__(129) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 213 */
-=======
-/* 215 */
->>>>>>> Ensure chips have a name before submitting values
+/* 214 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.6 Object.getOwnPropertyDescriptor(O, P)
@@ -38124,11 +37639,7 @@ __webpack_require__(29)('getOwnPropertyDescriptor', function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 214 */
-=======
-/* 216 */
->>>>>>> Ensure chips have a name before submitting values
+/* 215 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.9 Object.getPrototypeOf(O)
@@ -38142,11 +37653,7 @@ __webpack_require__(29)('getPrototypeOf', function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 215 */
-=======
-/* 217 */
->>>>>>> Ensure chips have a name before submitting values
+/* 216 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.14 Object.keys(O)
@@ -38160,11 +37667,7 @@ __webpack_require__(29)('keys', function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 216 */
-=======
-/* 218 */
->>>>>>> Ensure chips have a name before submitting values
+/* 217 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.7 Object.getOwnPropertyNames(O)
@@ -38173,11 +37676,7 @@ __webpack_require__(29)('getOwnPropertyNames', function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 217 */
-=======
-/* 219 */
->>>>>>> Ensure chips have a name before submitting values
+/* 218 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.5 Object.freeze(O)
@@ -38191,11 +37690,7 @@ __webpack_require__(29)('freeze', function ($freeze) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 218 */
-=======
-/* 220 */
->>>>>>> Ensure chips have a name before submitting values
+/* 219 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.17 Object.seal(O)
@@ -38209,11 +37704,7 @@ __webpack_require__(29)('seal', function ($seal) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 219 */
-=======
-/* 221 */
->>>>>>> Ensure chips have a name before submitting values
+/* 220 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.15 Object.preventExtensions(O)
@@ -38227,11 +37718,7 @@ __webpack_require__(29)('preventExtensions', function ($preventExtensions) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 220 */
-=======
-/* 222 */
->>>>>>> Ensure chips have a name before submitting values
+/* 221 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.12 Object.isFrozen(O)
@@ -38244,11 +37731,7 @@ __webpack_require__(29)('isFrozen', function ($isFrozen) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 221 */
-=======
-/* 223 */
->>>>>>> Ensure chips have a name before submitting values
+/* 222 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.13 Object.isSealed(O)
@@ -38261,11 +37744,7 @@ __webpack_require__(29)('isSealed', function ($isSealed) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 222 */
-=======
-/* 224 */
->>>>>>> Ensure chips have a name before submitting values
+/* 223 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.11 Object.isExtensible(O)
@@ -38278,11 +37757,7 @@ __webpack_require__(29)('isExtensible', function ($isExtensible) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 223 */
-=======
-/* 225 */
->>>>>>> Ensure chips have a name before submitting values
+/* 224 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.1 Object.assign(target, source)
@@ -38291,11 +37766,7 @@ var $export = __webpack_require__(0);
 $export($export.S + $export.F, 'Object', { assign: __webpack_require__(131) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 224 */
-=======
-/* 226 */
->>>>>>> Ensure chips have a name before submitting values
+/* 225 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.10 Object.is(value1, value2)
@@ -38303,11 +37774,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Object', { is: __webpack_require__(132) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 225 */
-=======
-/* 227 */
->>>>>>> Ensure chips have a name before submitting values
+/* 226 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.3.19 Object.setPrototypeOf(O, proto)
@@ -38315,11 +37782,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Object', { setPrototypeOf: __webpack_require__(93).set });
 
 /***/ }),
-<<<<<<< HEAD
-/* 226 */
-=======
-/* 228 */
->>>>>>> Ensure chips have a name before submitting values
+/* 227 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38336,11 +37799,7 @@ if (test + '' != '[object z]') {
 }
 
 /***/ }),
-<<<<<<< HEAD
-/* 227 */
-=======
-/* 229 */
->>>>>>> Ensure chips have a name before submitting values
+/* 228 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.2.3.2 / 15.3.4.5 Function.prototype.bind(thisArg, args...)
@@ -38349,11 +37808,7 @@ var $export = __webpack_require__(0);
 $export($export.P, 'Function', { bind: __webpack_require__(133) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 228 */
-=======
-/* 230 */
->>>>>>> Ensure chips have a name before submitting values
+/* 229 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var dP = __webpack_require__(9).f;
@@ -38374,11 +37829,7 @@ NAME in FProto || __webpack_require__(8) && dP(FProto, NAME, {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 229 */
-=======
-/* 231 */
->>>>>>> Ensure chips have a name before submitting values
+/* 230 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38399,11 +37850,7 @@ if (!(HAS_INSTANCE in FunctionProto)) __webpack_require__(9).f(FunctionProto, HA
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 230 */
-=======
-/* 232 */
->>>>>>> Ensure chips have a name before submitting values
+/* 231 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38412,11 +37859,7 @@ var $parseInt = __webpack_require__(135);
 $export($export.G + $export.F * (parseInt != $parseInt), { parseInt: $parseInt });
 
 /***/ }),
-<<<<<<< HEAD
-/* 231 */
-=======
-/* 233 */
->>>>>>> Ensure chips have a name before submitting values
+/* 232 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38425,11 +37868,7 @@ var $parseFloat = __webpack_require__(136);
 $export($export.G + $export.F * (parseFloat != $parseFloat), { parseFloat: $parseFloat });
 
 /***/ }),
-<<<<<<< HEAD
-/* 232 */
-=======
-/* 234 */
->>>>>>> Ensure chips have a name before submitting values
+/* 233 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38507,11 +37946,7 @@ if (!$Number(' 0o1') || !$Number('0b1') || $Number('+0x1')) {
 }
 
 /***/ }),
-<<<<<<< HEAD
-/* 233 */
-=======
-/* 235 */
->>>>>>> Ensure chips have a name before submitting values
+/* 234 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38627,11 +38062,7 @@ $export($export.P + $export.F * (!!$toFixed && (0.00008.toFixed(3) !== '0.000' |
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 234 */
-=======
-/* 236 */
->>>>>>> Ensure chips have a name before submitting values
+/* 235 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38656,11 +38087,7 @@ $export($export.P + $export.F * ($fails(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 235 */
-=======
-/* 237 */
->>>>>>> Ensure chips have a name before submitting values
+/* 236 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.1 Number.EPSILON
@@ -38669,11 +38096,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { EPSILON: Math.pow(2, -52) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 236 */
-=======
-/* 238 */
->>>>>>> Ensure chips have a name before submitting values
+/* 237 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.2 Number.isFinite(number)
@@ -38687,11 +38110,7 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 237 */
-=======
-/* 239 */
->>>>>>> Ensure chips have a name before submitting values
+/* 238 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.3 Number.isInteger(number)
@@ -38700,11 +38119,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { isInteger: __webpack_require__(138) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 238 */
-=======
-/* 240 */
->>>>>>> Ensure chips have a name before submitting values
+/* 239 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.4 Number.isNaN(number)
@@ -38718,11 +38133,7 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 239 */
-=======
-/* 241 */
->>>>>>> Ensure chips have a name before submitting values
+/* 240 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.5 Number.isSafeInteger(number)
@@ -38737,11 +38148,7 @@ $export($export.S, 'Number', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 240 */
-=======
-/* 242 */
->>>>>>> Ensure chips have a name before submitting values
+/* 241 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.6 Number.MAX_SAFE_INTEGER
@@ -38750,11 +38157,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { MAX_SAFE_INTEGER: 0x1fffffffffffff });
 
 /***/ }),
-<<<<<<< HEAD
-/* 241 */
-=======
-/* 243 */
->>>>>>> Ensure chips have a name before submitting values
+/* 242 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.1.2.10 Number.MIN_SAFE_INTEGER
@@ -38763,11 +38166,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Number', { MIN_SAFE_INTEGER: -0x1fffffffffffff });
 
 /***/ }),
-<<<<<<< HEAD
-/* 242 */
-=======
-/* 244 */
->>>>>>> Ensure chips have a name before submitting values
+/* 243 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38776,11 +38175,7 @@ var $parseFloat = __webpack_require__(136);
 $export($export.S + $export.F * (Number.parseFloat != $parseFloat), 'Number', { parseFloat: $parseFloat });
 
 /***/ }),
-<<<<<<< HEAD
-/* 243 */
-=======
-/* 245 */
->>>>>>> Ensure chips have a name before submitting values
+/* 244 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -38789,11 +38184,7 @@ var $parseInt = __webpack_require__(135);
 $export($export.S + $export.F * (Number.parseInt != $parseInt), 'Number', { parseInt: $parseInt });
 
 /***/ }),
-<<<<<<< HEAD
-/* 244 */
-=======
-/* 246 */
->>>>>>> Ensure chips have a name before submitting values
+/* 245 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.3 Math.acosh(x)
@@ -38813,11 +38204,7 @@ $export($export.S + $export.F * !($acosh
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 245 */
-=======
-/* 247 */
->>>>>>> Ensure chips have a name before submitting values
+/* 246 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.5 Math.asinh(x)
@@ -38832,11 +38219,7 @@ function asinh(x) {
 $export($export.S + $export.F * !($asinh && 1 / $asinh(0) > 0), 'Math', { asinh: asinh });
 
 /***/ }),
-<<<<<<< HEAD
-/* 246 */
-=======
-/* 248 */
->>>>>>> Ensure chips have a name before submitting values
+/* 247 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.7 Math.atanh(x)
@@ -38851,11 +38234,7 @@ $export($export.S + $export.F * !($atanh && 1 / $atanh(-0) < 0), 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 247 */
-=======
-/* 249 */
->>>>>>> Ensure chips have a name before submitting values
+/* 248 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.9 Math.cbrt(x)
@@ -38869,11 +38248,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 248 */
-=======
-/* 250 */
->>>>>>> Ensure chips have a name before submitting values
+/* 249 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.11 Math.clz32(x)
@@ -38886,11 +38261,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 249 */
-=======
-/* 251 */
->>>>>>> Ensure chips have a name before submitting values
+/* 250 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.12 Math.cosh(x)
@@ -38904,11 +38275,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 250 */
-=======
-/* 252 */
->>>>>>> Ensure chips have a name before submitting values
+/* 251 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.14 Math.expm1(x)
@@ -38918,11 +38285,7 @@ var $expm1 = __webpack_require__(98);
 $export($export.S + $export.F * ($expm1 != Math.expm1), 'Math', { expm1: $expm1 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 251 */
-=======
-/* 253 */
->>>>>>> Ensure chips have a name before submitting values
+/* 252 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.16 Math.fround(x)
@@ -38931,11 +38294,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { fround: __webpack_require__(140) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 252 */
-=======
-/* 254 */
->>>>>>> Ensure chips have a name before submitting values
+/* 253 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.17 Math.hypot([value1[, value2[, … ]]])
@@ -38966,11 +38325,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 253 */
-=======
-/* 255 */
->>>>>>> Ensure chips have a name before submitting values
+/* 254 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.18 Math.imul(x, y)
@@ -38992,11 +38347,7 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 254 */
-=======
-/* 256 */
->>>>>>> Ensure chips have a name before submitting values
+/* 255 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.21 Math.log10(x)
@@ -39009,11 +38360,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 255 */
-=======
-/* 257 */
->>>>>>> Ensure chips have a name before submitting values
+/* 256 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.20 Math.log1p(x)
@@ -39022,11 +38369,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { log1p: __webpack_require__(139) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 256 */
-=======
-/* 258 */
->>>>>>> Ensure chips have a name before submitting values
+/* 257 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.22 Math.log2(x)
@@ -39039,11 +38382,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 257 */
-=======
-/* 259 */
->>>>>>> Ensure chips have a name before submitting values
+/* 258 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.28 Math.sign(x)
@@ -39052,11 +38391,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { sign: __webpack_require__(97) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 258 */
-=======
-/* 260 */
->>>>>>> Ensure chips have a name before submitting values
+/* 259 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.30 Math.sinh(x)
@@ -39074,11 +38409,7 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 259 */
-=======
-/* 261 */
->>>>>>> Ensure chips have a name before submitting values
+/* 260 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.33 Math.tanh(x)
@@ -39095,11 +38426,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 260 */
-=======
-/* 262 */
->>>>>>> Ensure chips have a name before submitting values
+/* 261 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.2.2.34 Math.trunc(x)
@@ -39112,11 +38439,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 261 */
-=======
-/* 263 */
->>>>>>> Ensure chips have a name before submitting values
+/* 262 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -39142,11 +38465,7 @@ $export($export.S + $export.F * (!!$fromCodePoint && $fromCodePoint.length != 1)
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 262 */
-=======
-/* 264 */
->>>>>>> Ensure chips have a name before submitting values
+/* 263 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -39169,11 +38488,7 @@ $export($export.S, 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 263 */
-=======
-/* 265 */
->>>>>>> Ensure chips have a name before submitting values
+/* 264 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39187,11 +38502,7 @@ __webpack_require__(51)('trim', function ($trim) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 264 */
-=======
-/* 266 */
->>>>>>> Ensure chips have a name before submitting values
+/* 265 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39215,11 +38526,7 @@ __webpack_require__(99)(String, 'String', function (iterated) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 265 */
-=======
-/* 267 */
->>>>>>> Ensure chips have a name before submitting values
+/* 266 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39235,11 +38542,7 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 266 */
-=======
-/* 268 */
->>>>>>> Ensure chips have a name before submitting values
+/* 267 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39264,11 +38567,7 @@ $export($export.P + $export.F * __webpack_require__(102)(ENDS_WITH), 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 267 */
-=======
-/* 269 */
->>>>>>> Ensure chips have a name before submitting values
+/* 268 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39286,11 +38585,7 @@ $export($export.P + $export.F * __webpack_require__(102)(INCLUDES), 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 268 */
-=======
-/* 270 */
->>>>>>> Ensure chips have a name before submitting values
+/* 269 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -39301,11 +38596,7 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 269 */
-=======
-/* 271 */
->>>>>>> Ensure chips have a name before submitting values
+/* 270 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39328,11 +38619,7 @@ $export($export.P + $export.F * __webpack_require__(102)(STARTS_WITH), 'String',
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 270 */
-=======
-/* 272 */
->>>>>>> Ensure chips have a name before submitting values
+/* 271 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39346,11 +38633,7 @@ __webpack_require__(16)('anchor', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 271 */
-=======
-/* 273 */
->>>>>>> Ensure chips have a name before submitting values
+/* 272 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39364,11 +38647,7 @@ __webpack_require__(16)('big', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 272 */
-=======
-/* 274 */
->>>>>>> Ensure chips have a name before submitting values
+/* 273 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39382,11 +38661,7 @@ __webpack_require__(16)('blink', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 273 */
-=======
-/* 275 */
->>>>>>> Ensure chips have a name before submitting values
+/* 274 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39400,11 +38675,7 @@ __webpack_require__(16)('bold', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 274 */
-=======
-/* 276 */
->>>>>>> Ensure chips have a name before submitting values
+/* 275 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39418,11 +38689,7 @@ __webpack_require__(16)('fixed', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 275 */
-=======
-/* 277 */
->>>>>>> Ensure chips have a name before submitting values
+/* 276 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39436,11 +38703,7 @@ __webpack_require__(16)('fontcolor', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 276 */
-=======
-/* 278 */
->>>>>>> Ensure chips have a name before submitting values
+/* 277 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39454,11 +38717,7 @@ __webpack_require__(16)('fontsize', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 277 */
-=======
-/* 279 */
->>>>>>> Ensure chips have a name before submitting values
+/* 278 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39472,11 +38731,7 @@ __webpack_require__(16)('italics', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 278 */
-=======
-/* 280 */
->>>>>>> Ensure chips have a name before submitting values
+/* 279 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39490,11 +38745,7 @@ __webpack_require__(16)('link', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 279 */
-=======
-/* 281 */
->>>>>>> Ensure chips have a name before submitting values
+/* 280 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39508,11 +38759,7 @@ __webpack_require__(16)('small', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 280 */
-=======
-/* 282 */
->>>>>>> Ensure chips have a name before submitting values
+/* 281 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39526,11 +38773,7 @@ __webpack_require__(16)('strike', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 281 */
-=======
-/* 283 */
->>>>>>> Ensure chips have a name before submitting values
+/* 282 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39544,11 +38787,7 @@ __webpack_require__(16)('sub', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 282 */
-=======
-/* 284 */
->>>>>>> Ensure chips have a name before submitting values
+/* 283 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39562,11 +38801,7 @@ __webpack_require__(16)('sup', function (createHTML) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 283 */
-=======
-/* 285 */
->>>>>>> Ensure chips have a name before submitting values
+/* 284 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.3.3.1 / 15.9.4.4 Date.now()
@@ -39577,11 +38812,7 @@ $export($export.S, 'Date', { now: function now() {
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 284 */
-=======
-/* 286 */
->>>>>>> Ensure chips have a name before submitting values
+/* 285 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39605,20 +38836,12 @@ $export($export.P + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 285 */
-=======
-/* 287 */
->>>>>>> Ensure chips have a name before submitting values
+/* 286 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 20.3.4.36 / 15.9.5.43 Date.prototype.toISOString()
 var $export = __webpack_require__(0);
-<<<<<<< HEAD
-var toISOString = __webpack_require__(286);
-=======
-var toISOString = __webpack_require__(288);
->>>>>>> Ensure chips have a name before submitting values
+var toISOString = __webpack_require__(287);
 
 // PhantomJS / old WebKit has a broken implementations
 $export($export.P + $export.F * (Date.prototype.toISOString !== toISOString), 'Date', {
@@ -39626,11 +38849,7 @@ $export($export.P + $export.F * (Date.prototype.toISOString !== toISOString), 'D
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 286 */
-=======
-/* 288 */
->>>>>>> Ensure chips have a name before submitting values
+/* 287 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39660,11 +38879,7 @@ module.exports = fails(function () {
 } : $toISOString;
 
 /***/ }),
-<<<<<<< HEAD
-/* 287 */
-=======
-/* 289 */
->>>>>>> Ensure chips have a name before submitting values
+/* 288 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var DateProto = Date.prototype;
@@ -39681,27 +38896,16 @@ if (new Date(NaN) + '' != INVALID_DATE) {
 }
 
 /***/ }),
-<<<<<<< HEAD
-/* 288 */
-=======
-/* 290 */
->>>>>>> Ensure chips have a name before submitting values
+/* 289 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var TO_PRIMITIVE = __webpack_require__(6)('toPrimitive');
 var proto = Date.prototype;
 
-<<<<<<< HEAD
-if (!(TO_PRIMITIVE in proto)) __webpack_require__(14)(proto, TO_PRIMITIVE, __webpack_require__(289));
+if (!(TO_PRIMITIVE in proto)) __webpack_require__(14)(proto, TO_PRIMITIVE, __webpack_require__(290));
 
 /***/ }),
-/* 289 */
-=======
-if (!(TO_PRIMITIVE in proto)) __webpack_require__(14)(proto, TO_PRIMITIVE, __webpack_require__(291));
-
-/***/ }),
-/* 291 */
->>>>>>> Ensure chips have a name before submitting values
+/* 290 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39717,11 +38921,7 @@ module.exports = function (hint) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 290 */
-=======
-/* 292 */
->>>>>>> Ensure chips have a name before submitting values
+/* 291 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.2.2 / 15.4.3.2 Array.isArray(arg)
@@ -39730,11 +38930,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Array', { isArray: __webpack_require__(70) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 291 */
-=======
-/* 293 */
->>>>>>> Ensure chips have a name before submitting values
+/* 292 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39780,11 +38976,7 @@ $export($export.S + $export.F * !__webpack_require__(73)(function (iter) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 292 */
-=======
-/* 294 */
->>>>>>> Ensure chips have a name before submitting values
+/* 293 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39811,11 +39003,7 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 293 */
-=======
-/* 295 */
->>>>>>> Ensure chips have a name before submitting values
+/* 294 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39834,11 +39022,7 @@ $export($export.P + $export.F * (__webpack_require__(54) != Object || !__webpack
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 294 */
-=======
-/* 296 */
->>>>>>> Ensure chips have a name before submitting values
+/* 295 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39872,11 +39056,7 @@ $export($export.P + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 295 */
-=======
-/* 297 */
->>>>>>> Ensure chips have a name before submitting values
+/* 296 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39904,11 +39084,7 @@ $export($export.P + $export.F * (fails(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 296 */
-=======
-/* 298 */
->>>>>>> Ensure chips have a name before submitting values
+/* 297 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39926,11 +39102,7 @@ $export($export.P + $export.F * !STRICT, 'Array', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 297 */
-=======
-/* 299 */
->>>>>>> Ensure chips have a name before submitting values
+/* 298 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(5);
@@ -39951,11 +39123,7 @@ module.exports = function (original) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 298 */
-=======
-/* 300 */
->>>>>>> Ensure chips have a name before submitting values
+/* 299 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39972,11 +39140,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].map, true), 'Array',
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 299 */
-=======
-/* 301 */
->>>>>>> Ensure chips have a name before submitting values
+/* 300 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39993,11 +39157,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].filter, true), 'Arra
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 300 */
-=======
-/* 302 */
->>>>>>> Ensure chips have a name before submitting values
+/* 301 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40014,11 +39174,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].some, true), 'Array'
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 301 */
-=======
-/* 303 */
->>>>>>> Ensure chips have a name before submitting values
+/* 302 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40035,11 +39191,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].every, true), 'Array
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 302 */
-=======
-/* 304 */
->>>>>>> Ensure chips have a name before submitting values
+/* 303 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40056,11 +39208,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].reduce, true), 'Arra
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 303 */
-=======
-/* 305 */
->>>>>>> Ensure chips have a name before submitting values
+/* 304 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40077,11 +39225,7 @@ $export($export.P + $export.F * !__webpack_require__(25)([].reduceRight, true), 
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 304 */
-=======
-/* 306 */
->>>>>>> Ensure chips have a name before submitting values
+/* 305 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40102,11 +39246,7 @@ $export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(25)($nati
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 305 */
-=======
-/* 307 */
->>>>>>> Ensure chips have a name before submitting values
+/* 306 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40136,11 +39276,7 @@ $export($export.P + $export.F * (NEGATIVE_ZERO || !__webpack_require__(25)($nati
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 306 */
-=======
-/* 308 */
->>>>>>> Ensure chips have a name before submitting values
+/* 307 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.3.3 Array.prototype.copyWithin(target, start, end = this.length)
@@ -40151,11 +39287,7 @@ $export($export.P, 'Array', { copyWithin: __webpack_require__(143) });
 __webpack_require__(35)('copyWithin');
 
 /***/ }),
-<<<<<<< HEAD
-/* 307 */
-=======
-/* 309 */
->>>>>>> Ensure chips have a name before submitting values
+/* 308 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 22.1.3.6 Array.prototype.fill(value, start = 0, end = this.length)
@@ -40166,11 +39298,7 @@ $export($export.P, 'Array', { fill: __webpack_require__(107) });
 __webpack_require__(35)('fill');
 
 /***/ }),
-<<<<<<< HEAD
-/* 308 */
-=======
-/* 310 */
->>>>>>> Ensure chips have a name before submitting values
+/* 309 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40193,11 +39321,7 @@ $export($export.P + $export.F * forced, 'Array', {
 __webpack_require__(35)(KEY);
 
 /***/ }),
-<<<<<<< HEAD
-/* 309 */
-=======
-/* 311 */
->>>>>>> Ensure chips have a name before submitting values
+/* 310 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40220,21 +39344,13 @@ $export($export.P + $export.F * forced, 'Array', {
 __webpack_require__(35)(KEY);
 
 /***/ }),
-<<<<<<< HEAD
-/* 310 */
-=======
-/* 312 */
->>>>>>> Ensure chips have a name before submitting values
+/* 311 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(42)('Array');
 
 /***/ }),
-<<<<<<< HEAD
-/* 311 */
-=======
-/* 313 */
->>>>>>> Ensure chips have a name before submitting values
+/* 312 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
@@ -40283,11 +39399,7 @@ if (__webpack_require__(8) && (!CORRECT_NEW || __webpack_require__(4)(function (
 __webpack_require__(42)('RegExp');
 
 /***/ }),
-<<<<<<< HEAD
-/* 312 */
-=======
-/* 314 */
->>>>>>> Ensure chips have a name before submitting values
+/* 313 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40320,11 +39432,7 @@ if (__webpack_require__(4)(function () {
 }
 
 /***/ }),
-<<<<<<< HEAD
-/* 313 */
-=======
-/* 315 */
->>>>>>> Ensure chips have a name before submitting values
+/* 314 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40369,11 +39477,7 @@ __webpack_require__(75)('match', 1, function (defined, MATCH, $match, maybeCallN
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 314 */
-=======
-/* 316 */
->>>>>>> Ensure chips have a name before submitting values
+/* 315 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40500,11 +39604,7 @@ __webpack_require__(75)('replace', 2, function (defined, REPLACE, $replace, mayb
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 315 */
-=======
-/* 317 */
->>>>>>> Ensure chips have a name before submitting values
+/* 316 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40540,11 +39640,7 @@ __webpack_require__(75)('search', 1, function (defined, SEARCH, $search, maybeCa
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 316 */
-=======
-/* 318 */
->>>>>>> Ensure chips have a name before submitting values
+/* 317 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40667,11 +39763,7 @@ __webpack_require__(75)('split', 2, function (defined, SPLIT, $split, maybeCallN
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 317 */
-=======
-/* 319 */
->>>>>>> Ensure chips have a name before submitting values
+/* 318 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40961,11 +40053,7 @@ $export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(73)(function
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 318 */
-=======
-/* 320 */
->>>>>>> Ensure chips have a name before submitting values
+/* 319 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40988,11 +40076,7 @@ __webpack_require__(77)(WEAK_SET, function (get) {
 }, weak, false, true);
 
 /***/ }),
-<<<<<<< HEAD
-/* 319 */
-=======
-/* 321 */
->>>>>>> Ensure chips have a name before submitting values
+/* 320 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41045,11 +40129,7 @@ $export($export.P + $export.U + $export.F * __webpack_require__(4)(function () {
 __webpack_require__(42)(ARRAY_BUFFER);
 
 /***/ }),
-<<<<<<< HEAD
-/* 320 */
-=======
-/* 322 */
->>>>>>> Ensure chips have a name before submitting values
+/* 321 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -41058,11 +40138,7 @@ $export($export.G + $export.W + $export.F * !__webpack_require__(78).ABV, {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 321 */
-=======
-/* 323 */
->>>>>>> Ensure chips have a name before submitting values
+/* 322 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Int8', 1, function (init) {
@@ -41072,11 +40148,7 @@ __webpack_require__(31)('Int8', 1, function (init) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 322 */
-=======
-/* 324 */
->>>>>>> Ensure chips have a name before submitting values
+/* 323 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Uint8', 1, function (init) {
@@ -41086,11 +40158,7 @@ __webpack_require__(31)('Uint8', 1, function (init) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 323 */
-=======
-/* 325 */
->>>>>>> Ensure chips have a name before submitting values
+/* 324 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Uint8', 1, function (init) {
@@ -41100,11 +40168,7 @@ __webpack_require__(31)('Uint8', 1, function (init) {
 }, true);
 
 /***/ }),
-<<<<<<< HEAD
-/* 324 */
-=======
-/* 326 */
->>>>>>> Ensure chips have a name before submitting values
+/* 325 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Int16', 2, function (init) {
@@ -41114,11 +40178,7 @@ __webpack_require__(31)('Int16', 2, function (init) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 325 */
-=======
-/* 327 */
->>>>>>> Ensure chips have a name before submitting values
+/* 326 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Uint16', 2, function (init) {
@@ -41128,11 +40188,7 @@ __webpack_require__(31)('Uint16', 2, function (init) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 326 */
-=======
-/* 328 */
->>>>>>> Ensure chips have a name before submitting values
+/* 327 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Int32', 4, function (init) {
@@ -41142,11 +40198,7 @@ __webpack_require__(31)('Int32', 4, function (init) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 327 */
-=======
-/* 329 */
->>>>>>> Ensure chips have a name before submitting values
+/* 328 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Uint32', 4, function (init) {
@@ -41156,11 +40208,7 @@ __webpack_require__(31)('Uint32', 4, function (init) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 328 */
-=======
-/* 330 */
->>>>>>> Ensure chips have a name before submitting values
+/* 329 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Float32', 4, function (init) {
@@ -41170,11 +40218,7 @@ __webpack_require__(31)('Float32', 4, function (init) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 329 */
-=======
-/* 331 */
->>>>>>> Ensure chips have a name before submitting values
+/* 330 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(31)('Float64', 8, function (init) {
@@ -41184,11 +40228,7 @@ __webpack_require__(31)('Float64', 8, function (init) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 330 */
-=======
-/* 332 */
->>>>>>> Ensure chips have a name before submitting values
+/* 331 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.1 Reflect.apply(target, thisArgument, argumentsList)
@@ -41209,11 +40249,7 @@ $export($export.S + $export.F * !__webpack_require__(4)(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 331 */
-=======
-/* 333 */
->>>>>>> Ensure chips have a name before submitting values
+/* 332 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.2 Reflect.construct(target, argumentsList [, newTarget])
@@ -41270,11 +40306,7 @@ $export($export.S + $export.F * (NEW_TARGET_BUG || ARGS_BUG), 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 332 */
-=======
-/* 334 */
->>>>>>> Ensure chips have a name before submitting values
+/* 333 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.3 Reflect.defineProperty(target, propertyKey, attributes)
@@ -41302,11 +40334,7 @@ $export($export.S + $export.F * __webpack_require__(4)(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 333 */
-=======
-/* 335 */
->>>>>>> Ensure chips have a name before submitting values
+/* 334 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.4 Reflect.deleteProperty(target, propertyKey)
@@ -41322,11 +40350,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 334 */
-=======
-/* 336 */
->>>>>>> Ensure chips have a name before submitting values
+/* 335 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41361,11 +40385,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 335 */
-=======
-/* 337 */
->>>>>>> Ensure chips have a name before submitting values
+/* 336 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.6 Reflect.get(target, propertyKey [, receiver])
@@ -41387,11 +40407,7 @@ function get(target, propertyKey /* , receiver */) {
 $export($export.S, 'Reflect', { get: get });
 
 /***/ }),
-<<<<<<< HEAD
-/* 336 */
-=======
-/* 338 */
->>>>>>> Ensure chips have a name before submitting values
+/* 337 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.7 Reflect.getOwnPropertyDescriptor(target, propertyKey)
@@ -41406,11 +40422,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 337 */
-=======
-/* 339 */
->>>>>>> Ensure chips have a name before submitting values
+/* 338 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.8 Reflect.getPrototypeOf(target)
@@ -41425,11 +40437,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 338 */
-=======
-/* 340 */
->>>>>>> Ensure chips have a name before submitting values
+/* 339 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.9 Reflect.has(target, propertyKey)
@@ -41442,11 +40450,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 339 */
-=======
-/* 341 */
->>>>>>> Ensure chips have a name before submitting values
+/* 340 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.10 Reflect.isExtensible(target)
@@ -41462,11 +40466,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 340 */
-=======
-/* 342 */
->>>>>>> Ensure chips have a name before submitting values
+/* 341 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.11 Reflect.ownKeys(target)
@@ -41475,11 +40475,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Reflect', { ownKeys: __webpack_require__(155) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 341 */
-=======
-/* 343 */
->>>>>>> Ensure chips have a name before submitting values
+/* 342 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.12 Reflect.preventExtensions(target)
@@ -41500,11 +40496,7 @@ $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 342 */
-=======
-/* 344 */
->>>>>>> Ensure chips have a name before submitting values
+/* 343 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.13 Reflect.set(target, propertyKey, V [, receiver])
@@ -41542,11 +40534,7 @@ function set(target, propertyKey, V /* , receiver */) {
 $export($export.S, 'Reflect', { set: set });
 
 /***/ }),
-<<<<<<< HEAD
-/* 343 */
-=======
-/* 345 */
->>>>>>> Ensure chips have a name before submitting values
+/* 344 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 26.1.14 Reflect.setPrototypeOf(target, proto)
@@ -41566,11 +40554,7 @@ if (setProto) $export($export.S, 'Reflect', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 344 */
-=======
-/* 346 */
->>>>>>> Ensure chips have a name before submitting values
+/* 345 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41589,11 +40573,7 @@ $export($export.P, 'Array', {
 __webpack_require__(35)('includes');
 
 /***/ }),
-<<<<<<< HEAD
-/* 345 */
-=======
-/* 347 */
->>>>>>> Ensure chips have a name before submitting values
+/* 346 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41622,11 +40602,7 @@ $export($export.P, 'Array', {
 __webpack_require__(35)('flatMap');
 
 /***/ }),
-<<<<<<< HEAD
-/* 346 */
-=======
-/* 348 */
->>>>>>> Ensure chips have a name before submitting values
+/* 347 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41654,11 +40630,7 @@ $export($export.P, 'Array', {
 __webpack_require__(35)('flatten');
 
 /***/ }),
-<<<<<<< HEAD
-/* 347 */
-=======
-/* 349 */
->>>>>>> Ensure chips have a name before submitting values
+/* 348 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41675,11 +40647,7 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 348 */
-=======
-/* 350 */
->>>>>>> Ensure chips have a name before submitting values
+/* 349 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41700,11 +40668,7 @@ $export($export.P + $export.F * WEBKIT_BUG, 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 349 */
-=======
-/* 351 */
->>>>>>> Ensure chips have a name before submitting values
+/* 350 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41725,11 +40689,7 @@ $export($export.P + $export.F * WEBKIT_BUG, 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 350 */
-=======
-/* 352 */
->>>>>>> Ensure chips have a name before submitting values
+/* 351 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41743,11 +40703,7 @@ __webpack_require__(51)('trimLeft', function ($trim) {
 }, 'trimStart');
 
 /***/ }),
-<<<<<<< HEAD
-/* 351 */
-=======
-/* 353 */
->>>>>>> Ensure chips have a name before submitting values
+/* 352 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41761,11 +40717,7 @@ __webpack_require__(51)('trimRight', function ($trim) {
 }, 'trimEnd');
 
 /***/ }),
-<<<<<<< HEAD
-/* 352 */
-=======
-/* 354 */
->>>>>>> Ensure chips have a name before submitting values
+/* 353 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41802,31 +40754,19 @@ $export($export.P, 'String', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 353 */
-=======
-/* 355 */
->>>>>>> Ensure chips have a name before submitting values
+/* 354 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(89)('asyncIterator');
 
 /***/ }),
-<<<<<<< HEAD
-/* 354 */
-=======
-/* 356 */
->>>>>>> Ensure chips have a name before submitting values
+/* 355 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(89)('observable');
 
 /***/ }),
-<<<<<<< HEAD
-/* 355 */
-=======
-/* 357 */
->>>>>>> Ensure chips have a name before submitting values
+/* 356 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-getownpropertydescriptors
@@ -41853,11 +40793,7 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 356 */
-=======
-/* 358 */
->>>>>>> Ensure chips have a name before submitting values
+/* 357 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-values-entries
@@ -41871,11 +40807,7 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 357 */
-=======
-/* 359 */
->>>>>>> Ensure chips have a name before submitting values
+/* 358 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-object-values-entries
@@ -41889,11 +40821,7 @@ $export($export.S, 'Object', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 358 */
-=======
-/* 360 */
->>>>>>> Ensure chips have a name before submitting values
+/* 359 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41912,11 +40840,7 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(79), 'Object',
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 359 */
-=======
-/* 361 */
->>>>>>> Ensure chips have a name before submitting values
+/* 360 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41935,11 +40859,7 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(79), 'Object',
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 360 */
-=======
-/* 362 */
->>>>>>> Ensure chips have a name before submitting values
+/* 361 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41964,11 +40884,7 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(79), 'Object',
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 361 */
-=======
-/* 363 */
->>>>>>> Ensure chips have a name before submitting values
+/* 362 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -41993,11 +40909,7 @@ __webpack_require__(8) && $export($export.P + __webpack_require__(79), 'Object',
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 362 */
-=======
-/* 364 */
->>>>>>> Ensure chips have a name before submitting values
+/* 363 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
@@ -42006,11 +40918,7 @@ var $export = __webpack_require__(0);
 $export($export.P + $export.R, 'Map', { toJSON: __webpack_require__(159)('Map') });
 
 /***/ }),
-<<<<<<< HEAD
-/* 363 */
-=======
-/* 365 */
->>>>>>> Ensure chips have a name before submitting values
+/* 364 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/DavidBruant/Map-Set.prototype.toJSON
@@ -42019,99 +40927,63 @@ var $export = __webpack_require__(0);
 $export($export.P + $export.R, 'Set', { toJSON: __webpack_require__(159)('Set') });
 
 /***/ }),
-<<<<<<< HEAD
-/* 364 */
-=======
-/* 366 */
->>>>>>> Ensure chips have a name before submitting values
+/* 365 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-map.of
 __webpack_require__(80)('Map');
 
 /***/ }),
-<<<<<<< HEAD
-/* 365 */
-=======
-/* 367 */
->>>>>>> Ensure chips have a name before submitting values
+/* 366 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-set.of
 __webpack_require__(80)('Set');
 
 /***/ }),
-<<<<<<< HEAD
-/* 366 */
-=======
-/* 368 */
->>>>>>> Ensure chips have a name before submitting values
+/* 367 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.of
 __webpack_require__(80)('WeakMap');
 
 /***/ }),
-<<<<<<< HEAD
-/* 367 */
-=======
-/* 369 */
->>>>>>> Ensure chips have a name before submitting values
+/* 368 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.of
 __webpack_require__(80)('WeakSet');
 
 /***/ }),
-<<<<<<< HEAD
-/* 368 */
-=======
-/* 370 */
->>>>>>> Ensure chips have a name before submitting values
+/* 369 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-map.from
 __webpack_require__(81)('Map');
 
 /***/ }),
-<<<<<<< HEAD
-/* 369 */
-=======
-/* 371 */
->>>>>>> Ensure chips have a name before submitting values
+/* 370 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-set.from
 __webpack_require__(81)('Set');
 
 /***/ }),
-<<<<<<< HEAD
-/* 370 */
-=======
-/* 372 */
->>>>>>> Ensure chips have a name before submitting values
+/* 371 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakmap.from
 __webpack_require__(81)('WeakMap');
 
 /***/ }),
-<<<<<<< HEAD
-/* 371 */
-=======
-/* 373 */
->>>>>>> Ensure chips have a name before submitting values
+/* 372 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://tc39.github.io/proposal-setmap-offrom/#sec-weakset.from
 __webpack_require__(81)('WeakSet');
 
 /***/ }),
-<<<<<<< HEAD
-/* 372 */
-=======
-/* 374 */
->>>>>>> Ensure chips have a name before submitting values
+/* 373 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-global
@@ -42120,11 +40992,7 @@ var $export = __webpack_require__(0);
 $export($export.G, { global: __webpack_require__(3) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 373 */
-=======
-/* 375 */
->>>>>>> Ensure chips have a name before submitting values
+/* 374 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/tc39/proposal-global
@@ -42133,11 +41001,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'System', { global: __webpack_require__(3) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 374 */
-=======
-/* 376 */
->>>>>>> Ensure chips have a name before submitting values
+/* 375 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/ljharb/proposal-is-error
@@ -42151,11 +41015,7 @@ $export($export.S, 'Error', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 375 */
-=======
-/* 377 */
->>>>>>> Ensure chips have a name before submitting values
+/* 376 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -42168,11 +41028,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 376 */
-=======
-/* 378 */
->>>>>>> Ensure chips have a name before submitting values
+/* 377 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -42181,11 +41037,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { DEG_PER_RAD: Math.PI / 180 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 377 */
-=======
-/* 379 */
->>>>>>> Ensure chips have a name before submitting values
+/* 378 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -42199,11 +41051,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 378 */
-=======
-/* 380 */
->>>>>>> Ensure chips have a name before submitting values
+/* 379 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -42218,11 +41066,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 379 */
-=======
-/* 381 */
->>>>>>> Ensure chips have a name before submitting values
+/* 380 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -42238,11 +41082,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 380 */
-=======
-/* 382 */
->>>>>>> Ensure chips have a name before submitting values
+/* 381 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -42258,11 +41098,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 381 */
-=======
-/* 383 */
->>>>>>> Ensure chips have a name before submitting values
+/* 382 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -42283,11 +41119,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 382 */
-=======
-/* 384 */
->>>>>>> Ensure chips have a name before submitting values
+/* 383 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -42296,11 +41128,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { RAD_PER_DEG: 180 / Math.PI });
 
 /***/ }),
-<<<<<<< HEAD
-/* 383 */
-=======
-/* 385 */
->>>>>>> Ensure chips have a name before submitting values
+/* 384 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -42314,11 +41142,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 384 */
-=======
-/* 386 */
->>>>>>> Ensure chips have a name before submitting values
+/* 385 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://rwaldron.github.io/proposal-math-extensions/
@@ -42327,11 +41151,7 @@ var $export = __webpack_require__(0);
 $export($export.S, 'Math', { scale: __webpack_require__(161) });
 
 /***/ }),
-<<<<<<< HEAD
-/* 385 */
-=======
-/* 387 */
->>>>>>> Ensure chips have a name before submitting values
+/* 386 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://gist.github.com/BrendanEich/4294d5c212a6d2254703
@@ -42352,11 +41172,7 @@ $export($export.S, 'Math', {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 386 */
-=======
-/* 388 */
->>>>>>> Ensure chips have a name before submitting values
+/* 387 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // http://jfbastien.github.io/papers/Math.signbit.html
@@ -42368,11 +41184,7 @@ $export($export.S, 'Math', { signbit: function signbit(x) {
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 387 */
-=======
-/* 389 */
->>>>>>> Ensure chips have a name before submitting values
+/* 388 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42400,11 +41212,7 @@ $export($export.P + $export.R, 'Promise', { 'finally': function _finally(onFinal
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 388 */
-=======
-/* 390 */
->>>>>>> Ensure chips have a name before submitting values
+/* 389 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42423,11 +41231,7 @@ $export($export.S, 'Promise', { 'try': function _try(callbackfn) {
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 389 */
-=======
-/* 391 */
->>>>>>> Ensure chips have a name before submitting values
+/* 390 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -42440,11 +41244,7 @@ metadata.exp({ defineMetadata: function defineMetadata(metadataKey, metadataValu
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 390 */
-=======
-/* 392 */
->>>>>>> Ensure chips have a name before submitting values
+/* 391 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -42464,11 +41264,7 @@ metadata.exp({ deleteMetadata: function deleteMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 391 */
-=======
-/* 393 */
->>>>>>> Ensure chips have a name before submitting values
+/* 392 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -42490,11 +41286,7 @@ metadata.exp({ getMetadata: function getMetadata(metadataKey, target /* , target
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 392 */
-=======
-/* 394 */
->>>>>>> Ensure chips have a name before submitting values
+/* 393 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Set = __webpack_require__(151);
@@ -42518,11 +41310,7 @@ metadata.exp({ getMetadataKeys: function getMetadataKeys(target /* , targetKey *
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 393 */
-=======
-/* 395 */
->>>>>>> Ensure chips have a name before submitting values
+/* 394 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -42535,11 +41323,7 @@ metadata.exp({ getOwnMetadata: function getOwnMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 394 */
-=======
-/* 396 */
->>>>>>> Ensure chips have a name before submitting values
+/* 395 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -42552,11 +41336,7 @@ metadata.exp({ getOwnMetadataKeys: function getOwnMetadataKeys(target /* , targe
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 395 */
-=======
-/* 397 */
->>>>>>> Ensure chips have a name before submitting values
+/* 396 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -42577,11 +41357,7 @@ metadata.exp({ hasMetadata: function hasMetadata(metadataKey, target /* , target
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 396 */
-=======
-/* 398 */
->>>>>>> Ensure chips have a name before submitting values
+/* 397 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var metadata = __webpack_require__(32);
@@ -42594,11 +41370,7 @@ metadata.exp({ hasOwnMetadata: function hasOwnMetadata(metadataKey, target /* , 
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 397 */
-=======
-/* 399 */
->>>>>>> Ensure chips have a name before submitting values
+/* 398 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $metadata = __webpack_require__(32);
@@ -42614,11 +41386,7 @@ $metadata.exp({ metadata: function metadata(metadataKey, metadataValue) {
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 398 */
-=======
-/* 400 */
->>>>>>> Ensure chips have a name before submitting values
+/* 399 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-09/sept-25.md#510-globalasap-for-enqueuing-a-microtask
@@ -42635,11 +41403,7 @@ $export($export.G, {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 399 */
-=======
-/* 401 */
->>>>>>> Ensure chips have a name before submitting values
+/* 400 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42855,11 +41619,7 @@ $export($export.G, { Observable: $Observable });
 __webpack_require__(42)('Observable');
 
 /***/ }),
-<<<<<<< HEAD
-/* 400 */
-=======
-/* 402 */
->>>>>>> Ensure chips have a name before submitting values
+/* 401 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // ie9- setTimeout & setInterval additional parameters fix
@@ -42884,11 +41644,7 @@ $export($export.G + $export.B + $export.F * MSIE, {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 401 */
-=======
-/* 403 */
->>>>>>> Ensure chips have a name before submitting values
+/* 402 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $export = __webpack_require__(0);
@@ -42899,11 +41655,7 @@ $export($export.G + $export.B, {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 402 */
-=======
-/* 404 */
->>>>>>> Ensure chips have a name before submitting values
+/* 403 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var $iterators = __webpack_require__(108);
@@ -42968,11 +41720,7 @@ for (var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++
 }
 
 /***/ }),
-<<<<<<< HEAD
-/* 403 */
-=======
-/* 405 */
->>>>>>> Ensure chips have a name before submitting values
+/* 404 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global, module) {var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -43682,45 +42430,26 @@ for (var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(67), __webpack_require__(12)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 404 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(405);
-module.exports = __webpack_require__(21).RegExp.escape;
-
-/***/ }),
 /* 405 */
-=======
-/* 406 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(407);
+__webpack_require__(406);
 module.exports = __webpack_require__(21).RegExp.escape;
 
 /***/ }),
-/* 407 */
->>>>>>> Ensure chips have a name before submitting values
+/* 406 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // https://github.com/benjamingr/RexExp.escape
 var $export = __webpack_require__(0);
-<<<<<<< HEAD
-var $re = __webpack_require__(406)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
-=======
-var $re = __webpack_require__(408)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
->>>>>>> Ensure chips have a name before submitting values
+var $re = __webpack_require__(407)(/[\\^$*+?.()|[\]{}]/g, '\\$&');
 
 $export($export.S, 'RegExp', { escape: function escape(it) {
     return $re(it);
   } });
 
 /***/ }),
-<<<<<<< HEAD
-/* 406 */
-=======
-/* 408 */
->>>>>>> Ensure chips have a name before submitting values
+/* 407 */
 /***/ (function(module, exports) {
 
 module.exports = function (regExp, replace) {
@@ -43733,21 +42462,13 @@ module.exports = function (regExp, replace) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 407 */
-=======
-/* 409 */
->>>>>>> Ensure chips have a name before submitting values
+/* 408 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initButtons;
 /* unused harmony export VButton */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(408);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(410);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(409);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_ripple__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(2);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(11);
@@ -43846,11 +42567,7 @@ var VButton = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-<<<<<<< HEAD
-/* 408 */
-=======
-/* 410 */
->>>>>>> Ensure chips have a name before submitting values
+/* 409 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -45802,29 +44519,17 @@ var VButton = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 409 */
+/* 410 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(410);
-__webpack_require__(426);
-=======
-/* 411 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(412);
-__webpack_require__(428);
->>>>>>> Ensure chips have a name before submitting values
+__webpack_require__(411);
+__webpack_require__(427);
 var entryUnbind = __webpack_require__(185);
 
 module.exports = entryUnbind('Array', 'flat');
 
 /***/ }),
-<<<<<<< HEAD
-/* 410 */
-=======
-/* 412 */
->>>>>>> Ensure chips have a name before submitting values
+/* 411 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45851,11 +44556,7 @@ $({ target: 'Array', proto: true }, {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 411 */
-=======
-/* 413 */
->>>>>>> Ensure chips have a name before submitting values
+/* 412 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45875,11 +44576,7 @@ exports.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
 } : nativePropertyIsEnumerable;
 
 /***/ }),
-<<<<<<< HEAD
-/* 412 */
-=======
-/* 414 */
->>>>>>> Ensure chips have a name before submitting values
+/* 413 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(59);
@@ -45897,11 +44594,7 @@ module.exports = fails(function () {
 } : Object;
 
 /***/ }),
-<<<<<<< HEAD
-/* 413 */
-=======
-/* 415 */
->>>>>>> Ensure chips have a name before submitting values
+/* 414 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
@@ -45910,11 +44603,7 @@ var hide = __webpack_require__(62);
 var has = __webpack_require__(61);
 var setGlobal = __webpack_require__(118);
 var nativeFunctionToString = __webpack_require__(172);
-<<<<<<< HEAD
-var InternalStateModule = __webpack_require__(415);
-=======
-var InternalStateModule = __webpack_require__(417);
->>>>>>> Ensure chips have a name before submitting values
+var InternalStateModule = __webpack_require__(416);
 
 var getInternalState = InternalStateModule.get;
 var enforceInternalState = InternalStateModule.enforce;
@@ -45947,27 +44636,16 @@ shared('inspectSource', function (it) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 414 */
-=======
-/* 416 */
->>>>>>> Ensure chips have a name before submitting values
+/* 415 */
 /***/ (function(module, exports) {
 
 module.exports = false;
 
 /***/ }),
-<<<<<<< HEAD
-/* 415 */
+/* 416 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var NATIVE_WEAK_MAP = __webpack_require__(416);
-=======
-/* 417 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var NATIVE_WEAK_MAP = __webpack_require__(418);
->>>>>>> Ensure chips have a name before submitting values
+var NATIVE_WEAK_MAP = __webpack_require__(417);
 var global = __webpack_require__(26);
 var isObject = __webpack_require__(60);
 var hide = __webpack_require__(62);
@@ -46030,11 +44708,7 @@ module.exports = {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 416 */
-=======
-/* 418 */
->>>>>>> Ensure chips have a name before submitting values
+/* 417 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(26);
@@ -46045,19 +44719,11 @@ var WeakMap = global.WeakMap;
 module.exports = typeof WeakMap === 'function' && /native code/.test(nativeFunctionToString.call(WeakMap));
 
 /***/ }),
-<<<<<<< HEAD
-/* 417 */
+/* 418 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var has = __webpack_require__(61);
-var ownKeys = __webpack_require__(418);
-=======
-/* 419 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var has = __webpack_require__(61);
-var ownKeys = __webpack_require__(420);
->>>>>>> Ensure chips have a name before submitting values
+var ownKeys = __webpack_require__(419);
 var getOwnPropertyDescriptorModule = __webpack_require__(165);
 var definePropertyModule = __webpack_require__(117);
 
@@ -46072,23 +44738,13 @@ module.exports = function (target, source) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 418 */
+/* 419 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var getBuiltIn = __webpack_require__(175);
-var getOwnPropertyNamesModule = __webpack_require__(420);
-var getOwnPropertySymbolsModule = __webpack_require__(423);
+var getOwnPropertyNamesModule = __webpack_require__(421);
+var getOwnPropertySymbolsModule = __webpack_require__(424);
 var anObject = __webpack_require__(82);
-=======
-/* 420 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var getBuiltIn = __webpack_require__(175);
-var getOwnPropertyNamesModule = __webpack_require__(422);
-var getOwnPropertySymbolsModule = __webpack_require__(425);
-var anObject = __webpack_require__(81);
->>>>>>> Ensure chips have a name before submitting values
 
 // all object keys, includes non-enumerable and symbols
 module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
@@ -46098,21 +44754,13 @@ module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 419 */
-=======
-/* 421 */
->>>>>>> Ensure chips have a name before submitting values
+/* 420 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(26);
 
 /***/ }),
-<<<<<<< HEAD
-/* 420 */
-=======
-/* 422 */
->>>>>>> Ensure chips have a name before submitting values
+/* 421 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var internalObjectKeys = __webpack_require__(176);
@@ -46127,21 +44775,12 @@ exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 421 */
+/* 422 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var toIndexedObject = __webpack_require__(116);
 var toLength = __webpack_require__(84);
-var toAbsoluteIndex = __webpack_require__(422);
-=======
-/* 423 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var toIndexedObject = __webpack_require__(116);
-var toLength = __webpack_require__(83);
-var toAbsoluteIndex = __webpack_require__(424);
->>>>>>> Ensure chips have a name before submitting values
+var toAbsoluteIndex = __webpack_require__(423);
 
 // `Array.prototype.{ indexOf, includes }` methods implementation
 var createMethod = function createMethod(IS_INCLUDES) {
@@ -46173,11 +44812,7 @@ module.exports = {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 422 */
-=======
-/* 424 */
->>>>>>> Ensure chips have a name before submitting values
+/* 423 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var toInteger = __webpack_require__(120);
@@ -46194,21 +44829,13 @@ module.exports = function (index, length) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 423 */
-=======
-/* 425 */
->>>>>>> Ensure chips have a name before submitting values
+/* 424 */
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 /***/ }),
-<<<<<<< HEAD
-/* 424 */
-=======
-/* 426 */
->>>>>>> Ensure chips have a name before submitting values
+/* 425 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(59);
@@ -46231,11 +44858,7 @@ var POLYFILL = isForced.POLYFILL = 'P';
 module.exports = isForced;
 
 /***/ }),
-<<<<<<< HEAD
-/* 425 */
-=======
-/* 427 */
->>>>>>> Ensure chips have a name before submitting values
+/* 426 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(59);
@@ -46247,11 +44870,7 @@ module.exports = !!Object.getOwnPropertySymbols && !fails(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 426 */
-=======
-/* 428 */
->>>>>>> Ensure chips have a name before submitting values
+/* 427 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -46261,25 +44880,14 @@ var addToUnscopables = __webpack_require__(184);
 addToUnscopables('flat');
 
 /***/ }),
-<<<<<<< HEAD
-/* 427 */
+/* 428 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var anObject = __webpack_require__(82);
-var defineProperties = __webpack_require__(428);
+var defineProperties = __webpack_require__(429);
 var enumBugKeys = __webpack_require__(121);
 var hiddenKeys = __webpack_require__(119);
-var html = __webpack_require__(430);
-=======
-/* 429 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var anObject = __webpack_require__(81);
-var defineProperties = __webpack_require__(430);
-var enumBugKeys = __webpack_require__(121);
-var hiddenKeys = __webpack_require__(119);
-var html = __webpack_require__(432);
->>>>>>> Ensure chips have a name before submitting values
+var html = __webpack_require__(431);
 var documentCreateElement = __webpack_require__(171);
 var sharedKey = __webpack_require__(173);
 var IE_PROTO = sharedKey('IE_PROTO');
@@ -46327,22 +44935,13 @@ module.exports = Object.create || function create(O, Properties) {
 hiddenKeys[IE_PROTO] = true;
 
 /***/ }),
-<<<<<<< HEAD
-/* 428 */
-=======
-/* 430 */
->>>>>>> Ensure chips have a name before submitting values
+/* 429 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(58);
 var definePropertyModule = __webpack_require__(117);
-<<<<<<< HEAD
 var anObject = __webpack_require__(82);
-var objectKeys = __webpack_require__(429);
-=======
-var anObject = __webpack_require__(81);
-var objectKeys = __webpack_require__(431);
->>>>>>> Ensure chips have a name before submitting values
+var objectKeys = __webpack_require__(430);
 
 // `Object.defineProperties` method
 // https://tc39.github.io/ecma262/#sec-object.defineproperties
@@ -46358,11 +44957,7 @@ module.exports = DESCRIPTORS ? Object.defineProperties : function defineProperti
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 429 */
-=======
-/* 431 */
->>>>>>> Ensure chips have a name before submitting values
+/* 430 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var internalObjectKeys = __webpack_require__(176);
@@ -46375,11 +44970,7 @@ module.exports = Object.keys || function keys(O) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 430 */
-=======
-/* 432 */
->>>>>>> Ensure chips have a name before submitting values
+/* 431 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var getBuiltIn = __webpack_require__(175);
@@ -46387,11 +44978,7 @@ var getBuiltIn = __webpack_require__(175);
 module.exports = getBuiltIn('document', 'documentElement');
 
 /***/ }),
-<<<<<<< HEAD
-/* 431 */
-=======
-/* 433 */
->>>>>>> Ensure chips have a name before submitting values
+/* 432 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -46400,11 +44987,7 @@ module.exports = getBuiltIn('document', 'documentElement');
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(47);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(432);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(434);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(433);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3__material_dialog__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -46574,11 +45157,7 @@ var VDialog = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-<<<<<<< HEAD
-/* 432 */
-=======
-/* 434 */
->>>>>>> Ensure chips have a name before submitting values
+/* 433 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -50196,21 +48775,13 @@ var VDialog = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 433 */
-=======
-/* 435 */
->>>>>>> Ensure chips have a name before submitting values
+/* 434 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDateTime;
 /* unused harmony export VDateTime */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(434);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(436);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(435);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield__ = __webpack_require__(186);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__material_textfield__);
@@ -50336,11 +48907,7 @@ var VDateTime = function (_VTextField) {
 }(__WEBPACK_IMPORTED_MODULE_2__text_fields__["a" /* VTextField */]);
 
 /***/ }),
-<<<<<<< HEAD
-/* 434 */
-=======
-/* 436 */
->>>>>>> Ensure chips have a name before submitting values
+/* 435 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -52529,11 +51096,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = 
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 435 */
-=======
-/* 437 */
->>>>>>> Ensure chips have a name before submitting values
+/* 436 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -52618,24 +51181,23 @@ var VLoads = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */]);
 
 /***/ }),
-/* 436 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(437);
-
-/***/ }),
-<<<<<<< HEAD
 /* 437 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(438);
+module.exports = __webpack_require__(438);
+
+/***/ }),
+/* 438 */
+/***/ (function(module, exports, __webpack_require__) {
+
 __webpack_require__(439);
+__webpack_require__(440);
 var entryUnbind = __webpack_require__(185);
 
 module.exports = entryUnbind('Array', 'flatMap');
 
 /***/ }),
-/* 438 */
+/* 439 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52663,7 +51225,7 @@ $({ target: 'Array', proto: true }, {
 });
 
 /***/ }),
-/* 439 */
+/* 440 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -52673,7 +51235,7 @@ var addToUnscopables = __webpack_require__(184);
 addToUnscopables('flatMap');
 
 /***/ }),
-/* 440 */
+/* 441 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -52796,25 +51358,15 @@ var VUrls = function () {
 }();
 
 /***/ }),
-/* 441 */
-=======
-/* 438 */
->>>>>>> Ensure chips have a name before submitting values
+/* 442 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPosts; });
-<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(63);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(66);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(85);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(442);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(85);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(65);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(84);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(443);
->>>>>>> Ensure chips have a name before submitting values
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -53150,65 +51702,7 @@ var VPosts = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-<<<<<<< HEAD
-/* 442 */
-=======
-/* 439 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(440);
-
-/***/ }),
-/* 440 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(441);
-__webpack_require__(442);
-var entryUnbind = __webpack_require__(185);
-
-module.exports = entryUnbind('Array', 'flatMap');
-
-/***/ }),
-/* 441 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var $ = __webpack_require__(164);
-var flattenIntoArray = __webpack_require__(177);
-var toObject = __webpack_require__(181);
-var toLength = __webpack_require__(83);
-var aFunction = __webpack_require__(180);
-var arraySpeciesCreate = __webpack_require__(182);
-
-// `Array.prototype.flatMap` method
-// https://github.com/tc39/proposal-flatMap
-$({ target: 'Array', proto: true }, {
-  flatMap: function flatMap(callbackfn /* , thisArg */) {
-    var O = toObject(this);
-    var sourceLen = toLength(O.length);
-    var A;
-    aFunction(callbackfn);
-    A = arraySpeciesCreate(O, 0);
-    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
-    return A;
-  }
-});
-
-/***/ }),
-/* 442 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// this method was added to unscopables after implementation
-// in popular engines, so it's moved to a separate module
-var addToUnscopables = __webpack_require__(184);
-
-addToUnscopables('flatMap');
-
-/***/ }),
 /* 443 */
->>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -61948,17 +60442,10 @@ var VHeader = function (_eventHandlerMixin) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCTopAppBar; });
-<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(64);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(190);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(460);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(65);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(63);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(192);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(191);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(461);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(64);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(65);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(86);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(464);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(465);
@@ -62175,17 +60662,10 @@ var MDCTopAppBar = function (_MDCComponent) {
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCRipple; });
 /* unused harmony export RippleCapableSurface */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(190);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(191);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(461);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(192);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(192);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(193);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(191);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(192);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(462);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(194);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(193);
 /* unused harmony reexport MDCRippleFoundation */
 /* unused harmony reexport util */
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -62438,15 +60918,9 @@ RippleCapableSurface.prototype.disabled;
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(124);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(191);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(462);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(192);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(193);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(192);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(463);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(194);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(193);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -76954,11 +75428,7 @@ var VSelect = function (_dirtyableMixin) {
 /* harmony export (immutable) */ __webpack_exports__["a"] = initChips;
 /* unused harmony export VChip */
 /* unused harmony export VChipSet */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(193);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(195);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(194);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_chips__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(11);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
@@ -84608,11 +83078,7 @@ var VSwitch = function (_VBaseToggle) {
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRichTextArea;
 /* unused harmony export VRichTextArea */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(194);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(196);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(195);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(485);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(2);
@@ -86912,11 +85378,7 @@ module.exports = Array.isArray || function (arr) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return HorizontalRuleBlot; });
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(194);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(196);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(195);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -101679,11 +100141,7 @@ var VProgress = function (_VBaseComponent) {
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(506);
 /* harmony namespace reexport (by used) */ __webpack_require__.d(__webpack_exports__, "a", function() { return __WEBPACK_IMPORTED_MODULE_0__component__["a"]; });
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(196);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(198);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(197);
 /* unused harmony namespace reexport */
 /**
  * @license
@@ -101718,13 +100176,8 @@ var VProgress = function (_VBaseComponent) {
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgress; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(506);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(196);
-=======
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(507);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(198);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(197);
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -101830,11 +100283,7 @@ var MDCLinearProgress = /** @class */function (_super) {
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCComponent; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(125);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(195);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(197);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(196);
 /**
  * @license
  * Copyright 2016 Google Inc.

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -127,9 +127,10 @@ module.exports = function (it) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseComponent; });
-/* harmony export (immutable) */ __webpack_exports__["c"] = hookupComponentsManually;
-/* harmony export (immutable) */ __webpack_exports__["b"] = hookupComponents;
-/* harmony export (immutable) */ __webpack_exports__["d"] = unhookupComponents;
+/* harmony export (immutable) */ __webpack_exports__["d"] = hookupComponentsManually;
+/* harmony export (immutable) */ __webpack_exports__["c"] = hookupComponents;
+/* harmony export (immutable) */ __webpack_exports__["e"] = unhookupComponents;
+/* harmony export (immutable) */ __webpack_exports__["b"] = getRootNode;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_errors__ = __webpack_require__(115);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -4942,9 +4943,11 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(452);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(453);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(454);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(509);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
 
 
 
@@ -4985,9 +4988,11 @@ var VEvents = function () {
 
             var event = this.event;
             var eventParams = void 0;
+
             if (event.type === 'drop' && event.dataTransfer) {
-                //console.log('Drop Data Params: ' + event.dataTransfer.getData('text/plain'));
-                eventParams = JSON.parse(event.dataTransfer.getData('text/plain'));
+                eventParams = JSON.parse(event.dataTransfer.getData(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* DRAG_DATA_MIME_TYPE */]));
+            } else if (event.type === 'dropped') {
+                eventParams = event.detail;
             }
 
             // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries
@@ -6803,7 +6808,7 @@ function initialize(root, setRoot) {
     Object(__WEBPACK_IMPORTED_MODULE_32__progress__["a" /* initProgress */])(root);
     Object(__WEBPACK_IMPORTED_MODULE_30__tooltip__["a" /* initTooltips */])(root);
     Object(__WEBPACK_IMPORTED_MODULE_31__plugins__["a" /* initPlugins */])(root);
-    Object(__WEBPACK_IMPORTED_MODULE_33__drag_n_drop__["a" /* initDragAndDrop */])(root);
+    Object(__WEBPACK_IMPORTED_MODULE_33__drag_n_drop__["b" /* initDragAndDrop */])(root);
 
     // This needs to be last, because it relies on the components installed above.
     Object(__WEBPACK_IMPORTED_MODULE_4__events__["b" /* initEvents */])(root);
@@ -13684,7 +13689,7 @@ var AFTER_INPUT_TIMEOUT = 500; // ms
 
 function initTextFields(e) {
     console.debug('\tTextFields');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-text-field', VTextField, __WEBPACK_IMPORTED_MODULE_0__material_textfield__["MDCTextField"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-text-field', VTextField, __WEBPACK_IMPORTED_MODULE_0__material_textfield__["MDCTextField"]);
 }
 
 var VTextField = function (_dirtyableMixin) {
@@ -13900,12 +13905,12 @@ function createSurfaceClickHandler(mdcMenu) {
 
 function uninitMenus(root) {
     console.debug('\tUninit Menus');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["d" /* unhookupComponents */])(root, '.v-menu');
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["e" /* unhookupComponents */])(root, '.v-menu');
 }
 
 function initMenus(root) {
     console.debug('\tMenus');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(root, '.v-menu', VMenu, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(root, '.v-menu', VMenu, null);
 }
 
 var VMenu = function (_eventHandlerMixin) {
@@ -42275,7 +42280,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initButtons(e) {
     console.debug('\tButtons');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-button', VButton, __WEBPACK_IMPORTED_MODULE_0__material_ripple__["MDCRipple"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-button', VButton, __WEBPACK_IMPORTED_MODULE_0__material_ripple__["MDCRipple"]);
 }
 
 var VButton = function (_eventHandlerMixin) {
@@ -44838,7 +44843,7 @@ function hideDialog() {
 
 function initDialogs(e) {
     console.debug('\tDialogs');
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["b" /* hookupComponents */])(e, '.v-dialog', VDialog, __WEBPACK_IMPORTED_MODULE_3__material_dialog__["MDCDialog"]);
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponents */])(e, '.v-dialog', VDialog, __WEBPACK_IMPORTED_MODULE_3__material_dialog__["MDCDialog"]);
 }
 
 var VDialog = function (_eventHandlerMixin) {
@@ -48592,7 +48597,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initDateTime(e) {
     console.debug('\tDateTime');
-    Object(__WEBPACK_IMPORTED_MODULE_3__base_component__["b" /* hookupComponents */])(e, '.v-datetime', VDateTime, __WEBPACK_IMPORTED_MODULE_1__material_textfield__["MDCTextField"]);
+    Object(__WEBPACK_IMPORTED_MODULE_3__base_component__["c" /* hookupComponents */])(e, '.v-datetime', VDateTime, __WEBPACK_IMPORTED_MODULE_1__material_textfield__["MDCTextField"]);
 }
 
 var VDateTime = function (_VTextField) {
@@ -56792,8 +56797,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initDrawer(e) {
     console.debug('\tDrawer');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-drawer__modal', VModalDrawer, __WEBPACK_IMPORTED_MODULE_0__material_drawer__["MDCDrawer"]);
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-drawer__dismissible', VDismissibleDrawer, __WEBPACK_IMPORTED_MODULE_0__material_drawer__["MDCDrawer"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-drawer__modal', VModalDrawer, __WEBPACK_IMPORTED_MODULE_0__material_drawer__["MDCDrawer"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-drawer__dismissible', VDismissibleDrawer, __WEBPACK_IMPORTED_MODULE_0__material_drawer__["MDCDrawer"]);
 }
 
 var VDrawer = function (_eventHandlerMixin) {
@@ -60202,7 +60207,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initHeader(e) {
     console.debug('\tHeader');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-header', VHeader, __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__["a" /* MDCTopAppBar */]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-header', VHeader, __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__["a" /* MDCTopAppBar */]);
 }
 
 var VHeader = function (_eventHandlerMixin) {
@@ -62078,7 +62083,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initIconToggles(e) {
     console.debug('\tIcon Toggles');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-icon-toggle', VIconToggle, __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__["MDCIconToggle"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-icon-toggle', VIconToggle, __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__["MDCIconToggle"]);
 }
 
 var VIconToggle = function (_VBaseToggle) {
@@ -64906,7 +64911,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSelects(e) {
     console.debug('\tSelects');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-select', VSelect, __WEBPACK_IMPORTED_MODULE_0__material_select__["MDCSelect"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-select', VSelect, __WEBPACK_IMPORTED_MODULE_0__material_select__["MDCSelect"]);
 }
 
 var VSelect = function (_dirtyableMixin) {
@@ -75249,7 +75254,7 @@ function initChips(e) {
     // Because the chip set constructs chips on its own, a `hookupComponents`
     // call for chips is not needed.
 
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponentsManually */])(e, '.v-chip-set', function (element) {
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["d" /* hookupComponentsManually */])(e, '.v-chip-set', function (element) {
         var selectable = element.classList.contains(SELECTABLE_VARIANT_CLASS);
         var chipFactory = voomChipFactoryFactory(selectable);
         var mdcComponent = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["MDCChipSet"](element, undefined, chipFactory);
@@ -75373,7 +75378,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initCards(e) {
     console.debug('\tCards');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-card', VCard, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-card', VCard, null);
 }
 
 var VCard = function (_VBaseContainer) {
@@ -75410,7 +75415,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initForms(e) {
     console.debug('\tForms');
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["b" /* hookupComponents */])(e, '.v-form', VForm, null);
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponents */])(e, '.v-form', VForm, null);
 }
 
 var VForm = function (_eventHandlerMixin) {
@@ -75448,7 +75453,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSnackbar(e) {
     console.debug('\tSnackbar');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-snackbar', VSnackbar, __WEBPACK_IMPORTED_MODULE_0__material_snackbar__["MDCSnackbar"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-snackbar', VSnackbar, __WEBPACK_IMPORTED_MODULE_0__material_snackbar__["MDCSnackbar"]);
 }
 
 // This class displays a page level message
@@ -77037,7 +77042,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initCheckboxes(e) {
     console.debug('\tCheckboxes');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-checkbox', VCheckbox, __WEBPACK_IMPORTED_MODULE_2__material_checkbox__["MDCCheckbox"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-checkbox', VCheckbox, __WEBPACK_IMPORTED_MODULE_2__material_checkbox__["MDCCheckbox"]);
 }
 
 var VCheckbox = function (_VBaseToggle) {
@@ -80194,7 +80199,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSwitches(e) {
     console.debug('\tSwitches');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-switch', VSwitch, __WEBPACK_IMPORTED_MODULE_2__material_switch__["MDCSwitch"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-switch', VSwitch, __WEBPACK_IMPORTED_MODULE_2__material_switch__["MDCSwitch"]);
 }
 
 var VSwitch = function (_VBaseToggle) {
@@ -82888,7 +82893,7 @@ var EMPTY_VALUE = '';
 
 function initRichTextArea(e) {
     console.debug('\tRich Text Area');
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["b" /* hookupComponents */])(e, '.v-rich-text-area-container', VRichTextArea, null);
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponents */])(e, '.v-rich-text-area-container', VRichTextArea, null);
 }
 
 var VRichTextArea = function (_dirtyableMixin) {
@@ -85234,7 +85239,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSteppers(e) {
     console.debug('\tStepper');
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["b" /* hookupComponents */])(e, '.v-stepper', VStepper, null);
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponents */])(e, '.v-stepper', VStepper, null);
 }
 
 var VStepper = function (_eventHandlerMixin) {
@@ -85313,7 +85318,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initRadios(e) {
     console.debug('\tRadios');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-radio', VRadio, __WEBPACK_IMPORTED_MODULE_2__material_radio__["MDCRadio"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-radio', VRadio, __WEBPACK_IMPORTED_MODULE_2__material_radio__["MDCRadio"]);
 }
 
 var VRadio = function (_VBaseToggle) {
@@ -87938,7 +87943,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSliders(e) {
     console.debug('\tSliders');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-slider', VSlider, __WEBPACK_IMPORTED_MODULE_2__material_slider__["MDCSlider"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-slider', VSlider, __WEBPACK_IMPORTED_MODULE_2__material_slider__["MDCSlider"]);
 }
 
 var VSlider = function (_dirtyableMixin) {
@@ -90105,7 +90110,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initHiddenFields(e) {
     console.debug('\tHiddenFields');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-hidden-field', VHiddenField, null);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-hidden-field', VHiddenField, null);
 }
 
 var VHiddenField = function (_dirtyableMixin) {
@@ -90185,7 +90190,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initContent(e) {
     console.debug('\tContent');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-content', VContent, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-content', VContent, null);
 }
 
 var VContent = function (_eventHandlerMixin) {
@@ -90223,8 +90228,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initGrid(e) {
     console.debug('\tGrid');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-grid', VGrid, null);
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-column', VColumn, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-grid', VGrid, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-column', VColumn, null);
 }
 
 var VGrid = function (_eventHandlerMixin) {
@@ -90274,7 +90279,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initTabBars(e) {
     console.debug('\tTab Bars');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-tab-bar', VTabBar, __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__["MDCTabBar"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-tab-bar', VTabBar, __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__["MDCTabBar"]);
 }
 
 var VTabBar = function (_eventHandlerMixin) {
@@ -96949,7 +96954,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initFileInputs(e) {
     console.debug('\tFile Inputs');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-file-input', VFileInput, null);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-file-input', VFileInput, null);
 }
 
 var VFileInput = function (_dirtyableMixin) {
@@ -97086,7 +97091,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initFormFields(e) {
     console.debug('\tForm Fields');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-form-field', VFormField, __WEBPACK_IMPORTED_MODULE_2__material_form_field__["MDCFormField"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-form-field', VFormField, __WEBPACK_IMPORTED_MODULE_2__material_form_field__["MDCFormField"]);
 }
 
 var VFormField = function (_VBaseContainer) {
@@ -99629,7 +99634,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initImages(e) {
     console.debug('\tImages');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-image', VImage);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-image', VImage);
 }
 
 var VImage = function (_eventHandlerMixin) {
@@ -99674,7 +99679,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initTypography(e) {
     console.debug('\tTypography');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-typography', VTypography);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-typography', VTypography);
 }
 
 var VTypography = function (_eventHandlerMixin) {
@@ -99724,7 +99729,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initTooltips(e) {
     console.debug('\tTooltips');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-tooltip', VTooltip, MaterialTooltip);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-tooltip', VTooltip, MaterialTooltip);
 }
 
 var VTooltip = function (_eventHandlerMixin) {
@@ -99763,7 +99768,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initPlugins(e) {
     console.debug('\tPlugins');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-plugin', VPluginComponent);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-plugin', VPluginComponent);
 }
 
 // Delegating plugin class. Allows a plugin to define a class-name as a data
@@ -99878,7 +99883,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initProgress(e) {
     console.debug('\tProgress');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-progress', VProgress, __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__["a" /* MDCLinearProgress */]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-progress', VProgress, __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__["a" /* MDCLinearProgress */]);
 }
 
 var VProgress = function (_VBaseComponent) {
@@ -100308,81 +100313,147 @@ var strings = {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export (immutable) */ __webpack_exports__["a"] = initDragAndDrop;
-function createDragStartHandler() {
-    return function (e) {
-        var dragParamData = e.target.dataset.drag_params;
-        if (typeof dragParamData !== 'undefined') {
-            e.dataTransfer.setData("text/plain", dragParamData);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return DRAG_DATA_MIME_TYPE; });
+/* unused harmony export EVENT_DROPPED */
+/* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
+/*
+    A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
+    three modes:
+
+    1. read/write, during a `dragstart` event: items can be read and added
+    2. read-only, during a `drop` event: items can be read, but not added
+    3. protected, during all other types of DragEvent: items cannot be read
+       or added.
+
+    (see https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw)
+
+    Thus, attempting to mutate the store during events other than `dragstart`
+    fails silently: no error is raised, but items are not added.
+
+
+    To read items in protected mode, serialize data as a string and store it as
+    a key instead of as a value. This makes it accessible via
+    `dataTransfer.types`:
+
+    // in a dragstart handler:
+    event.dataTransfer.setData(JSON.stringify(foo), '');
+
+    // in a later read-only or protected DragEvent handler:
+    const json = event.dataTransfer.types[someIndex];
+    const foo = JSON.stringify(json);
+
+
+    There is no workaround for attempting mutating a drag data store not in
+    read/write mode.
+ */
+
+
+
+var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
+var EVENT_DROPPED = 'dropped';
+
+var ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
+
+function createDragStartHandler(root, element) {
+    return function (event) {
+        var dragParamData = event.target.dataset.drag_params;
+
+        if (dragParamData) {
+            event.dataTransfer.setData(DRAG_DATA_MIME_TYPE, dragParamData);
+
             var zone = JSON.parse(dragParamData).zone;
-            if (zone != null) {
-                e.dataTransfer.setData(zone, '');
+
+            if (zone) {
+                event.dataTransfer.setData(zone, '');
             }
-            e.dataTransfer.effectAllowed = 'move';
-            e.target.classList.remove('v-dnd-draggable');
-            e.target.classList.add('v-dnd-moving');
+
+            event.dataTransfer.effectAllowed = 'move';
+            event.target.classList.remove('v-dnd-draggable');
+            event.target.classList.add('v-dnd-moving');
+
+            event.dataTransfer.setData(ELEMENT_ID_MIME_TYPE, element.id);
         }
     };
 }
 
-// function createDragHandler() {
-//     return function (e) { }
-// }
+function createDragOverHandler(root, element) {
+    return function (event) {
+        var dropZone = element.dataset.dropzone;
 
-function createDragOverHandler() {
-    return function (e) {
-        var targetZone = this.dataset.dropzone;
-        if (targetZone == null || e.dataTransfer.types.includes(targetZone)) {
-            // We are allowing a drop if we are here
-            // Note that during a dragover event the event/dataTransfer object is in a protected and as a result
-            // cannot be read. However, we can interogate the set of types that it contains. My hack/workaround
-            // is that during dragStart I add the zone as a type and look for that here
-            if (e.preventDefault) {
-                e.preventDefault();
+        if (dropZone == null || event.dataTransfer.types.includes(dropZone)) {
+            if (event.preventDefault) {
+                event.preventDefault();
             }
-            this.classList.add('v-dnd-over');
+            element.classList.add('v-dnd-over');
         } else {
-            this.classList.remove('v-dnd-over');
+            element.classList.remove('v-dnd-over');
         }
     };
 }
 
-// function createDragEnterHandler() {
-//     return function (e) {}
-// }
-
-function createDragLeaveHandler() {
-    return function () {
-        this.classList.remove('v-dnd-over');
+function createDragLeaveHandler(root, element) {
+    return function (event) {
+        element.classList.remove('v-dnd-over');
     };
 }
 
-function createDropHandler() {
-    return function (e) {
-        if (e.stopPropagation) {
-            e.stopPropagation();
+function createDropHandler(root, element) {
+    // When an element is upgraded to a Voom component after being replaced via
+    // `replaces`, root may refer to the replaced element itself instead of the
+    // element's root node.
+    // Since a valid drop zone may exist anywhere on the page, it is not
+    // guaranteed that root contains the element being dragged.
+    // getRootNode will fetch `root`'s actual root node (document or shadow
+    // DOM root).
+    var trueRoot = Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* getRootNode */])(root);
+
+    return function (event) {
+        event.stopPropagation();
+        event.preventDefault();
+
+        var id = event.dataTransfer.getData(ELEMENT_ID_MIME_TYPE);
+        var draggedElement = id ? trueRoot.querySelector('#' + id) : null;
+        var dragParams = {};
+
+        if (draggedElement) {
+            dragParams = JSON.parse(draggedElement.dataset.drag_params);
         }
-        if (e.preventDefault) {
-            e.preventDefault();
-        }
-        this.classList.remove('v-dnd-over');
-        this.classList.remove('v-dnd-moving');
-        this.classList.add('v-dnd-draggable');
+
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
+
+        // Emit a "dropped" event for the element being dragged:
+        // The drag_params of the dragged element are merged with the
+        // drop_params of the drop zone.
+        var dropZoneParams = JSON.parse(element.dataset.drop_params);
+        var params = Object.assign({}, dragParams, dropZoneParams);
+        var droppedEvent = new CustomEvent(EVENT_DROPPED, { detail: params });
+
+        draggedElement.dispatchEvent(droppedEvent);
+
         return false;
     };
 }
 
-function createDragEndHandler() {
-    return function (e) {
-        this.classList.remove('v-dnd-over');
-        this.classList.remove('v-dnd-moving');
-        this.classList.add('v-dnd-draggable');
+function createDragEndHandler(root, element) {
+    return function (event) {
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
     };
 }
 
-function initDragAndDrop(e) {
+var DRAGGABLE_SELECTOR = '[draggable=true]';
+var DROP_ZONE_SELECTOR = '[data-dropzone]';
 
-    var draggables = document.querySelectorAll('[draggable=true]');
+function initDragAndDrop(root) {
+    var draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
+        console.log('root matches DRAGGABLE_SELECTOR');
+        draggables.unshift(root);
+    }
+
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
     var _iteratorError = undefined;
@@ -100391,9 +100462,8 @@ function initDragAndDrop(e) {
         for (var _iterator = draggables[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
             var elem = _step.value;
 
-            elem.addEventListener("dragstart", createDragStartHandler(), false);
-            // elem.addEventListener("drag", createDragHandler(), false);
-            elem.addEventListener("dragend", createDragEndHandler(), false);
+            elem.addEventListener('dragstart', createDragStartHandler(root, elem));
+            elem.addEventListener('dragend', createDragEndHandler(root, elem));
         }
     } catch (err) {
         _didIteratorError = true;
@@ -100410,7 +100480,13 @@ function initDragAndDrop(e) {
         }
     }
 
-    var dropZones = document.querySelectorAll('[data-dropzone]');
+    var dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
+        console.log('root matches DROP_ZONE_SELECTOR');
+        dropZones.unshift(root);
+    }
+
     var _iteratorNormalCompletion2 = true;
     var _didIteratorError2 = false;
     var _iteratorError2 = undefined;
@@ -100419,10 +100495,9 @@ function initDragAndDrop(e) {
         for (var _iterator2 = dropZones[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
             var _elem = _step2.value;
 
-            _elem.addEventListener("dragover", createDragOverHandler(), false);
-            _elem.addEventListener("drop", createDropHandler(), false);
-            // elem.addEventListener("dragenter", createDragEnterHandler(), false);
-            _elem.addEventListener("dragleave", createDragLeaveHandler(), false);
+            _elem.addEventListener('dragover', createDragOverHandler(root, _elem));
+            _elem.addEventListener('drop', createDropHandler(root, _elem));
+            _elem.addEventListener('dragleave', createDragLeaveHandler(root, _elem));
         }
     } catch (err) {
         _didIteratorError2 = true;

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -14058,7 +14058,7 @@ var VDialog = function () {
     const foo = JSON.stringify(json);
 
 
-    There is no workaround for attempting mutating a drag data store not in
+    There is no workaround for attempting to mutate a drag data store not in
     read/write mode.
  */
 
@@ -14164,7 +14164,6 @@ function initDragAndDrop(root) {
     var draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
 
     if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
-        console.log('root matches DRAGGABLE_SELECTOR');
         draggables.unshift(root);
     }
 
@@ -14197,7 +14196,6 @@ function initDragAndDrop(root) {
     var dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
 
     if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
-        console.log('root matches DROP_ZONE_SELECTOR');
         dropZones.unshift(root);
     }
 

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -4987,13 +4987,7 @@ var VEvents = function () {
             var _this2 = this;
 
             var event = this.event;
-            var eventParams = void 0;
-
-            if (event.type === 'drop' && event.dataTransfer) {
-                eventParams = JSON.parse(event.dataTransfer.getData(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* DRAG_DATA_MIME_TYPE */]));
-            } else if (event.type === 'dropped') {
-                eventParams = event.detail;
-            }
+            var eventParams = Object(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* extractDragDropData */])(event);
 
             // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries
             var fnlist = this.actions.map(function (action) {
@@ -14033,9 +14027,9 @@ var VDialog = function () {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return DRAG_DATA_MIME_TYPE; });
 /* unused harmony export EVENT_DROPPED */
 /* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
+/* harmony export (immutable) */ __webpack_exports__["a"] = extractDragDropData;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /*
     A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
@@ -14070,9 +14064,9 @@ var VDialog = function () {
 
 
 
-var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
 var EVENT_DROPPED = 'dropped';
 
+var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
 var ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
 
 function createDragStartHandler(root, element) {
@@ -14233,6 +14227,22 @@ function initDragAndDrop(root) {
             }
         }
     }
+}
+
+/**
+ * extractDragDropData attempts to extract a payload of drag-n-drop data from
+ * the provided event previously set during  a `dragstart` event.
+ * @param {Event} event
+ * @return {Object}
+ */
+function extractDragDropData(event) {
+    if (event.type === 'drop' && event.dataTransfer) {
+        return JSON.parse(event.dataTransfer.getData(DRAG_DATA_MIME_TYPE));
+    } else if (event.type === EVENT_DROPPED) {
+        return event.detail;
+    }
+
+    return {};
 }
 
 /***/ }),

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -4987,7 +4987,11 @@ var VEvents = function () {
             var _this2 = this;
 
             var event = this.event;
-            var eventParams = Object(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* extractDragDropData */])(event);
+            var eventParams = {};
+
+            if (Object(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["b" /* hasDragDropData */])(event)) {
+                eventParams = Object.assign(eventParams, Object(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* extractDragDropData */])(event));
+            }
 
             // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries
             var fnlist = this.actions.map(function (action) {
@@ -6802,7 +6806,7 @@ function initialize(root, setRoot) {
     Object(__WEBPACK_IMPORTED_MODULE_32__progress__["a" /* initProgress */])(root);
     Object(__WEBPACK_IMPORTED_MODULE_30__tooltip__["a" /* initTooltips */])(root);
     Object(__WEBPACK_IMPORTED_MODULE_31__plugins__["a" /* initPlugins */])(root);
-    Object(__WEBPACK_IMPORTED_MODULE_33__drag_n_drop__["b" /* initDragAndDrop */])(root);
+    Object(__WEBPACK_IMPORTED_MODULE_33__drag_n_drop__["c" /* initDragAndDrop */])(root);
 
     // This needs to be last, because it relies on the components installed above.
     Object(__WEBPACK_IMPORTED_MODULE_4__events__["b" /* initEvents */])(root);
@@ -14028,7 +14032,8 @@ var VDialog = function () {
 
 "use strict";
 /* unused harmony export EVENT_DROPPED */
-/* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
+/* harmony export (immutable) */ __webpack_exports__["c"] = initDragAndDrop;
+/* harmony export (immutable) */ __webpack_exports__["b"] = hasDragDropData;
 /* harmony export (immutable) */ __webpack_exports__["a"] = extractDragDropData;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(2);
 /*
@@ -14225,6 +14230,16 @@ function initDragAndDrop(root) {
             }
         }
     }
+}
+
+/**
+ * hasDragDropData determines whether the provided event has previously-set
+ * drag-n-drop data available.
+ * @param {Event} event
+ * @return {Boolean}
+ */
+function hasDragDropData(event) {
+    return event.type === 'drop' && event.dataTransfer || event.type === EVENT_DROPPED && event.detail;
 }
 
 /**

--- a/public/wc.js
+++ b/public/wc.js
@@ -2109,7 +2109,11 @@ var VEvents = function () {
             var _this2 = this;
 
             var event = this.event;
-            var eventParams = Object(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* extractDragDropData */])(event);
+            var eventParams = {};
+
+            if (Object(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["b" /* hasDragDropData */])(event)) {
+                eventParams = Object.assign(eventParams, Object(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* extractDragDropData */])(event));
+            }
 
             // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries
             var fnlist = this.actions.map(function (action) {
@@ -2964,7 +2968,7 @@ function initialize(root, setRoot) {
     Object(__WEBPACK_IMPORTED_MODULE_32__progress__["a" /* initProgress */])(root);
     Object(__WEBPACK_IMPORTED_MODULE_30__tooltip__["a" /* initTooltips */])(root);
     Object(__WEBPACK_IMPORTED_MODULE_31__plugins__["a" /* initPlugins */])(root);
-    Object(__WEBPACK_IMPORTED_MODULE_33__drag_n_drop__["b" /* initDragAndDrop */])(root);
+    Object(__WEBPACK_IMPORTED_MODULE_33__drag_n_drop__["c" /* initDragAndDrop */])(root);
 
     // This needs to be last, because it relies on the components installed above.
     Object(__WEBPACK_IMPORTED_MODULE_4__events__["b" /* initEvents */])(root);
@@ -10222,7 +10226,8 @@ var VDialog = function () {
 
 "use strict";
 /* unused harmony export EVENT_DROPPED */
-/* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
+/* harmony export (immutable) */ __webpack_exports__["c"] = initDragAndDrop;
+/* harmony export (immutable) */ __webpack_exports__["b"] = hasDragDropData;
 /* harmony export (immutable) */ __webpack_exports__["a"] = extractDragDropData;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /*
@@ -10419,6 +10424,16 @@ function initDragAndDrop(root) {
             }
         }
     }
+}
+
+/**
+ * hasDragDropData determines whether the provided event has previously-set
+ * drag-n-drop data available.
+ * @param {Event} event
+ * @return {Boolean}
+ */
+function hasDragDropData(event) {
+    return event.type === 'drop' && event.dataTransfer || event.type === EVENT_DROPPED && event.detail;
 }
 
 /**

--- a/public/wc.js
+++ b/public/wc.js
@@ -60,11 +60,7 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-<<<<<<< HEAD
-/******/ 	return __webpack_require__(__webpack_require__.s = 68);
-=======
-/******/ 	return __webpack_require__(__webpack_require__.s = 70);
->>>>>>> Ensure chips have a name before submitting values
+/******/ 	return __webpack_require__(__webpack_require__.s = 69);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -781,10 +777,10 @@ module.exports = DESCRIPTORS ? function (object, key, value) {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(33);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(100);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(101);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(21);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(104);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(105);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -1230,11 +1226,7 @@ module.exports = function (it) {
 
 var global = __webpack_require__(3);
 var setGlobal = __webpack_require__(24);
-<<<<<<< HEAD
-var IS_PURE = __webpack_require__(77);
-=======
-var IS_PURE = __webpack_require__(79);
->>>>>>> Ensure chips have a name before submitting values
+var IS_PURE = __webpack_require__(78);
 
 var SHARED = '__core-js_shared__';
 var store = global[SHARED] || setGlobal(SHARED, {});
@@ -1373,225 +1365,6 @@ function expandParams(results, params) {
 }
 
 /***/ }),
-<<<<<<< HEAD
-=======
-/* 18 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(33);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(103);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(21);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(59);
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-
-
-
-
-
-var VBase = function (_VUrls) {
-    _inherits(VBase, _VUrls);
-
-    function VBase(options, root) {
-        _classCallCheck(this, VBase);
-
-        var _this = _possibleConstructorReturn(this, (VBase.__proto__ || Object.getPrototypeOf(VBase)).call(this));
-
-        _this.options = options;
-        _this.root = root;
-        return _this;
-    }
-
-    _createClass(VBase, [{
-        key: 'clearErrors',
-        value: function clearErrors() {
-            new __WEBPACK_IMPORTED_MODULE_2__errors__["a" /* VErrors */](this.root).clearErrors();
-        }
-    }, {
-        key: 'parentElement',
-        value: function parentElement() {
-            return this.root.getElementById(this.options.__parent_id__);
-        }
-
-        /**
-         * taggedInputs retrieves all components matching this event's input_tag
-         * value.
-         * @return {NodeList}
-         */
-
-    }, {
-        key: 'taggedInputs',
-        value: function taggedInputs() {
-            var inputTag = this.options.input_tag;
-
-            if (!inputTag) {
-                return [];
-            }
-
-            var selector = '[data-input-tag="' + inputTag + '"]';
-            var inputs = this.root.querySelectorAll(selector);
-
-            if (inputs.length < 1) {
-                console.warn('input_tag ' + inputTag + ' matched 0 elements. Are you sure' + 'you\'ve specified the correct value?');
-            }
-
-            return inputs;
-        }
-
-        /**
-         * inputs retrieves relevant input elements for this event.
-         *
-         * - If an `input_tag` has been provided, all matching tagged elements are
-         *   included.
-         * - If this component is a input element, it is included.
-         * - If this component has input elements, its input elements are included.
-         *   If not, the input elements of the nearest container (dialog or content)
-         *   are included.
-         * @return {Array<HTMLElement>}
-         */
-
-    }, {
-        key: 'inputs',
-        value: function inputs() {
-            var components = [];
-
-            // Collect tagged components, if applicable:
-            if (this.options.input_tag) {
-                var taggedComponents = Array.from(this.taggedInputs()).filter(function (element) {
-                    return element.vComponent;
-                }).map(function (element) {
-                    return element.vComponent;
-                });
-
-                components.push(taggedComponents);
-            }
-
-            var comp = this.component();
-
-            if (comp) {
-                // Include ourselves if we're a form field component, but not a
-                // container:
-                if (comp.respondTo('prepareSubmit') && !comp.respondTo('inputs')) {
-                    components.push(comp);
-                } else if (!comp.respondTo('inputs')) {
-                    // Defer to the component's closest container (card, content,
-                    // dialog, or form) if the component itself does not respond to
-                    // `inputs`:
-                    comp = this.closestContainer();
-                }
-            }
-
-            if (comp && comp.respondTo('inputs')) {
-                components.push(comp);
-            }
-
-            // Map components to elements.
-            // Containers are mapped to their child elements.
-            // Form field components are mapped to their own element.
-            var elements = components.flat().flatMap(function (comp) {
-                if (comp.respondTo('inputs')) {
-                    return Array.from(comp.inputs());
-                } else if (comp.respondTo('prepareSubmit')) {
-                    return comp.element;
-                }
-            });
-
-            // Deduplicate:
-            return Array.from(new Set(elements));
-        }
-
-        /**
-         * inputComponents retrieves the Component for each of this event's
-         * relevant input elements.
-         * @return {Array<VBaseComponent>}
-         */
-
-    }, {
-        key: 'inputComponents',
-        value: function inputComponents() {
-            return this.inputs().filter(function (element) {
-                return element.vComponent;
-            }).map(function (element) {
-                return element.vComponent;
-            });
-        }
-
-        /**
-         * inputValues retrieves submit values for each of this event's relevant
-         * input elements.
-         * @return {Array}
-         */
-
-    }, {
-        key: 'inputValues',
-        value: function inputValues() {
-            var params = [];
-
-            this.inputComponents().filter(function (comp) {
-                return comp.respondTo('prepareSubmit');
-            }).map(function (comp) {
-                return comp.prepareSubmit(params);
-            });
-
-            return params;
-        }
-    }, {
-        key: 'component',
-        value: function component() {
-            var parent = this.parentElement();
-
-            return parent ? parent.vComponent : null;
-        }
-    }, {
-        key: 'validate',
-        value: function validate() {
-            var comp = this.component();
-
-            if (comp) {
-                return comp.validate();
-            }
-
-            return [];
-        }
-    }, {
-        key: 'closestContainer',
-        value: function closestContainer() {
-            var element = this.closestContainerElement();
-
-            if (!element) {
-                return null;
-            }
-
-            return element.vComponent;
-        }
-    }, {
-        key: 'closestContainerElement',
-        value: function closestContainerElement() {
-            var comp = this.component();
-
-            if (!(comp && comp.element)) {
-                return null;
-            }
-
-            return comp.element.closest('[data-is-container]');
-        }
-    }]);
-
-    return VBase;
-}(__WEBPACK_IMPORTED_MODULE_3__utils_urls__["a" /* VUrls */]);
-
-/***/ }),
->>>>>>> Ensure chips have a name before submitting values
 /* 19 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
@@ -2135,11 +1908,7 @@ var VErrors = function () {
 /***/ (function(module, exports, __webpack_require__) {
 
 // toObject with fallback for non-array-like ES3 strings
-<<<<<<< HEAD
-var IndexedObject = __webpack_require__(75);
-=======
-var IndexedObject = __webpack_require__(77);
->>>>>>> Ensure chips have a name before submitting values
+var IndexedObject = __webpack_require__(76);
 var requireObjectCoercible = __webpack_require__(38);
 
 module.exports = function (it) {
@@ -2282,17 +2051,10 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VEvents; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = initEvents;
 /* harmony export (immutable) */ __webpack_exports__["c"] = removeEvents;
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(99);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(105);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(107);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(60);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(101);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(102);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(100);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(106);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(108);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(61);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(60);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(21);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(111);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(112);
@@ -2303,7 +2065,7 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(117);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(118);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(119);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(62);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(61);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -3102,52 +2864,16 @@ function __importDefault(mod) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initialize;
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(70);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(94);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(96);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(57);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(29);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(119);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(120);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(122);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(130);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(59);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(132);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(134);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(135);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(136);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(137);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(139);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(141);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(143);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(149);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(150);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(152);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(154);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(155);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(156);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(157);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(159);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(160);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(161);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(163);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(164);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(165);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(166);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(167);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(173);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(72);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(96);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(98);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(71);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(95);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(97);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(57);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(29);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(120);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(121);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(123);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(131);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(60);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(59);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(133);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(135);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(136);
@@ -3171,8 +2897,7 @@ function __importDefault(mod) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(166);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(167);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(168);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(62);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(61);
 
 
 
@@ -3258,11 +2983,7 @@ function initialize(root, setRoot) {
 /* 33 */
 /***/ (function(module, exports, __webpack_require__) {
 
-<<<<<<< HEAD
-module.exports = __webpack_require__(72);
-=======
-module.exports = __webpack_require__(74);
->>>>>>> Ensure chips have a name before submitting values
+module.exports = __webpack_require__(73);
 
 /***/ }),
 /* 34 */
@@ -3273,17 +2994,10 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 var global = __webpack_require__(3);
 var getOwnPropertyDescriptor = __webpack_require__(35).f;
 var hide = __webpack_require__(11);
-<<<<<<< HEAD
-var redefine = __webpack_require__(76);
+var redefine = __webpack_require__(77);
 var setGlobal = __webpack_require__(24);
-var copyConstructorProperties = __webpack_require__(80);
-var isForced = __webpack_require__(87);
-=======
-var redefine = __webpack_require__(78);
-var setGlobal = __webpack_require__(24);
-var copyConstructorProperties = __webpack_require__(82);
-var isForced = __webpack_require__(89);
->>>>>>> Ensure chips have a name before submitting values
+var copyConstructorProperties = __webpack_require__(81);
+var isForced = __webpack_require__(88);
 
 /*
   options.target      - name of the target object
@@ -3337,11 +3051,7 @@ module.exports = function (options, source) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(7);
-<<<<<<< HEAD
-var propertyIsEnumerableModule = __webpack_require__(74);
-=======
-var propertyIsEnumerableModule = __webpack_require__(76);
->>>>>>> Ensure chips have a name before submitting values
+var propertyIsEnumerableModule = __webpack_require__(75);
 var createPropertyDescriptor = __webpack_require__(36);
 var toIndexedObject = __webpack_require__(22);
 var toPrimitive = __webpack_require__(39);
@@ -3482,11 +3192,7 @@ module.exports = function (key) {
 /* 45 */
 /***/ (function(module, exports, __webpack_require__) {
 
-<<<<<<< HEAD
-var path = __webpack_require__(82);
-=======
-var path = __webpack_require__(84);
->>>>>>> Ensure chips have a name before submitting values
+var path = __webpack_require__(83);
 var global = __webpack_require__(3);
 
 var aFunction = function aFunction(variable) {
@@ -3503,11 +3209,7 @@ module.exports = function (namespace, method) {
 
 var has = __webpack_require__(10);
 var toIndexedObject = __webpack_require__(22);
-<<<<<<< HEAD
-var indexOf = __webpack_require__(84).indexOf;
-=======
-var indexOf = __webpack_require__(86).indexOf;
->>>>>>> Ensure chips have a name before submitting values
+var indexOf = __webpack_require__(85).indexOf;
 var hiddenKeys = __webpack_require__(25);
 
 module.exports = function (object, names) {
@@ -3662,11 +3364,7 @@ module.exports = function (originalArray, length) {
 var global = __webpack_require__(3);
 var shared = __webpack_require__(16);
 var uid = __webpack_require__(44);
-<<<<<<< HEAD
-var NATIVE_SYMBOL = __webpack_require__(88);
-=======
-var NATIVE_SYMBOL = __webpack_require__(90);
->>>>>>> Ensure chips have a name before submitting values
+var NATIVE_SYMBOL = __webpack_require__(89);
 
 var _Symbol = global.Symbol;
 var store = shared('wks');
@@ -3680,11 +3378,7 @@ module.exports = function (name) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var wellKnownSymbol = __webpack_require__(53);
-<<<<<<< HEAD
-var create = __webpack_require__(90);
-=======
-var create = __webpack_require__(92);
->>>>>>> Ensure chips have a name before submitting values
+var create = __webpack_require__(91);
 var hide = __webpack_require__(11);
 
 var UNSCOPABLES = wellKnownSymbol('unscopables');
@@ -10326,11 +10020,7 @@ var VTextField = function (_dirtyableMixin) {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(98);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(100);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(99);
 
 
 /* harmony default export */ __webpack_exports__["a"] = (new __WEBPACK_IMPORTED_MODULE_0__utils_config__["a" /* default */]({
@@ -10740,7 +10430,7 @@ function initDragAndDrop(root) {
 }
 
 /***/ }),
-/* 63 */
+/* 62 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -10918,11 +10608,7 @@ var MDCComponent = function () {
 /* harmony default export */ __webpack_exports__["a"] = (MDCComponent);
 
 /***/ }),
-<<<<<<< HEAD
-/* 62 */
-=======
-/* 64 */
->>>>>>> Ensure chips have a name before submitting values
+/* 63 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -11103,11 +10789,7 @@ var MDCRippleAdapter = function () {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCRippleAdapter);
 
 /***/ }),
-<<<<<<< HEAD
-/* 63 */
-=======
-/* 65 */
->>>>>>> Ensure chips have a name before submitting values
+/* 64 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -11288,11 +10970,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 
 
 /***/ }),
-<<<<<<< HEAD
-/* 64 */
-=======
-/* 66 */
->>>>>>> Ensure chips have a name before submitting values
+/* 65 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -14875,11 +14553,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 65 */
-=======
-/* 67 */
->>>>>>> Ensure chips have a name before submitting values
+/* 66 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(Buffer, module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof2 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -27809,11 +27483,7 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(145).Buffer, __webpack_require__(2)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 66 */
-=======
-/* 68 */
->>>>>>> Ensure chips have a name before submitting values
+/* 67 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -27898,25 +27568,15 @@ var MDCFoundation = /** @class */function () {
 //# sourceMappingURL=foundation.js.map
 
 /***/ }),
-<<<<<<< HEAD
-/* 67 */
-=======
-/* 69 */
->>>>>>> Ensure chips have a name before submitting values
+/* 68 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgressFoundation; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(171);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(66);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(172);
-=======
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(172);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(68);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(67);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(173);
->>>>>>> Ensure chips have a name before submitting values
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -28044,25 +27704,14 @@ var MDCLinearProgressFoundation = /** @class */function (_super) {
 //# sourceMappingURL=foundation.js.map
 
 /***/ }),
-<<<<<<< HEAD
-/* 68 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(69);
-
-
-/***/ }),
 /* 69 */
-=======
-/* 70 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(71);
+module.exports = __webpack_require__(70);
 
 
 /***/ }),
-/* 71 */
->>>>>>> Ensure chips have a name before submitting values
+/* 70 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -28154,21 +27803,13 @@ __webpack_require__(179);
 customElements.define('flow-matic', FlowMatic);
 
 /***/ }),
-<<<<<<< HEAD
-/* 70 */
-=======
-/* 72 */
->>>>>>> Ensure chips have a name before submitting values
+/* 71 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initButtons;
 /* unused harmony export VButton */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(71);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(73);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(72);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_ripple__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
@@ -28267,11 +27908,7 @@ var VButton = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-<<<<<<< HEAD
-/* 71 */
-=======
-/* 73 */
->>>>>>> Ensure chips have a name before submitting values
+/* 72 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -30223,29 +29860,17 @@ var VButton = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 72 */
+/* 73 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(73);
-__webpack_require__(89);
-=======
-/* 74 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(75);
-__webpack_require__(91);
->>>>>>> Ensure chips have a name before submitting values
+__webpack_require__(74);
+__webpack_require__(90);
 var entryUnbind = __webpack_require__(55);
 
 module.exports = entryUnbind('Array', 'flat');
 
 /***/ }),
-<<<<<<< HEAD
-/* 73 */
-=======
-/* 75 */
->>>>>>> Ensure chips have a name before submitting values
+/* 74 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30272,11 +29897,7 @@ $({ target: 'Array', proto: true }, {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 74 */
-=======
-/* 76 */
->>>>>>> Ensure chips have a name before submitting values
+/* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -30296,11 +29917,7 @@ exports.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
 } : nativePropertyIsEnumerable;
 
 /***/ }),
-<<<<<<< HEAD
-/* 75 */
-=======
-/* 77 */
->>>>>>> Ensure chips have a name before submitting values
+/* 76 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(8);
@@ -30318,11 +29935,7 @@ module.exports = fails(function () {
 } : Object;
 
 /***/ }),
-<<<<<<< HEAD
-/* 76 */
-=======
-/* 78 */
->>>>>>> Ensure chips have a name before submitting values
+/* 77 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
@@ -30331,11 +29944,7 @@ var hide = __webpack_require__(11);
 var has = __webpack_require__(10);
 var setGlobal = __webpack_require__(24);
 var nativeFunctionToString = __webpack_require__(42);
-<<<<<<< HEAD
-var InternalStateModule = __webpack_require__(78);
-=======
-var InternalStateModule = __webpack_require__(80);
->>>>>>> Ensure chips have a name before submitting values
+var InternalStateModule = __webpack_require__(79);
 
 var getInternalState = InternalStateModule.get;
 var enforceInternalState = InternalStateModule.enforce;
@@ -30368,27 +29977,16 @@ shared('inspectSource', function (it) {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 77 */
-=======
-/* 79 */
->>>>>>> Ensure chips have a name before submitting values
+/* 78 */
 /***/ (function(module, exports) {
 
 module.exports = false;
 
 /***/ }),
-<<<<<<< HEAD
-/* 78 */
+/* 79 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var NATIVE_WEAK_MAP = __webpack_require__(79);
-=======
-/* 80 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var NATIVE_WEAK_MAP = __webpack_require__(81);
->>>>>>> Ensure chips have a name before submitting values
+var NATIVE_WEAK_MAP = __webpack_require__(80);
 var global = __webpack_require__(3);
 var isObject = __webpack_require__(9);
 var hide = __webpack_require__(11);
@@ -30451,11 +30049,7 @@ module.exports = {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 79 */
-=======
-/* 81 */
->>>>>>> Ensure chips have a name before submitting values
+/* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
@@ -30466,19 +30060,11 @@ var WeakMap = global.WeakMap;
 module.exports = typeof WeakMap === 'function' && /native code/.test(nativeFunctionToString.call(WeakMap));
 
 /***/ }),
-<<<<<<< HEAD
-/* 80 */
+/* 81 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var has = __webpack_require__(10);
-var ownKeys = __webpack_require__(81);
-=======
-/* 82 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var has = __webpack_require__(10);
-var ownKeys = __webpack_require__(83);
->>>>>>> Ensure chips have a name before submitting values
+var ownKeys = __webpack_require__(82);
 var getOwnPropertyDescriptorModule = __webpack_require__(35);
 var definePropertyModule = __webpack_require__(23);
 
@@ -30493,23 +30079,13 @@ module.exports = function (target, source) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 81 */
+/* 82 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var getBuiltIn = __webpack_require__(45);
-var getOwnPropertyNamesModule = __webpack_require__(83);
-var getOwnPropertySymbolsModule = __webpack_require__(86);
+var getOwnPropertyNamesModule = __webpack_require__(84);
+var getOwnPropertySymbolsModule = __webpack_require__(87);
 var anObject = __webpack_require__(15);
-=======
-/* 83 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var getBuiltIn = __webpack_require__(45);
-var getOwnPropertyNamesModule = __webpack_require__(85);
-var getOwnPropertySymbolsModule = __webpack_require__(88);
-var anObject = __webpack_require__(14);
->>>>>>> Ensure chips have a name before submitting values
 
 // all object keys, includes non-enumerable and symbols
 module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
@@ -30519,21 +30095,13 @@ module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 82 */
-=======
-/* 84 */
->>>>>>> Ensure chips have a name before submitting values
+/* 83 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(3);
 
 /***/ }),
-<<<<<<< HEAD
-/* 83 */
-=======
-/* 85 */
->>>>>>> Ensure chips have a name before submitting values
+/* 84 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var internalObjectKeys = __webpack_require__(46);
@@ -30548,21 +30116,12 @@ exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 84 */
+/* 85 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var toIndexedObject = __webpack_require__(22);
 var toLength = __webpack_require__(17);
-var toAbsoluteIndex = __webpack_require__(85);
-=======
-/* 86 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var toIndexedObject = __webpack_require__(22);
-var toLength = __webpack_require__(16);
-var toAbsoluteIndex = __webpack_require__(87);
->>>>>>> Ensure chips have a name before submitting values
+var toAbsoluteIndex = __webpack_require__(86);
 
 // `Array.prototype.{ indexOf, includes }` methods implementation
 var createMethod = function createMethod(IS_INCLUDES) {
@@ -30594,11 +30153,7 @@ module.exports = {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 85 */
-=======
-/* 87 */
->>>>>>> Ensure chips have a name before submitting values
+/* 86 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var toInteger = __webpack_require__(26);
@@ -30615,21 +30170,13 @@ module.exports = function (index, length) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 86 */
-=======
-/* 88 */
->>>>>>> Ensure chips have a name before submitting values
+/* 87 */
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 /***/ }),
-<<<<<<< HEAD
-/* 87 */
-=======
-/* 89 */
->>>>>>> Ensure chips have a name before submitting values
+/* 88 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(8);
@@ -30652,11 +30199,7 @@ var POLYFILL = isForced.POLYFILL = 'P';
 module.exports = isForced;
 
 /***/ }),
-<<<<<<< HEAD
-/* 88 */
-=======
-/* 90 */
->>>>>>> Ensure chips have a name before submitting values
+/* 89 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(8);
@@ -30668,11 +30211,7 @@ module.exports = !!Object.getOwnPropertySymbols && !fails(function () {
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 89 */
-=======
-/* 91 */
->>>>>>> Ensure chips have a name before submitting values
+/* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -30682,25 +30221,14 @@ var addToUnscopables = __webpack_require__(54);
 addToUnscopables('flat');
 
 /***/ }),
-<<<<<<< HEAD
-/* 90 */
+/* 91 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var anObject = __webpack_require__(15);
-var defineProperties = __webpack_require__(91);
+var defineProperties = __webpack_require__(92);
 var enumBugKeys = __webpack_require__(27);
 var hiddenKeys = __webpack_require__(25);
-var html = __webpack_require__(93);
-=======
-/* 92 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var anObject = __webpack_require__(14);
-var defineProperties = __webpack_require__(93);
-var enumBugKeys = __webpack_require__(27);
-var hiddenKeys = __webpack_require__(25);
-var html = __webpack_require__(95);
->>>>>>> Ensure chips have a name before submitting values
+var html = __webpack_require__(94);
 var documentCreateElement = __webpack_require__(41);
 var sharedKey = __webpack_require__(43);
 var IE_PROTO = sharedKey('IE_PROTO');
@@ -30748,22 +30276,13 @@ module.exports = Object.create || function create(O, Properties) {
 hiddenKeys[IE_PROTO] = true;
 
 /***/ }),
-<<<<<<< HEAD
-/* 91 */
-=======
-/* 93 */
->>>>>>> Ensure chips have a name before submitting values
+/* 92 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(7);
 var definePropertyModule = __webpack_require__(23);
-<<<<<<< HEAD
 var anObject = __webpack_require__(15);
-var objectKeys = __webpack_require__(92);
-=======
-var anObject = __webpack_require__(14);
-var objectKeys = __webpack_require__(94);
->>>>>>> Ensure chips have a name before submitting values
+var objectKeys = __webpack_require__(93);
 
 // `Object.defineProperties` method
 // https://tc39.github.io/ecma262/#sec-object.defineproperties
@@ -30779,11 +30298,7 @@ module.exports = DESCRIPTORS ? Object.defineProperties : function defineProperti
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 92 */
-=======
-/* 94 */
->>>>>>> Ensure chips have a name before submitting values
+/* 93 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var internalObjectKeys = __webpack_require__(46);
@@ -30796,11 +30311,7 @@ module.exports = Object.keys || function keys(O) {
 };
 
 /***/ }),
-<<<<<<< HEAD
-/* 93 */
-=======
-/* 95 */
->>>>>>> Ensure chips have a name before submitting values
+/* 94 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var getBuiltIn = __webpack_require__(45);
@@ -30808,11 +30319,7 @@ var getBuiltIn = __webpack_require__(45);
 module.exports = getBuiltIn('document', 'documentElement');
 
 /***/ }),
-<<<<<<< HEAD
-/* 94 */
-=======
-/* 96 */
->>>>>>> Ensure chips have a name before submitting values
+/* 95 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -30821,11 +30328,7 @@ module.exports = getBuiltIn('document', 'documentElement');
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(4);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(0);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(95);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(97);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(96);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3__material_dialog__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -30995,11 +30498,7 @@ var VDialog = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-<<<<<<< HEAD
-/* 95 */
-=======
-/* 97 */
->>>>>>> Ensure chips have a name before submitting values
+/* 96 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -34617,21 +34116,13 @@ var VDialog = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-<<<<<<< HEAD
-/* 96 */
-=======
-/* 98 */
->>>>>>> Ensure chips have a name before submitting values
+/* 97 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDateTime;
 /* unused harmony export VDateTime */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(97);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(99);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(98);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield__ = __webpack_require__(56);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__material_textfield__);
@@ -34757,11 +34248,7 @@ var VDateTime = function (_VTextField) {
 }(__WEBPACK_IMPORTED_MODULE_2__text_fields__["a" /* VTextField */]);
 
 /***/ }),
-<<<<<<< HEAD
-/* 97 */
-=======
-/* 99 */
->>>>>>> Ensure chips have a name before submitting values
+/* 98 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -36950,11 +36437,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = 
 });
 
 /***/ }),
-<<<<<<< HEAD
-/* 98 */
-=======
-/* 100 */
->>>>>>> Ensure chips have a name before submitting values
+/* 99 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -37056,11 +36539,7 @@ var VConfig = function () {
 /* harmony default export */ __webpack_exports__["a"] = (VConfig);
 
 /***/ }),
-<<<<<<< HEAD
-/* 99 */
-=======
-/* 101 */
->>>>>>> Ensure chips have a name before submitting values
+/* 100 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -37145,24 +36624,23 @@ var VLoads = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */]);
 
 /***/ }),
-/* 100 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(101);
-
-/***/ }),
-<<<<<<< HEAD
 /* 101 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(102);
+module.exports = __webpack_require__(102);
+
+/***/ }),
+/* 102 */
+/***/ (function(module, exports, __webpack_require__) {
+
 __webpack_require__(103);
+__webpack_require__(104);
 var entryUnbind = __webpack_require__(55);
 
 module.exports = entryUnbind('Array', 'flatMap');
 
 /***/ }),
-/* 102 */
+/* 103 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -37190,7 +36668,7 @@ $({ target: 'Array', proto: true }, {
 });
 
 /***/ }),
-/* 103 */
+/* 104 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -37200,7 +36678,7 @@ var addToUnscopables = __webpack_require__(54);
 addToUnscopables('flatMap');
 
 /***/ }),
-/* 104 */
+/* 105 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -37323,23 +36801,15 @@ var VUrls = function () {
 }();
 
 /***/ }),
-/* 105 */
-=======
-/* 102 */
->>>>>>> Ensure chips have a name before submitting values
+/* 106 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPosts; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(12);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(58);
-<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(18);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(106);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(17);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(107);
->>>>>>> Ensure chips have a name before submitting values
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -37675,65 +37145,7 @@ var VPosts = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-<<<<<<< HEAD
-/* 106 */
-=======
-/* 103 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(104);
-
-/***/ }),
-/* 104 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(105);
-__webpack_require__(106);
-var entryUnbind = __webpack_require__(55);
-
-module.exports = entryUnbind('Array', 'flatMap');
-
-/***/ }),
-/* 105 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var $ = __webpack_require__(34);
-var flattenIntoArray = __webpack_require__(47);
-var toObject = __webpack_require__(51);
-var toLength = __webpack_require__(16);
-var aFunction = __webpack_require__(50);
-var arraySpeciesCreate = __webpack_require__(52);
-
-// `Array.prototype.flatMap` method
-// https://github.com/tc39/proposal-flatMap
-$({ target: 'Array', proto: true }, {
-  flatMap: function flatMap(callbackfn /* , thisArg */) {
-    var O = toObject(this);
-    var sourceLen = toLength(O.length);
-    var A;
-    aFunction(callbackfn);
-    A = arraySpeciesCreate(O, 0);
-    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
-    return A;
-  }
-});
-
-/***/ }),
-/* 106 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// this method was added to unscopables after implementation
-// in popular engines, so it's moved to a separate module
-var addToUnscopables = __webpack_require__(54);
-
-addToUnscopables('flatMap');
-
-/***/ }),
 /* 107 */
->>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -46473,17 +45885,10 @@ var VHeader = function (_eventHandlerMixin) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCTopAppBar; });
-<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(13);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(61);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(124);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(14);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(12);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(62);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(125);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(13);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(14);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(19);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(128);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(129);
@@ -46700,17 +46105,10 @@ var MDCTopAppBar = function (_MDCComponent) {
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCRipple; });
 /* unused harmony export RippleCapableSurface */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(61);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(62);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(125);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(63);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(63);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(62);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(63);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(126);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(65);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(64);
 /* unused harmony reexport MDCRippleFoundation */
 /* unused harmony reexport util */
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -46963,15 +46361,9 @@ RippleCapableSurface.prototype.disabled;
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(30);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(62);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(126);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(63);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(63);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(127);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(65);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(64);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -61479,11 +60871,7 @@ var VSelect = function (_dirtyableMixin) {
 /* harmony export (immutable) */ __webpack_exports__["a"] = initChips;
 /* unused harmony export VChip */
 /* unused harmony export VChipSet */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(64);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(66);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(65);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_chips__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(0);
@@ -69133,11 +68521,7 @@ var VSwitch = function (_VBaseToggle) {
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRichTextArea;
 /* unused harmony export VRichTextArea */
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(65);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(67);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(66);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(149);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(0);
@@ -71437,11 +70821,7 @@ module.exports = Array.isArray || function (arr) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return HorizontalRuleBlot; });
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(65);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(67);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(66);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -86204,11 +85584,7 @@ var VProgress = function (_VBaseComponent) {
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(170);
 /* harmony namespace reexport (by used) */ __webpack_require__.d(__webpack_exports__, "a", function() { return __WEBPACK_IMPORTED_MODULE_0__component__["a"]; });
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(67);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(69);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(68);
 /* unused harmony namespace reexport */
 /**
  * @license
@@ -86243,13 +85619,8 @@ var VProgress = function (_VBaseComponent) {
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgress; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(170);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(67);
-=======
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(171);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(69);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(68);
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -86355,11 +85726,7 @@ var MDCLinearProgress = /** @class */function (_super) {
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCComponent; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
-<<<<<<< HEAD
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(66);
-=======
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(68);
->>>>>>> Ensure chips have a name before submitting values
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(67);
 /**
  * @license
  * Copyright 2016 Google Inc.

--- a/public/wc.js
+++ b/public/wc.js
@@ -61505,6 +61505,8 @@ var EVENT_DESELECT = 'deselect';
 var EVENT_TRAILING_ICON_CLICK = 'trailing_icon_click';
 
 var SELECTABLE_VARIANT_CLASS = 'v-chip-set--selectable-variant';
+var CHIP_BEHAVIOR_AUTO_REMOVE = 'auto_remove';
+var CHIP_BEHAVIOR_NO_AUTO_REMOVE = 'no_auto_remove';
 
 function initChips(e) {
     console.debug('\tChips');
@@ -61517,8 +61519,7 @@ function initChips(e) {
     // call for chips is not needed.
 
     Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["d" /* hookupComponentsManually */])(e, '.v-chip-set', function (element) {
-        var selectable = element.classList.contains(SELECTABLE_VARIANT_CLASS);
-        var chipFactory = voomChipFactoryFactory(selectable);
+        var chipFactory = voomChipFactoryFactory(CHIP_BEHAVIOR_NO_AUTO_REMOVE);
         var mdcComponent = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["MDCChipSet"](element, undefined, chipFactory);
 
         return new VChipSet(element, mdcComponent);
@@ -61599,10 +61600,14 @@ var VChip = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
 
 // Returns a function which constructs VChip components.
-function voomChipFactoryFactory(selectable) {
+function voomChipFactoryFactory() {
+    var behavior = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : CHIP_BEHAVIOR_AUTO_REMOVE;
+
+    var autoRemove = behavior === CHIP_BEHAVIOR_AUTO_REMOVE;
+
     return function (element) {
         var mdcComponent = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["MDCChip"](element);
-        mdcComponent.shouldRemoveOnTrailingIconClick = !selectable;
+        mdcComponent.shouldRemoveOnTrailingIconClick = autoRemove;
 
         return new VChip(element, mdcComponent);
     };

--- a/public/wc.js
+++ b/public/wc.js
@@ -60,7 +60,11 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
+<<<<<<< HEAD
 /******/ 	return __webpack_require__(__webpack_require__.s = 68);
+=======
+/******/ 	return __webpack_require__(__webpack_require__.s = 70);
+>>>>>>> Ensure chips have a name before submitting values
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -1226,7 +1230,11 @@ module.exports = function (it) {
 
 var global = __webpack_require__(3);
 var setGlobal = __webpack_require__(24);
+<<<<<<< HEAD
 var IS_PURE = __webpack_require__(77);
+=======
+var IS_PURE = __webpack_require__(79);
+>>>>>>> Ensure chips have a name before submitting values
 
 var SHARED = '__core-js_shared__';
 var store = global[SHARED] || setGlobal(SHARED, {});
@@ -1365,6 +1373,225 @@ function expandParams(results, params) {
 }
 
 /***/ }),
+<<<<<<< HEAD
+=======
+/* 18 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBase; });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__ = __webpack_require__(33);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_core_js_features_array_flat__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__ = __webpack_require__(103);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_core_js_features_array_flat_map__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__errors__ = __webpack_require__(21);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__utils_urls__ = __webpack_require__(59);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+
+
+
+
+
+var VBase = function (_VUrls) {
+    _inherits(VBase, _VUrls);
+
+    function VBase(options, root) {
+        _classCallCheck(this, VBase);
+
+        var _this = _possibleConstructorReturn(this, (VBase.__proto__ || Object.getPrototypeOf(VBase)).call(this));
+
+        _this.options = options;
+        _this.root = root;
+        return _this;
+    }
+
+    _createClass(VBase, [{
+        key: 'clearErrors',
+        value: function clearErrors() {
+            new __WEBPACK_IMPORTED_MODULE_2__errors__["a" /* VErrors */](this.root).clearErrors();
+        }
+    }, {
+        key: 'parentElement',
+        value: function parentElement() {
+            return this.root.getElementById(this.options.__parent_id__);
+        }
+
+        /**
+         * taggedInputs retrieves all components matching this event's input_tag
+         * value.
+         * @return {NodeList}
+         */
+
+    }, {
+        key: 'taggedInputs',
+        value: function taggedInputs() {
+            var inputTag = this.options.input_tag;
+
+            if (!inputTag) {
+                return [];
+            }
+
+            var selector = '[data-input-tag="' + inputTag + '"]';
+            var inputs = this.root.querySelectorAll(selector);
+
+            if (inputs.length < 1) {
+                console.warn('input_tag ' + inputTag + ' matched 0 elements. Are you sure' + 'you\'ve specified the correct value?');
+            }
+
+            return inputs;
+        }
+
+        /**
+         * inputs retrieves relevant input elements for this event.
+         *
+         * - If an `input_tag` has been provided, all matching tagged elements are
+         *   included.
+         * - If this component is a input element, it is included.
+         * - If this component has input elements, its input elements are included.
+         *   If not, the input elements of the nearest container (dialog or content)
+         *   are included.
+         * @return {Array<HTMLElement>}
+         */
+
+    }, {
+        key: 'inputs',
+        value: function inputs() {
+            var components = [];
+
+            // Collect tagged components, if applicable:
+            if (this.options.input_tag) {
+                var taggedComponents = Array.from(this.taggedInputs()).filter(function (element) {
+                    return element.vComponent;
+                }).map(function (element) {
+                    return element.vComponent;
+                });
+
+                components.push(taggedComponents);
+            }
+
+            var comp = this.component();
+
+            if (comp) {
+                // Include ourselves if we're a form field component, but not a
+                // container:
+                if (comp.respondTo('prepareSubmit') && !comp.respondTo('inputs')) {
+                    components.push(comp);
+                } else if (!comp.respondTo('inputs')) {
+                    // Defer to the component's closest container (card, content,
+                    // dialog, or form) if the component itself does not respond to
+                    // `inputs`:
+                    comp = this.closestContainer();
+                }
+            }
+
+            if (comp && comp.respondTo('inputs')) {
+                components.push(comp);
+            }
+
+            // Map components to elements.
+            // Containers are mapped to their child elements.
+            // Form field components are mapped to their own element.
+            var elements = components.flat().flatMap(function (comp) {
+                if (comp.respondTo('inputs')) {
+                    return Array.from(comp.inputs());
+                } else if (comp.respondTo('prepareSubmit')) {
+                    return comp.element;
+                }
+            });
+
+            // Deduplicate:
+            return Array.from(new Set(elements));
+        }
+
+        /**
+         * inputComponents retrieves the Component for each of this event's
+         * relevant input elements.
+         * @return {Array<VBaseComponent>}
+         */
+
+    }, {
+        key: 'inputComponents',
+        value: function inputComponents() {
+            return this.inputs().filter(function (element) {
+                return element.vComponent;
+            }).map(function (element) {
+                return element.vComponent;
+            });
+        }
+
+        /**
+         * inputValues retrieves submit values for each of this event's relevant
+         * input elements.
+         * @return {Array}
+         */
+
+    }, {
+        key: 'inputValues',
+        value: function inputValues() {
+            var params = [];
+
+            this.inputComponents().filter(function (comp) {
+                return comp.respondTo('prepareSubmit');
+            }).map(function (comp) {
+                return comp.prepareSubmit(params);
+            });
+
+            return params;
+        }
+    }, {
+        key: 'component',
+        value: function component() {
+            var parent = this.parentElement();
+
+            return parent ? parent.vComponent : null;
+        }
+    }, {
+        key: 'validate',
+        value: function validate() {
+            var comp = this.component();
+
+            if (comp) {
+                return comp.validate();
+            }
+
+            return [];
+        }
+    }, {
+        key: 'closestContainer',
+        value: function closestContainer() {
+            var element = this.closestContainerElement();
+
+            if (!element) {
+                return null;
+            }
+
+            return element.vComponent;
+        }
+    }, {
+        key: 'closestContainerElement',
+        value: function closestContainerElement() {
+            var comp = this.component();
+
+            if (!(comp && comp.element)) {
+                return null;
+            }
+
+            return comp.element.closest('[data-is-container]');
+        }
+    }]);
+
+    return VBase;
+}(__WEBPACK_IMPORTED_MODULE_3__utils_urls__["a" /* VUrls */]);
+
+/***/ }),
+>>>>>>> Ensure chips have a name before submitting values
 /* 19 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
@@ -1908,7 +2135,11 @@ var VErrors = function () {
 /***/ (function(module, exports, __webpack_require__) {
 
 // toObject with fallback for non-array-like ES3 strings
+<<<<<<< HEAD
 var IndexedObject = __webpack_require__(75);
+=======
+var IndexedObject = __webpack_require__(77);
+>>>>>>> Ensure chips have a name before submitting values
 var requireObjectCoercible = __webpack_require__(38);
 
 module.exports = function (it) {
@@ -2051,21 +2282,28 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VEvents; });
 /* harmony export (immutable) */ __webpack_exports__["b"] = initEvents;
 /* harmony export (immutable) */ __webpack_exports__["c"] = removeEvents;
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(99);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(105);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(107);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(60);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_loads__ = __webpack_require__(101);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__events_posts__ = __webpack_require__(102);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__events_replaces__ = __webpack_require__(108);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__events_dialog__ = __webpack_require__(61);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events_errors__ = __webpack_require__(21);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(110);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(111);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(112);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(113);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(114);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(115);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(116);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(117);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(118);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(173);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__events_toggle_visibility__ = __webpack_require__(111);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__events_prompt_if_dirty__ = __webpack_require__(112);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__events_snackbar__ = __webpack_require__(113);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__events_clears__ = __webpack_require__(114);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__events_removes__ = __webpack_require__(115);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__events_stepper__ = __webpack_require__(116);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(117);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(118);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(119);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(62);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -2864,6 +3102,7 @@ function __importDefault(mod) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initialize;
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(70);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(94);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(96);
@@ -2898,6 +3137,42 @@ function __importDefault(mod) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(166);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(167);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(173);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__button__ = __webpack_require__(72);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__dialogs__ = __webpack_require__(96);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__datetime__ = __webpack_require__(98);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__text_fields__ = __webpack_require__(57);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(29);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__lists__ = __webpack_require__(120);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__drawer__ = __webpack_require__(121);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__header__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__icon_toggles__ = __webpack_require__(131);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__menus__ = __webpack_require__(60);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__selects__ = __webpack_require__(133);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__chips__ = __webpack_require__(135);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__cards__ = __webpack_require__(136);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__forms__ = __webpack_require__(137);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__snackbar__ = __webpack_require__(138);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_15__checkboxes__ = __webpack_require__(140);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_16__switches__ = __webpack_require__(142);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_17__rich_text_area__ = __webpack_require__(144);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_18__steppers__ = __webpack_require__(150);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_19__radios__ = __webpack_require__(151);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_20__sliders__ = __webpack_require__(153);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_21__hidden_fields__ = __webpack_require__(155);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_22__content__ = __webpack_require__(156);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_23__grid__ = __webpack_require__(157);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_24__tab_bars__ = __webpack_require__(158);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_25__data_tables__ = __webpack_require__(160);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_26__file_inputs__ = __webpack_require__(161);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_27__form_fields__ = __webpack_require__(162);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_28__images__ = __webpack_require__(164);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_29__typography__ = __webpack_require__(165);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_30__tooltip__ = __webpack_require__(166);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_31__plugins__ = __webpack_require__(167);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_32__progress__ = __webpack_require__(168);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_33__drag_n_drop__ = __webpack_require__(62);
+>>>>>>> Ensure chips have a name before submitting values
 
 
 
@@ -2983,7 +3258,11 @@ function initialize(root, setRoot) {
 /* 33 */
 /***/ (function(module, exports, __webpack_require__) {
 
+<<<<<<< HEAD
 module.exports = __webpack_require__(72);
+=======
+module.exports = __webpack_require__(74);
+>>>>>>> Ensure chips have a name before submitting values
 
 /***/ }),
 /* 34 */
@@ -2994,10 +3273,17 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 var global = __webpack_require__(3);
 var getOwnPropertyDescriptor = __webpack_require__(35).f;
 var hide = __webpack_require__(11);
+<<<<<<< HEAD
 var redefine = __webpack_require__(76);
 var setGlobal = __webpack_require__(24);
 var copyConstructorProperties = __webpack_require__(80);
 var isForced = __webpack_require__(87);
+=======
+var redefine = __webpack_require__(78);
+var setGlobal = __webpack_require__(24);
+var copyConstructorProperties = __webpack_require__(82);
+var isForced = __webpack_require__(89);
+>>>>>>> Ensure chips have a name before submitting values
 
 /*
   options.target      - name of the target object
@@ -3051,7 +3337,11 @@ module.exports = function (options, source) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(7);
+<<<<<<< HEAD
 var propertyIsEnumerableModule = __webpack_require__(74);
+=======
+var propertyIsEnumerableModule = __webpack_require__(76);
+>>>>>>> Ensure chips have a name before submitting values
 var createPropertyDescriptor = __webpack_require__(36);
 var toIndexedObject = __webpack_require__(22);
 var toPrimitive = __webpack_require__(39);
@@ -3192,7 +3482,11 @@ module.exports = function (key) {
 /* 45 */
 /***/ (function(module, exports, __webpack_require__) {
 
+<<<<<<< HEAD
 var path = __webpack_require__(82);
+=======
+var path = __webpack_require__(84);
+>>>>>>> Ensure chips have a name before submitting values
 var global = __webpack_require__(3);
 
 var aFunction = function aFunction(variable) {
@@ -3209,7 +3503,11 @@ module.exports = function (namespace, method) {
 
 var has = __webpack_require__(10);
 var toIndexedObject = __webpack_require__(22);
+<<<<<<< HEAD
 var indexOf = __webpack_require__(84).indexOf;
+=======
+var indexOf = __webpack_require__(86).indexOf;
+>>>>>>> Ensure chips have a name before submitting values
 var hiddenKeys = __webpack_require__(25);
 
 module.exports = function (object, names) {
@@ -3364,7 +3662,11 @@ module.exports = function (originalArray, length) {
 var global = __webpack_require__(3);
 var shared = __webpack_require__(16);
 var uid = __webpack_require__(44);
+<<<<<<< HEAD
 var NATIVE_SYMBOL = __webpack_require__(88);
+=======
+var NATIVE_SYMBOL = __webpack_require__(90);
+>>>>>>> Ensure chips have a name before submitting values
 
 var _Symbol = global.Symbol;
 var store = shared('wks');
@@ -3378,7 +3680,11 @@ module.exports = function (name) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var wellKnownSymbol = __webpack_require__(53);
+<<<<<<< HEAD
 var create = __webpack_require__(90);
+=======
+var create = __webpack_require__(92);
+>>>>>>> Ensure chips have a name before submitting values
 var hide = __webpack_require__(11);
 
 var UNSCOPABLES = wellKnownSymbol('unscopables');
@@ -10020,7 +10326,11 @@ var VTextField = function (_dirtyableMixin) {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(98);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__utils_config__ = __webpack_require__(100);
+>>>>>>> Ensure chips have a name before submitting values
 
 
 /* harmony default export */ __webpack_exports__["a"] = (new __WEBPACK_IMPORTED_MODULE_0__utils_config__["a" /* default */]({
@@ -10055,7 +10365,7 @@ var VTextField = function (_dirtyableMixin) {
 /* harmony export (immutable) */ __webpack_exports__["b"] = uninitMenus;
 /* harmony export (immutable) */ __webpack_exports__["a"] = initMenus;
 /* unused harmony export VMenu */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(109);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu__ = __webpack_require__(110);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_menu___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_menu__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
@@ -10224,6 +10534,213 @@ var VDialog = function () {
 
 /***/ }),
 /* 61 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return DRAG_DATA_MIME_TYPE; });
+/* unused harmony export EVENT_DROPPED */
+/* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
+/*
+    A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
+    three modes:
+
+    1. read/write, during a `dragstart` event: items can be read and added
+    2. read-only, during a `drop` event: items can be read, but not added
+    3. protected, during all other types of DragEvent: items cannot be read
+       or added.
+
+    (see https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw)
+
+    Thus, attempting to mutate the store during events other than `dragstart`
+    fails silently: no error is raised, but items are not added.
+
+
+    To read items in protected mode, serialize data as a string and store it as
+    a key instead of as a value. This makes it accessible via
+    `dataTransfer.types`:
+
+    // in a dragstart handler:
+    event.dataTransfer.setData(JSON.stringify(foo), '');
+
+    // in a later read-only or protected DragEvent handler:
+    const json = event.dataTransfer.types[someIndex];
+    const foo = JSON.stringify(json);
+
+
+    There is no workaround for attempting mutating a drag data store not in
+    read/write mode.
+ */
+
+
+
+var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
+var EVENT_DROPPED = 'dropped';
+
+var ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
+
+function createDragStartHandler(root, element) {
+    return function (event) {
+        var dragParamData = event.target.dataset.drag_params;
+
+        if (dragParamData) {
+            event.dataTransfer.setData(DRAG_DATA_MIME_TYPE, dragParamData);
+
+            var zone = JSON.parse(dragParamData).zone;
+
+            if (zone) {
+                event.dataTransfer.setData(zone, '');
+            }
+
+            event.dataTransfer.effectAllowed = 'move';
+            event.target.classList.remove('v-dnd-draggable');
+            event.target.classList.add('v-dnd-moving');
+
+            event.dataTransfer.setData(ELEMENT_ID_MIME_TYPE, element.id);
+        }
+    };
+}
+
+function createDragOverHandler(root, element) {
+    return function (event) {
+        var dropZone = element.dataset.dropzone;
+
+        if (dropZone == null || event.dataTransfer.types.includes(dropZone)) {
+            if (event.preventDefault) {
+                event.preventDefault();
+            }
+            element.classList.add('v-dnd-over');
+        } else {
+            element.classList.remove('v-dnd-over');
+        }
+    };
+}
+
+function createDragLeaveHandler(root, element) {
+    return function (event) {
+        element.classList.remove('v-dnd-over');
+    };
+}
+
+function createDropHandler(root, element) {
+    // When an element is upgraded to a Voom component after being replaced via
+    // `replaces`, root may refer to the replaced element itself instead of the
+    // element's root node.
+    // Since a valid drop zone may exist anywhere on the page, it is not
+    // guaranteed that root contains the element being dragged.
+    // getRootNode will fetch `root`'s actual root node (document or shadow
+    // DOM root).
+    var trueRoot = Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* getRootNode */])(root);
+
+    return function (event) {
+        event.stopPropagation();
+        event.preventDefault();
+
+        var id = event.dataTransfer.getData(ELEMENT_ID_MIME_TYPE);
+        var draggedElement = id ? trueRoot.querySelector('#' + id) : null;
+        var dragParams = {};
+
+        if (draggedElement) {
+            dragParams = JSON.parse(draggedElement.dataset.drag_params);
+        }
+
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
+
+        // Emit a "dropped" event for the element being dragged:
+        // The drag_params of the dragged element are merged with the
+        // drop_params of the drop zone.
+        var dropZoneParams = JSON.parse(element.dataset.drop_params);
+        var params = Object.assign({}, dragParams, dropZoneParams);
+        var droppedEvent = new CustomEvent(EVENT_DROPPED, { detail: params });
+
+        draggedElement.dispatchEvent(droppedEvent);
+
+        return false;
+    };
+}
+
+function createDragEndHandler(root, element) {
+    return function (event) {
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
+    };
+}
+
+var DRAGGABLE_SELECTOR = '[draggable=true]';
+var DROP_ZONE_SELECTOR = '[data-dropzone]';
+
+function initDragAndDrop(root) {
+    var draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
+        console.log('root matches DRAGGABLE_SELECTOR');
+        draggables.unshift(root);
+    }
+
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+        for (var _iterator = draggables[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var elem = _step.value;
+
+            elem.addEventListener('dragstart', createDragStartHandler(root, elem));
+            elem.addEventListener('dragend', createDragEndHandler(root, elem));
+        }
+    } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion && _iterator.return) {
+                _iterator.return();
+            }
+        } finally {
+            if (_didIteratorError) {
+                throw _iteratorError;
+            }
+        }
+    }
+
+    var dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
+        console.log('root matches DROP_ZONE_SELECTOR');
+        dropZones.unshift(root);
+    }
+
+    var _iteratorNormalCompletion2 = true;
+    var _didIteratorError2 = false;
+    var _iteratorError2 = undefined;
+
+    try {
+        for (var _iterator2 = dropZones[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+            var _elem = _step2.value;
+
+            _elem.addEventListener('dragover', createDragOverHandler(root, _elem));
+            _elem.addEventListener('drop', createDropHandler(root, _elem));
+            _elem.addEventListener('dragleave', createDragLeaveHandler(root, _elem));
+        }
+    } catch (err) {
+        _didIteratorError2 = true;
+        _iteratorError2 = err;
+    } finally {
+        try {
+            if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                _iterator2.return();
+            }
+        } finally {
+            if (_didIteratorError2) {
+                throw _iteratorError2;
+            }
+        }
+    }
+}
+
+/***/ }),
+/* 63 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -10401,7 +10918,11 @@ var MDCComponent = function () {
 /* harmony default export */ __webpack_exports__["a"] = (MDCComponent);
 
 /***/ }),
+<<<<<<< HEAD
 /* 62 */
+=======
+/* 64 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -10582,7 +11103,11 @@ var MDCRippleAdapter = function () {
 /* unused harmony default export */ var _unused_webpack_default_export = (MDCRippleAdapter);
 
 /***/ }),
+<<<<<<< HEAD
 /* 63 */
+=======
+/* 65 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -10763,7 +11288,11 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 
 
 /***/ }),
+<<<<<<< HEAD
 /* 64 */
+=======
+/* 66 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -14346,7 +14875,11 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 65 */
+=======
+/* 67 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(Buffer, module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof2 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -27273,10 +27806,14 @@ function getNormalizedEventCoords(ev, pageOffset, clientRect) {
     /******/)["default"]
   );
 });
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(144).Buffer, __webpack_require__(2)(module)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(145).Buffer, __webpack_require__(2)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 66 */
+=======
+/* 68 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -27361,15 +27898,25 @@ var MDCFoundation = /** @class */function () {
 //# sourceMappingURL=foundation.js.map
 
 /***/ }),
+<<<<<<< HEAD
 /* 67 */
+=======
+/* 69 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgressFoundation; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(171);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(66);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(172);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_animation_util__ = __webpack_require__(172);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_base_foundation__ = __webpack_require__(68);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(173);
+>>>>>>> Ensure chips have a name before submitting values
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -27497,6 +28044,7 @@ var MDCLinearProgressFoundation = /** @class */function (_super) {
 //# sourceMappingURL=foundation.js.map
 
 /***/ }),
+<<<<<<< HEAD
 /* 68 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -27505,6 +28053,16 @@ module.exports = __webpack_require__(69);
 
 /***/ }),
 /* 69 */
+=======
+/* 70 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(71);
+
+
+/***/ }),
+/* 71 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -27596,13 +28154,21 @@ __webpack_require__(179);
 customElements.define('flow-matic', FlowMatic);
 
 /***/ }),
+<<<<<<< HEAD
 /* 70 */
+=======
+/* 72 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initButtons;
 /* unused harmony export VButton */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(71);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple__ = __webpack_require__(73);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_ripple___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_ripple__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
@@ -27701,7 +28267,11 @@ var VButton = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
+<<<<<<< HEAD
 /* 71 */
+=======
+/* 73 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -29653,17 +30223,29 @@ var VButton = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 72 */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(73);
 __webpack_require__(89);
+=======
+/* 74 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(75);
+__webpack_require__(91);
+>>>>>>> Ensure chips have a name before submitting values
 var entryUnbind = __webpack_require__(55);
 
 module.exports = entryUnbind('Array', 'flat');
 
 /***/ }),
+<<<<<<< HEAD
 /* 73 */
+=======
+/* 75 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -29690,7 +30272,11 @@ $({ target: 'Array', proto: true }, {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 74 */
+=======
+/* 76 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -29710,7 +30296,11 @@ exports.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
 } : nativePropertyIsEnumerable;
 
 /***/ }),
+<<<<<<< HEAD
 /* 75 */
+=======
+/* 77 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(8);
@@ -29728,7 +30318,11 @@ module.exports = fails(function () {
 } : Object;
 
 /***/ }),
+<<<<<<< HEAD
 /* 76 */
+=======
+/* 78 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
@@ -29737,7 +30331,11 @@ var hide = __webpack_require__(11);
 var has = __webpack_require__(10);
 var setGlobal = __webpack_require__(24);
 var nativeFunctionToString = __webpack_require__(42);
+<<<<<<< HEAD
 var InternalStateModule = __webpack_require__(78);
+=======
+var InternalStateModule = __webpack_require__(80);
+>>>>>>> Ensure chips have a name before submitting values
 
 var getInternalState = InternalStateModule.get;
 var enforceInternalState = InternalStateModule.enforce;
@@ -29770,16 +30368,27 @@ shared('inspectSource', function (it) {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 77 */
+=======
+/* 79 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports) {
 
 module.exports = false;
 
 /***/ }),
+<<<<<<< HEAD
 /* 78 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var NATIVE_WEAK_MAP = __webpack_require__(79);
+=======
+/* 80 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var NATIVE_WEAK_MAP = __webpack_require__(81);
+>>>>>>> Ensure chips have a name before submitting values
 var global = __webpack_require__(3);
 var isObject = __webpack_require__(9);
 var hide = __webpack_require__(11);
@@ -29842,7 +30451,11 @@ module.exports = {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 79 */
+=======
+/* 81 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(3);
@@ -29853,11 +30466,19 @@ var WeakMap = global.WeakMap;
 module.exports = typeof WeakMap === 'function' && /native code/.test(nativeFunctionToString.call(WeakMap));
 
 /***/ }),
+<<<<<<< HEAD
 /* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var has = __webpack_require__(10);
 var ownKeys = __webpack_require__(81);
+=======
+/* 82 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var has = __webpack_require__(10);
+var ownKeys = __webpack_require__(83);
+>>>>>>> Ensure chips have a name before submitting values
 var getOwnPropertyDescriptorModule = __webpack_require__(35);
 var definePropertyModule = __webpack_require__(23);
 
@@ -29872,6 +30493,7 @@ module.exports = function (target, source) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 81 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -29879,6 +30501,15 @@ var getBuiltIn = __webpack_require__(45);
 var getOwnPropertyNamesModule = __webpack_require__(83);
 var getOwnPropertySymbolsModule = __webpack_require__(86);
 var anObject = __webpack_require__(15);
+=======
+/* 83 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var getBuiltIn = __webpack_require__(45);
+var getOwnPropertyNamesModule = __webpack_require__(85);
+var getOwnPropertySymbolsModule = __webpack_require__(88);
+var anObject = __webpack_require__(14);
+>>>>>>> Ensure chips have a name before submitting values
 
 // all object keys, includes non-enumerable and symbols
 module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
@@ -29888,13 +30519,21 @@ module.exports = getBuiltIn('Reflect', 'ownKeys') || function ownKeys(it) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 82 */
+=======
+/* 84 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(3);
 
 /***/ }),
+<<<<<<< HEAD
 /* 83 */
+=======
+/* 85 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var internalObjectKeys = __webpack_require__(46);
@@ -29909,12 +30548,21 @@ exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 84 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var toIndexedObject = __webpack_require__(22);
 var toLength = __webpack_require__(17);
 var toAbsoluteIndex = __webpack_require__(85);
+=======
+/* 86 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var toIndexedObject = __webpack_require__(22);
+var toLength = __webpack_require__(16);
+var toAbsoluteIndex = __webpack_require__(87);
+>>>>>>> Ensure chips have a name before submitting values
 
 // `Array.prototype.{ indexOf, includes }` methods implementation
 var createMethod = function createMethod(IS_INCLUDES) {
@@ -29946,7 +30594,11 @@ module.exports = {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 85 */
+=======
+/* 87 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var toInteger = __webpack_require__(26);
@@ -29963,13 +30615,21 @@ module.exports = function (index, length) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 86 */
+=======
+/* 88 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports) {
 
 exports.f = Object.getOwnPropertySymbols;
 
 /***/ }),
+<<<<<<< HEAD
 /* 87 */
+=======
+/* 89 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(8);
@@ -29992,7 +30652,11 @@ var POLYFILL = isForced.POLYFILL = 'P';
 module.exports = isForced;
 
 /***/ }),
+<<<<<<< HEAD
 /* 88 */
+=======
+/* 90 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var fails = __webpack_require__(8);
@@ -30004,7 +30668,11 @@ module.exports = !!Object.getOwnPropertySymbols && !fails(function () {
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 89 */
+=======
+/* 91 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 // this method was added to unscopables after implementation
@@ -30014,6 +30682,7 @@ var addToUnscopables = __webpack_require__(54);
 addToUnscopables('flat');
 
 /***/ }),
+<<<<<<< HEAD
 /* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -30022,6 +30691,16 @@ var defineProperties = __webpack_require__(91);
 var enumBugKeys = __webpack_require__(27);
 var hiddenKeys = __webpack_require__(25);
 var html = __webpack_require__(93);
+=======
+/* 92 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var anObject = __webpack_require__(14);
+var defineProperties = __webpack_require__(93);
+var enumBugKeys = __webpack_require__(27);
+var hiddenKeys = __webpack_require__(25);
+var html = __webpack_require__(95);
+>>>>>>> Ensure chips have a name before submitting values
 var documentCreateElement = __webpack_require__(41);
 var sharedKey = __webpack_require__(43);
 var IE_PROTO = sharedKey('IE_PROTO');
@@ -30069,13 +30748,22 @@ module.exports = Object.create || function create(O, Properties) {
 hiddenKeys[IE_PROTO] = true;
 
 /***/ }),
+<<<<<<< HEAD
 /* 91 */
+=======
+/* 93 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var DESCRIPTORS = __webpack_require__(7);
 var definePropertyModule = __webpack_require__(23);
+<<<<<<< HEAD
 var anObject = __webpack_require__(15);
 var objectKeys = __webpack_require__(92);
+=======
+var anObject = __webpack_require__(14);
+var objectKeys = __webpack_require__(94);
+>>>>>>> Ensure chips have a name before submitting values
 
 // `Object.defineProperties` method
 // https://tc39.github.io/ecma262/#sec-object.defineproperties
@@ -30091,7 +30779,11 @@ module.exports = DESCRIPTORS ? Object.defineProperties : function defineProperti
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 92 */
+=======
+/* 94 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var internalObjectKeys = __webpack_require__(46);
@@ -30104,7 +30796,11 @@ module.exports = Object.keys || function keys(O) {
 };
 
 /***/ }),
+<<<<<<< HEAD
 /* 93 */
+=======
+/* 95 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var getBuiltIn = __webpack_require__(45);
@@ -30112,7 +30808,11 @@ var getBuiltIn = __webpack_require__(45);
 module.exports = getBuiltIn('document', 'documentElement');
 
 /***/ }),
+<<<<<<< HEAD
 /* 94 */
+=======
+/* 96 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -30121,7 +30821,11 @@ module.exports = getBuiltIn('document', 'documentElement');
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(4);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(0);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(95);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog__ = __webpack_require__(97);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__material_dialog___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3__material_dialog__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -30291,7 +30995,11 @@ var VDialog = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
+<<<<<<< HEAD
 /* 95 */
+=======
+/* 97 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -33909,13 +34617,21 @@ var VDialog = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
+<<<<<<< HEAD
 /* 96 */
+=======
+/* 98 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDateTime;
 /* unused harmony export VDateTime */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(97);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(99);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield__ = __webpack_require__(56);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_textfield___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__material_textfield__);
@@ -34041,7 +34757,11 @@ var VDateTime = function (_VTextField) {
 }(__WEBPACK_IMPORTED_MODULE_2__text_fields__["a" /* VTextField */]);
 
 /***/ }),
+<<<<<<< HEAD
 /* 97 */
+=======
+/* 99 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -36230,7 +36950,11 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = 
 });
 
 /***/ }),
+<<<<<<< HEAD
 /* 98 */
+=======
+/* 100 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -36332,7 +37056,11 @@ var VConfig = function () {
 /* harmony default export */ __webpack_exports__["a"] = (VConfig);
 
 /***/ }),
+<<<<<<< HEAD
 /* 99 */
+=======
+/* 101 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -36423,6 +37151,7 @@ var VLoads = function (_VBase) {
 module.exports = __webpack_require__(101);
 
 /***/ }),
+<<<<<<< HEAD
 /* 101 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -36595,14 +37324,22 @@ var VUrls = function () {
 
 /***/ }),
 /* 105 */
+=======
+/* 102 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VPosts; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base__ = __webpack_require__(12);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__config__ = __webpack_require__(58);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(18);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(106);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__action_parameter__ = __webpack_require__(17);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__encode__ = __webpack_require__(107);
+>>>>>>> Ensure chips have a name before submitting values
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -36938,7 +37675,65 @@ var VPosts = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
+<<<<<<< HEAD
 /* 106 */
+=======
+/* 103 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(104);
+
+/***/ }),
+/* 104 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(105);
+__webpack_require__(106);
+var entryUnbind = __webpack_require__(55);
+
+module.exports = entryUnbind('Array', 'flatMap');
+
+/***/ }),
+/* 105 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var $ = __webpack_require__(34);
+var flattenIntoArray = __webpack_require__(47);
+var toObject = __webpack_require__(51);
+var toLength = __webpack_require__(16);
+var aFunction = __webpack_require__(50);
+var arraySpeciesCreate = __webpack_require__(52);
+
+// `Array.prototype.flatMap` method
+// https://github.com/tc39/proposal-flatMap
+$({ target: 'Array', proto: true }, {
+  flatMap: function flatMap(callbackfn /* , thisArg */) {
+    var O = toObject(this);
+    var sourceLen = toLength(O.length);
+    var A;
+    aFunction(callbackfn);
+    A = arraySpeciesCreate(O, 0);
+    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+    return A;
+  }
+});
+
+/***/ }),
+/* 106 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// this method was added to unscopables after implementation
+// in popular engines, so it's moved to a separate module
+var addToUnscopables = __webpack_require__(54);
+
+addToUnscopables('flatMap');
+
+/***/ }),
+/* 107 */
+>>>>>>> Ensure chips have a name before submitting values
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -36952,7 +37747,7 @@ function encode(value) {
 }
 
 /***/ }),
-/* 107 */
+/* 108 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -36960,7 +37755,7 @@ function encode(value) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__action_parameter__ = __webpack_require__(18);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base__ = __webpack_require__(12);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__initialize__ = __webpack_require__(32);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__uninitialize__ = __webpack_require__(108);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__uninitialize__ = __webpack_require__(109);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
@@ -37127,7 +37922,7 @@ var VReplaces = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_1__base__["a" /* VBase */]);
 
 /***/ }),
-/* 108 */
+/* 109 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -37142,7 +37937,7 @@ function uninitialize(root) {
 }
 
 /***/ }),
-/* 109 */
+/* 110 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -41497,7 +42292,7 @@ function uninitialize(root) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 110 */
+/* 111 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41579,7 +42374,7 @@ var VToggleVisibility = function () {
 }();
 
 /***/ }),
-/* 111 */
+/* 112 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41699,7 +42494,7 @@ var VPromptIfDirty = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 112 */
+/* 113 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41741,7 +42536,7 @@ var VSnackbarEvent = function () {
 }();
 
 /***/ }),
-/* 113 */
+/* 114 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41807,7 +42602,7 @@ var VClears = function () {
 }();
 
 /***/ }),
-/* 114 */
+/* 115 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41868,7 +42663,7 @@ var VRemoves = function () {
 }();
 
 /***/ }),
-/* 115 */
+/* 116 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41916,7 +42711,7 @@ var VStepperEvent = function (_VBase) {
 }(__WEBPACK_IMPORTED_MODULE_0__base__["a" /* VBase */]);
 
 /***/ }),
-/* 116 */
+/* 117 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41953,7 +42748,7 @@ var VNavigates = function () {
 }();
 
 /***/ }),
-/* 117 */
+/* 118 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -41988,7 +42783,7 @@ var VPluginEventAction = function () {
 }();
 
 /***/ }),
-/* 118 */
+/* 119 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -42003,7 +42798,7 @@ function getRoot(element) {
 }
 
 /***/ }),
-/* 119 */
+/* 120 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -42214,14 +43009,14 @@ function initLists(e) {
 }
 
 /***/ }),
-/* 120 */
+/* 121 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initDrawer;
 /* unused harmony export VModalDrawer */
 /* unused harmony export VDismissibleDrawer */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(121);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer__ = __webpack_require__(122);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_drawer___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_drawer__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
@@ -42301,7 +43096,7 @@ var VDismissibleDrawer = function (_VDrawer2) {
 }(VDrawer);
 
 /***/ }),
-/* 121 */
+/* 122 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -45628,13 +46423,13 @@ var VDismissibleDrawer = function (_VDrawer2) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 122 */
+/* 123 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initHeader;
 /* unused harmony export VHeader */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(123);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__ = __webpack_require__(124);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__ = __webpack_require__(1);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -45673,19 +46468,26 @@ var VHeader = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 123 */
+/* 124 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCTopAppBar; });
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(13);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(61);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(124);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(14);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__adapter__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_ripple_index__ = __webpack_require__(125);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__constants__ = __webpack_require__(13);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__foundation__ = __webpack_require__(19);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(127);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(128);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(129);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__fixed_foundation__ = __webpack_require__(128);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__short_foundation__ = __webpack_require__(129);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__standard_foundation__ = __webpack_require__(130);
 /* unused harmony reexport MDCTopAppBarBaseFoundation */
 /* unused harmony reexport MDCTopAppBarFoundation */
 /* unused harmony reexport MDCFixedTopAppBarFoundation */
@@ -45892,16 +46694,23 @@ var MDCTopAppBar = function (_MDCComponent) {
 
 
 /***/ }),
-/* 124 */
+/* 125 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCRipple; });
 /* unused harmony export RippleCapableSurface */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(61);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(62);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(125);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(63);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_component__ = __webpack_require__(63);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(126);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(65);
+>>>>>>> Ensure chips have a name before submitting values
 /* unused harmony reexport MDCRippleFoundation */
 /* unused harmony reexport util */
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -46149,14 +46958,20 @@ RippleCapableSurface.prototype.disabled;
 
 
 /***/ }),
-/* 125 */
+/* 126 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_base_foundation__ = __webpack_require__(30);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(62);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(126);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(63);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__adapter__ = __webpack_require__(64);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__constants__ = __webpack_require__(127);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util__ = __webpack_require__(65);
+>>>>>>> Ensure chips have a name before submitting values
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -46936,7 +47751,7 @@ var MDCRippleFoundation = function (_MDCFoundation) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCRippleFoundation);
 
 /***/ }),
-/* 126 */
+/* 127 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -46997,7 +47812,7 @@ var numbers = {
 
 
 /***/ }),
-/* 127 */
+/* 128 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -47109,7 +47924,7 @@ var MDCFixedTopAppBarFoundation = function (_MDCTopAppBarFoundati) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCFixedTopAppBarFoundation);
 
 /***/ }),
-/* 128 */
+/* 129 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -47231,7 +48046,7 @@ var MDCShortTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCShortTopAppBarFoundation);
 
 /***/ }),
-/* 129 */
+/* 130 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -47504,7 +48319,7 @@ var MDCTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* harmony default export */ __webpack_exports__["a"] = (MDCTopAppBarFoundation);
 
 /***/ }),
-/* 130 */
+/* 131 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -47512,7 +48327,7 @@ var MDCTopAppBarFoundation = function (_MDCTopAppBarBaseFoun) {
 /* unused harmony export VIconToggle */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(20);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(131);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__ = __webpack_require__(132);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -47542,7 +48357,7 @@ var VIconToggle = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 131 */
+/* 132 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -50328,13 +51143,13 @@ var VIconToggle = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 132 */
+/* 133 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSelects;
 /* unused harmony export VSelect */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(133);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select__ = __webpack_require__(134);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_select___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_select__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__ = __webpack_require__(28);
@@ -50422,7 +51237,7 @@ var VSelect = function (_dirtyableMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 133 */
+/* 134 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -60654,7 +61469,7 @@ var VSelect = function (_dirtyableMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 134 */
+/* 135 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -60664,7 +61479,11 @@ var VSelect = function (_dirtyableMixin) {
 /* harmony export (immutable) */ __webpack_exports__["a"] = initChips;
 /* unused harmony export VChip */
 /* unused harmony export VChipSet */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(64);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips__ = __webpack_require__(66);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_chips___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_chips__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(0);
@@ -60733,7 +61552,7 @@ var VChip = function (_eventHandlerMixin) {
 
         // Called to collect data for submission
         value: function prepareSubmit(params) {
-            if (this.shouldSubmitParams) {
+            if (this.shouldSubmitParams()) {
                 params.push([this.name(), this.value()]);
             }
         }
@@ -60758,16 +61577,16 @@ var VChip = function (_eventHandlerMixin) {
             this.element.setAttribute('data-value', value);
         }
     }, {
+        key: 'shouldSubmitParams',
+        value: function shouldSubmitParams() {
+            // Selectable chips (those within a :filter or :choice chipset) which
+            // are not currently selected do not submit their value.
+            return this.name() && this.value() && (!this.selectable || this.mdcComponent.selected);
+        }
+    }, {
         key: 'trailingIcon',
         get: function get() {
             return this.element.querySelector('.mdc-chip__icon.mdc-chip__icon--trailing');
-        }
-    }, {
-        key: 'shouldSubmitParams',
-        get: function get() {
-            // Selectable chips (those within a :filter or :choice chipset) which
-            // are not currently selected do not submit their value.
-            return this.value() && (!this.selectable || this.mdcComponent.selected);
         }
     }, {
         key: 'selectable',
@@ -60802,7 +61621,7 @@ var VChipSet = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_2__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 135 */
+/* 136 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -60837,7 +61656,7 @@ var VCard = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 136 */
+/* 137 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -60874,13 +61693,13 @@ var VForm = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 137 */
+/* 138 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initSnackbar;
 /* unused harmony export VSnackbar */
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(138);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar__ = __webpack_require__(139);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__material_snackbar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__material_snackbar__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -60929,7 +61748,7 @@ var VSnackbar = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 138 */
+/* 139 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -62463,7 +63282,7 @@ var VSnackbar = function (_VBaseComponent) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 139 */
+/* 140 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -62471,7 +63290,7 @@ var VSnackbar = function (_VBaseComponent) {
 /* unused harmony export VCheckbox */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(20);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(140);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox__ = __webpack_require__(141);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_checkbox___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_checkbox__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -62504,7 +63323,7 @@ var VCheckbox = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 140 */
+/* 141 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -65620,7 +66439,7 @@ var VCheckbox = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 141 */
+/* 142 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -65628,7 +66447,7 @@ var VCheckbox = function (_VBaseToggle) {
 /* unused harmony export VSwitch */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(20);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(142);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch__ = __webpack_require__(143);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_switch___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_switch__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -65658,7 +66477,7 @@ var VSwitch = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 142 */
+/* 143 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -68303,15 +69122,19 @@ var VSwitch = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 143 */
+/* 144 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initRichTextArea;
 /* unused harmony export VRichTextArea */
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(65);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(67);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(148);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__rich_text_area_horizontal_rule_blot__ = __webpack_require__(149);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_event_handler__ = __webpack_require__(1);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__mixins_dirtyable__ = __webpack_require__(5);
@@ -68634,7 +69457,7 @@ function getListLevel(el) {
 }
 
 /***/ }),
-/* 144 */
+/* 145 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -68648,9 +69471,9 @@ function getListLevel(el) {
 
 
 
-var base64 = __webpack_require__(145);
-var ieee754 = __webpack_require__(146);
-var isArray = __webpack_require__(147);
+var base64 = __webpack_require__(146);
+var ieee754 = __webpack_require__(147);
+var isArray = __webpack_require__(148);
 
 exports.Buffer = Buffer;
 exports.SlowBuffer = SlowBuffer;
@@ -70378,7 +71201,7 @@ function isnan(val) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(6)))
 
 /***/ }),
-/* 145 */
+/* 146 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -70505,7 +71328,7 @@ function fromByteArray(uint8) {
 }
 
 /***/ }),
-/* 146 */
+/* 147 */
 /***/ (function(module, exports) {
 
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
@@ -70594,7 +71417,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 };
 
 /***/ }),
-/* 147 */
+/* 148 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -70604,12 +71427,16 @@ module.exports = Array.isArray || function (arr) {
 };
 
 /***/ }),
-/* 148 */
+/* 149 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return HorizontalRuleBlot; });
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(65);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill__ = __webpack_require__(67);
+>>>>>>> Ensure chips have a name before submitting values
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_quill___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_quill__);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -70659,7 +71486,7 @@ var HorizontalRuleBlot = function (_Embed) {
 }(Embed);;
 
 /***/ }),
-/* 149 */
+/* 150 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -70739,7 +71566,7 @@ var VStepper = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_0__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_1__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 150 */
+/* 151 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -70747,7 +71574,7 @@ var VStepper = function (_eventHandlerMixin) {
 /* unused harmony export VRadio */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_toggle__ = __webpack_require__(20);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(151);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio__ = __webpack_require__(152);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_radio___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_radio__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -70777,7 +71604,7 @@ var VRadio = function (_VBaseToggle) {
 }(__WEBPACK_IMPORTED_MODULE_1__base_toggle__["a" /* VBaseToggle */]);
 
 /***/ }),
-/* 151 */
+/* 152 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -73354,7 +74181,7 @@ var VRadio = function (_VBaseToggle) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 152 */
+/* 153 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -73362,7 +74189,7 @@ var VRadio = function (_VBaseToggle) {
 /* unused harmony export VSlider */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(153);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider__ = __webpack_require__(154);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_slider___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_slider__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__ = __webpack_require__(28);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__events__ = __webpack_require__(29);
@@ -73462,7 +74289,7 @@ var VSlider = function (_dirtyableMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_5__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_3__mixins_visibility_observer__["a" /* visibilityObserverMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]))));
 
 /***/ }),
-/* 153 */
+/* 154 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -75532,7 +76359,7 @@ var VSlider = function (_dirtyableMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 154 */
+/* 155 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75612,7 +76439,7 @@ var VHiddenField = function (_dirtyableMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_dirtyable__["a" /* dirtyableMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 155 */
+/* 156 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75649,7 +76476,7 @@ var VContent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 156 */
+/* 157 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75700,7 +76527,7 @@ var VColumn = function (_eventHandlerMixin2) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]));
 
 /***/ }),
-/* 157 */
+/* 158 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -75708,7 +76535,7 @@ var VColumn = function (_eventHandlerMixin2) {
 /* unused harmony export VTabBar */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__ = __webpack_require__(1);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(158);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__ = __webpack_require__(159);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_tab_bar___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_tab_bar__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -75772,7 +76599,7 @@ var VTabBar = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 158 */
+/* 159 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -82244,7 +83071,7 @@ var VTabBar = function (_eventHandlerMixin) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 159 */
+/* 160 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -82374,7 +83201,7 @@ function initTables(e) {
 }
 
 /***/ }),
-/* 160 */
+/* 161 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -82510,7 +83337,7 @@ var VFileInput = function (_dirtyableMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_2__mixins_dirtyable__["a" /* dirtyableMixin */])(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */])));
 
 /***/ }),
-/* 161 */
+/* 162 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -82518,7 +83345,7 @@ var VFileInput = function (_dirtyableMixin) {
 /* unused harmony export VFormField */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_container__ = __webpack_require__(4);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(162);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field__ = __webpack_require__(163);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__material_form_field___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2__material_form_field__);
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -82550,7 +83377,7 @@ var VFormField = function (_VBaseContainer) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_container__["a" /* VBaseContainer */]);
 
 /***/ }),
-/* 162 */
+/* 163 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(module) {var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -85055,7 +85882,7 @@ var VFormField = function (_VBaseContainer) {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)(module)))
 
 /***/ }),
-/* 163 */
+/* 164 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85100,7 +85927,7 @@ var VImage = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 164 */
+/* 165 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85150,7 +85977,7 @@ var VTypography = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 165 */
+/* 166 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85188,7 +86015,7 @@ var VTooltip = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 166 */
+/* 167 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85305,14 +86132,14 @@ var VPluginComponent = function (_eventHandlerMixin) {
 }(Object(__WEBPACK_IMPORTED_MODULE_1__mixins_event_handler__["a" /* eventHandlerMixin */])(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]));
 
 /***/ }),
-/* 167 */
+/* 168 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (immutable) */ __webpack_exports__["a"] = initProgress;
 /* unused harmony export VProgress */
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__ = __webpack_require__(168);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__ = __webpack_require__(169);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -85366,13 +86193,17 @@ var VProgress = function (_VBaseComponent) {
 }(__WEBPACK_IMPORTED_MODULE_0__base_component__["a" /* VBaseComponent */]);
 
 /***/ }),
-/* 168 */
+/* 169 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(169);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__component__ = __webpack_require__(170);
 /* harmony namespace reexport (by used) */ __webpack_require__.d(__webpack_exports__, "a", function() { return __WEBPACK_IMPORTED_MODULE_0__component__["a"]; });
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(67);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(69);
+>>>>>>> Ensure chips have a name before submitting values
 /* unused harmony namespace reexport */
 /**
  * @license
@@ -85401,14 +86232,19 @@ var VProgress = function (_VBaseComponent) {
 //# sourceMappingURL=index.js.map
 
 /***/ }),
-/* 169 */
+/* 170 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCLinearProgress; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(170);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(67);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__material_base_component__ = __webpack_require__(171);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__foundation__ = __webpack_require__(69);
+>>>>>>> Ensure chips have a name before submitting values
 /**
  * @license
  * Copyright 2017 Google Inc.
@@ -85508,13 +86344,17 @@ var MDCLinearProgress = /** @class */function (_super) {
 //# sourceMappingURL=component.js.map
 
 /***/ }),
-/* 170 */
+/* 171 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return MDCComponent; });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_tslib__ = __webpack_require__(31);
+<<<<<<< HEAD
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(66);
+=======
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__foundation__ = __webpack_require__(68);
+>>>>>>> Ensure chips have a name before submitting values
 /**
  * @license
  * Copyright 2016 Google Inc.
@@ -85619,7 +86459,7 @@ var MDCComponent = /** @class */function () {
 //# sourceMappingURL=component.js.map
 
 /***/ }),
-/* 171 */
+/* 172 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85712,7 +86552,7 @@ function getCorrectEventName(windowObj, eventType) {
 //# sourceMappingURL=util.js.map
 
 /***/ }),
-/* 172 */
+/* 173 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -85750,213 +86590,6 @@ var strings = {
     PRIMARY_BAR_SELECTOR: '.mdc-linear-progress__primary-bar'
 };
 //# sourceMappingURL=constants.js.map
-
-/***/ }),
-/* 173 */
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return DRAG_DATA_MIME_TYPE; });
-/* unused harmony export EVENT_DROPPED */
-/* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
-/*
-    A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
-    three modes:
-
-    1. read/write, during a `dragstart` event: items can be read and added
-    2. read-only, during a `drop` event: items can be read, but not added
-    3. protected, during all other types of DragEvent: items cannot be read
-       or added.
-
-    (see https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw)
-
-    Thus, attempting to mutate the store during events other than `dragstart`
-    fails silently: no error is raised, but items are not added.
-
-
-    To read items in protected mode, serialize data as a string and store it as
-    a key instead of as a value. This makes it accessible via
-    `dataTransfer.types`:
-
-    // in a dragstart handler:
-    event.dataTransfer.setData(JSON.stringify(foo), '');
-
-    // in a later read-only or protected DragEvent handler:
-    const json = event.dataTransfer.types[someIndex];
-    const foo = JSON.stringify(json);
-
-
-    There is no workaround for attempting mutating a drag data store not in
-    read/write mode.
- */
-
-
-
-var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
-var EVENT_DROPPED = 'dropped';
-
-var ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
-
-function createDragStartHandler(root, element) {
-    return function (event) {
-        var dragParamData = event.target.dataset.drag_params;
-
-        if (dragParamData) {
-            event.dataTransfer.setData(DRAG_DATA_MIME_TYPE, dragParamData);
-
-            var zone = JSON.parse(dragParamData).zone;
-
-            if (zone) {
-                event.dataTransfer.setData(zone, '');
-            }
-
-            event.dataTransfer.effectAllowed = 'move';
-            event.target.classList.remove('v-dnd-draggable');
-            event.target.classList.add('v-dnd-moving');
-
-            event.dataTransfer.setData(ELEMENT_ID_MIME_TYPE, element.id);
-        }
-    };
-}
-
-function createDragOverHandler(root, element) {
-    return function (event) {
-        var dropZone = element.dataset.dropzone;
-
-        if (dropZone == null || event.dataTransfer.types.includes(dropZone)) {
-            if (event.preventDefault) {
-                event.preventDefault();
-            }
-            element.classList.add('v-dnd-over');
-        } else {
-            element.classList.remove('v-dnd-over');
-        }
-    };
-}
-
-function createDragLeaveHandler(root, element) {
-    return function (event) {
-        element.classList.remove('v-dnd-over');
-    };
-}
-
-function createDropHandler(root, element) {
-    // When an element is upgraded to a Voom component after being replaced via
-    // `replaces`, root may refer to the replaced element itself instead of the
-    // element's root node.
-    // Since a valid drop zone may exist anywhere on the page, it is not
-    // guaranteed that root contains the element being dragged.
-    // getRootNode will fetch `root`'s actual root node (document or shadow
-    // DOM root).
-    var trueRoot = Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* getRootNode */])(root);
-
-    return function (event) {
-        event.stopPropagation();
-        event.preventDefault();
-
-        var id = event.dataTransfer.getData(ELEMENT_ID_MIME_TYPE);
-        var draggedElement = id ? trueRoot.querySelector('#' + id) : null;
-        var dragParams = {};
-
-        if (draggedElement) {
-            dragParams = JSON.parse(draggedElement.dataset.drag_params);
-        }
-
-        element.classList.remove('v-dnd-over', 'v-dnd-moving');
-        element.classList.add('v-dnd-draggable');
-
-        // Emit a "dropped" event for the element being dragged:
-        // The drag_params of the dragged element are merged with the
-        // drop_params of the drop zone.
-        var dropZoneParams = JSON.parse(element.dataset.drop_params);
-        var params = Object.assign({}, dragParams, dropZoneParams);
-        var droppedEvent = new CustomEvent(EVENT_DROPPED, { detail: params });
-
-        draggedElement.dispatchEvent(droppedEvent);
-
-        return false;
-    };
-}
-
-function createDragEndHandler(root, element) {
-    return function (event) {
-        element.classList.remove('v-dnd-over', 'v-dnd-moving');
-        element.classList.add('v-dnd-draggable');
-    };
-}
-
-var DRAGGABLE_SELECTOR = '[draggable=true]';
-var DROP_ZONE_SELECTOR = '[data-dropzone]';
-
-function initDragAndDrop(root) {
-    var draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
-
-    if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
-        console.log('root matches DRAGGABLE_SELECTOR');
-        draggables.unshift(root);
-    }
-
-    var _iteratorNormalCompletion = true;
-    var _didIteratorError = false;
-    var _iteratorError = undefined;
-
-    try {
-        for (var _iterator = draggables[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-            var elem = _step.value;
-
-            elem.addEventListener('dragstart', createDragStartHandler(root, elem));
-            elem.addEventListener('dragend', createDragEndHandler(root, elem));
-        }
-    } catch (err) {
-        _didIteratorError = true;
-        _iteratorError = err;
-    } finally {
-        try {
-            if (!_iteratorNormalCompletion && _iterator.return) {
-                _iterator.return();
-            }
-        } finally {
-            if (_didIteratorError) {
-                throw _iteratorError;
-            }
-        }
-    }
-
-    var dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
-
-    if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
-        console.log('root matches DROP_ZONE_SELECTOR');
-        dropZones.unshift(root);
-    }
-
-    var _iteratorNormalCompletion2 = true;
-    var _didIteratorError2 = false;
-    var _iteratorError2 = undefined;
-
-    try {
-        for (var _iterator2 = dropZones[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-            var _elem = _step2.value;
-
-            _elem.addEventListener('dragover', createDragOverHandler(root, _elem));
-            _elem.addEventListener('drop', createDropHandler(root, _elem));
-            _elem.addEventListener('dragleave', createDragLeaveHandler(root, _elem));
-        }
-    } catch (err) {
-        _didIteratorError2 = true;
-        _iteratorError2 = err;
-    } finally {
-        try {
-            if (!_iteratorNormalCompletion2 && _iterator2.return) {
-                _iterator2.return();
-            }
-        } finally {
-            if (_didIteratorError2) {
-                throw _iteratorError2;
-            }
-        }
-    }
-}
 
 /***/ }),
 /* 174 */

--- a/public/wc.js
+++ b/public/wc.js
@@ -2109,13 +2109,7 @@ var VEvents = function () {
             var _this2 = this;
 
             var event = this.event;
-            var eventParams = void 0;
-
-            if (event.type === 'drop' && event.dataTransfer) {
-                eventParams = JSON.parse(event.dataTransfer.getData(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* DRAG_DATA_MIME_TYPE */]));
-            } else if (event.type === 'dropped') {
-                eventParams = event.detail;
-            }
+            var eventParams = Object(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* extractDragDropData */])(event);
 
             // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries
             var fnlist = this.actions.map(function (action) {
@@ -10227,9 +10221,9 @@ var VDialog = function () {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return DRAG_DATA_MIME_TYPE; });
 /* unused harmony export EVENT_DROPPED */
 /* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
+/* harmony export (immutable) */ __webpack_exports__["a"] = extractDragDropData;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
 /*
     A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
@@ -10264,9 +10258,9 @@ var VDialog = function () {
 
 
 
-var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
 var EVENT_DROPPED = 'dropped';
 
+var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
 var ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
 
 function createDragStartHandler(root, element) {
@@ -10427,6 +10421,22 @@ function initDragAndDrop(root) {
             }
         }
     }
+}
+
+/**
+ * extractDragDropData attempts to extract a payload of drag-n-drop data from
+ * the provided event previously set during  a `dragstart` event.
+ * @param {Event} event
+ * @return {Object}
+ */
+function extractDragDropData(event) {
+    if (event.type === 'drop' && event.dataTransfer) {
+        return JSON.parse(event.dataTransfer.getData(DRAG_DATA_MIME_TYPE));
+    } else if (event.type === EVENT_DROPPED) {
+        return event.detail;
+    }
+
+    return {};
 }
 
 /***/ }),

--- a/public/wc.js
+++ b/public/wc.js
@@ -10252,7 +10252,7 @@ var VDialog = function () {
     const foo = JSON.stringify(json);
 
 
-    There is no workaround for attempting mutating a drag data store not in
+    There is no workaround for attempting to mutate a drag data store not in
     read/write mode.
  */
 
@@ -10358,7 +10358,6 @@ function initDragAndDrop(root) {
     var draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
 
     if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
-        console.log('root matches DRAGGABLE_SELECTOR');
         draggables.unshift(root);
     }
 
@@ -10391,7 +10390,6 @@ function initDragAndDrop(root) {
     var dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
 
     if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
-        console.log('root matches DROP_ZONE_SELECTOR');
         dropZones.unshift(root);
     }
 

--- a/public/wc.js
+++ b/public/wc.js
@@ -69,9 +69,10 @@
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return VBaseComponent; });
-/* harmony export (immutable) */ __webpack_exports__["c"] = hookupComponentsManually;
-/* harmony export (immutable) */ __webpack_exports__["b"] = hookupComponents;
-/* harmony export (immutable) */ __webpack_exports__["d"] = unhookupComponents;
+/* harmony export (immutable) */ __webpack_exports__["d"] = hookupComponentsManually;
+/* harmony export (immutable) */ __webpack_exports__["c"] = hookupComponents;
+/* harmony export (immutable) */ __webpack_exports__["e"] = unhookupComponents;
+/* harmony export (immutable) */ __webpack_exports__["b"] = getRootNode;
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__events_errors__ = __webpack_require__(21);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -2064,9 +2065,11 @@ var visibilityObserverMixin = function visibilityObserverMixin(Base) {
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__events_navigates__ = __webpack_require__(116);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__events_plugin__ = __webpack_require__(117);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__root_document__ = __webpack_require__(118);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_14__drag_n_drop__ = __webpack_require__(173);
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
 
 
 
@@ -2107,9 +2110,11 @@ var VEvents = function () {
 
             var event = this.event;
             var eventParams = void 0;
+
             if (event.type === 'drop' && event.dataTransfer) {
-                //console.log('Drop Data Params: ' + event.dataTransfer.getData('text/plain'));
-                eventParams = JSON.parse(event.dataTransfer.getData('text/plain'));
+                eventParams = JSON.parse(event.dataTransfer.getData(__WEBPACK_IMPORTED_MODULE_14__drag_n_drop__["a" /* DRAG_DATA_MIME_TYPE */]));
+            } else if (event.type === 'dropped') {
+                eventParams = event.detail;
             }
 
             // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries
@@ -2965,7 +2970,7 @@ function initialize(root, setRoot) {
     Object(__WEBPACK_IMPORTED_MODULE_32__progress__["a" /* initProgress */])(root);
     Object(__WEBPACK_IMPORTED_MODULE_30__tooltip__["a" /* initTooltips */])(root);
     Object(__WEBPACK_IMPORTED_MODULE_31__plugins__["a" /* initPlugins */])(root);
-    Object(__WEBPACK_IMPORTED_MODULE_33__drag_n_drop__["a" /* initDragAndDrop */])(root);
+    Object(__WEBPACK_IMPORTED_MODULE_33__drag_n_drop__["b" /* initDragAndDrop */])(root);
 
     // This needs to be last, because it relies on the components installed above.
     Object(__WEBPACK_IMPORTED_MODULE_4__events__["b" /* initEvents */])(root);
@@ -9846,7 +9851,7 @@ var AFTER_INPUT_TIMEOUT = 500; // ms
 
 function initTextFields(e) {
     console.debug('\tTextFields');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-text-field', VTextField, __WEBPACK_IMPORTED_MODULE_0__material_textfield__["MDCTextField"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-text-field', VTextField, __WEBPACK_IMPORTED_MODULE_0__material_textfield__["MDCTextField"]);
 }
 
 var VTextField = function (_dirtyableMixin) {
@@ -10094,12 +10099,12 @@ function createSurfaceClickHandler(mdcMenu) {
 
 function uninitMenus(root) {
     console.debug('\tUninit Menus');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["d" /* unhookupComponents */])(root, '.v-menu');
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["e" /* unhookupComponents */])(root, '.v-menu');
 }
 
 function initMenus(root) {
     console.debug('\tMenus');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(root, '.v-menu', VMenu, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(root, '.v-menu', VMenu, null);
 }
 
 var VMenu = function (_eventHandlerMixin) {
@@ -27616,7 +27621,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initButtons(e) {
     console.debug('\tButtons');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-button', VButton, __WEBPACK_IMPORTED_MODULE_0__material_ripple__["MDCRipple"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-button', VButton, __WEBPACK_IMPORTED_MODULE_0__material_ripple__["MDCRipple"]);
 }
 
 var VButton = function (_eventHandlerMixin) {
@@ -30179,7 +30184,7 @@ function hideDialog() {
 
 function initDialogs(e) {
     console.debug('\tDialogs');
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["b" /* hookupComponents */])(e, '.v-dialog', VDialog, __WEBPACK_IMPORTED_MODULE_3__material_dialog__["MDCDialog"]);
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponents */])(e, '.v-dialog', VDialog, __WEBPACK_IMPORTED_MODULE_3__material_dialog__["MDCDialog"]);
 }
 
 var VDialog = function (_eventHandlerMixin) {
@@ -33933,7 +33938,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initDateTime(e) {
     console.debug('\tDateTime');
-    Object(__WEBPACK_IMPORTED_MODULE_3__base_component__["b" /* hookupComponents */])(e, '.v-datetime', VDateTime, __WEBPACK_IMPORTED_MODULE_1__material_textfield__["MDCTextField"]);
+    Object(__WEBPACK_IMPORTED_MODULE_3__base_component__["c" /* hookupComponents */])(e, '.v-datetime', VDateTime, __WEBPACK_IMPORTED_MODULE_1__material_textfield__["MDCTextField"]);
 }
 
 var VDateTime = function (_VTextField) {
@@ -42235,8 +42240,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initDrawer(e) {
     console.debug('\tDrawer');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-drawer__modal', VModalDrawer, __WEBPACK_IMPORTED_MODULE_0__material_drawer__["MDCDrawer"]);
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-drawer__dismissible', VDismissibleDrawer, __WEBPACK_IMPORTED_MODULE_0__material_drawer__["MDCDrawer"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-drawer__modal', VModalDrawer, __WEBPACK_IMPORTED_MODULE_0__material_drawer__["MDCDrawer"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-drawer__dismissible', VDismissibleDrawer, __WEBPACK_IMPORTED_MODULE_0__material_drawer__["MDCDrawer"]);
 }
 
 var VDrawer = function (_eventHandlerMixin) {
@@ -45645,7 +45650,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initHeader(e) {
     console.debug('\tHeader');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-header', VHeader, __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__["a" /* MDCTopAppBar */]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-header', VHeader, __WEBPACK_IMPORTED_MODULE_0__material_top_app_bar_index__["a" /* MDCTopAppBar */]);
 }
 
 var VHeader = function (_eventHandlerMixin) {
@@ -47521,7 +47526,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initIconToggles(e) {
     console.debug('\tIcon Toggles');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-icon-toggle', VIconToggle, __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__["MDCIconToggle"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-icon-toggle', VIconToggle, __WEBPACK_IMPORTED_MODULE_2__material_icon_toggle__["MDCIconToggle"]);
 }
 
 var VIconToggle = function (_VBaseToggle) {
@@ -50349,7 +50354,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSelects(e) {
     console.debug('\tSelects');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-select', VSelect, __WEBPACK_IMPORTED_MODULE_0__material_select__["MDCSelect"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-select', VSelect, __WEBPACK_IMPORTED_MODULE_0__material_select__["MDCSelect"]);
 }
 
 var VSelect = function (_dirtyableMixin) {
@@ -60692,7 +60697,7 @@ function initChips(e) {
     // Because the chip set constructs chips on its own, a `hookupComponents`
     // call for chips is not needed.
 
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponentsManually */])(e, '.v-chip-set', function (element) {
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["d" /* hookupComponentsManually */])(e, '.v-chip-set', function (element) {
         var selectable = element.classList.contains(SELECTABLE_VARIANT_CLASS);
         var chipFactory = voomChipFactoryFactory(selectable);
         var mdcComponent = new __WEBPACK_IMPORTED_MODULE_0__material_chips__["MDCChipSet"](element, undefined, chipFactory);
@@ -60816,7 +60821,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initCards(e) {
     console.debug('\tCards');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-card', VCard, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-card', VCard, null);
 }
 
 var VCard = function (_VBaseContainer) {
@@ -60853,7 +60858,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initForms(e) {
     console.debug('\tForms');
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["b" /* hookupComponents */])(e, '.v-form', VForm, null);
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponents */])(e, '.v-form', VForm, null);
 }
 
 var VForm = function (_eventHandlerMixin) {
@@ -60891,7 +60896,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSnackbar(e) {
     console.debug('\tSnackbar');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-snackbar', VSnackbar, __WEBPACK_IMPORTED_MODULE_0__material_snackbar__["MDCSnackbar"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-snackbar', VSnackbar, __WEBPACK_IMPORTED_MODULE_0__material_snackbar__["MDCSnackbar"]);
 }
 
 // This class displays a page level message
@@ -62480,7 +62485,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initCheckboxes(e) {
     console.debug('\tCheckboxes');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-checkbox', VCheckbox, __WEBPACK_IMPORTED_MODULE_2__material_checkbox__["MDCCheckbox"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-checkbox', VCheckbox, __WEBPACK_IMPORTED_MODULE_2__material_checkbox__["MDCCheckbox"]);
 }
 
 var VCheckbox = function (_VBaseToggle) {
@@ -65637,7 +65642,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSwitches(e) {
     console.debug('\tSwitches');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-switch', VSwitch, __WEBPACK_IMPORTED_MODULE_2__material_switch__["MDCSwitch"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-switch', VSwitch, __WEBPACK_IMPORTED_MODULE_2__material_switch__["MDCSwitch"]);
 }
 
 var VSwitch = function (_VBaseToggle) {
@@ -68331,7 +68336,7 @@ var EMPTY_VALUE = '';
 
 function initRichTextArea(e) {
     console.debug('\tRich Text Area');
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["b" /* hookupComponents */])(e, '.v-rich-text-area-container', VRichTextArea, null);
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponents */])(e, '.v-rich-text-area-container', VRichTextArea, null);
 }
 
 var VRichTextArea = function (_dirtyableMixin) {
@@ -70677,7 +70682,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSteppers(e) {
     console.debug('\tStepper');
-    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["b" /* hookupComponents */])(e, '.v-stepper', VStepper, null);
+    Object(__WEBPACK_IMPORTED_MODULE_2__base_component__["c" /* hookupComponents */])(e, '.v-stepper', VStepper, null);
 }
 
 var VStepper = function (_eventHandlerMixin) {
@@ -70756,7 +70761,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initRadios(e) {
     console.debug('\tRadios');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-radio', VRadio, __WEBPACK_IMPORTED_MODULE_2__material_radio__["MDCRadio"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-radio', VRadio, __WEBPACK_IMPORTED_MODULE_2__material_radio__["MDCRadio"]);
 }
 
 var VRadio = function (_VBaseToggle) {
@@ -73381,7 +73386,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initSliders(e) {
     console.debug('\tSliders');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-slider', VSlider, __WEBPACK_IMPORTED_MODULE_2__material_slider__["MDCSlider"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-slider', VSlider, __WEBPACK_IMPORTED_MODULE_2__material_slider__["MDCSlider"]);
 }
 
 var VSlider = function (_dirtyableMixin) {
@@ -75548,7 +75553,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initHiddenFields(e) {
     console.debug('\tHiddenFields');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-hidden-field', VHiddenField, null);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-hidden-field', VHiddenField, null);
 }
 
 var VHiddenField = function (_dirtyableMixin) {
@@ -75628,7 +75633,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initContent(e) {
     console.debug('\tContent');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-content', VContent, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-content', VContent, null);
 }
 
 var VContent = function (_eventHandlerMixin) {
@@ -75666,8 +75671,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initGrid(e) {
     console.debug('\tGrid');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-grid', VGrid, null);
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-column', VColumn, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-grid', VGrid, null);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-column', VColumn, null);
 }
 
 var VGrid = function (_eventHandlerMixin) {
@@ -75717,7 +75722,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initTabBars(e) {
     console.debug('\tTab Bars');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-tab-bar', VTabBar, __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__["MDCTabBar"]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-tab-bar', VTabBar, __WEBPACK_IMPORTED_MODULE_2__material_tab_bar__["MDCTabBar"]);
 }
 
 var VTabBar = function (_eventHandlerMixin) {
@@ -82392,7 +82397,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initFileInputs(e) {
     console.debug('\tFile Inputs');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-file-input', VFileInput, null);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-file-input', VFileInput, null);
 }
 
 var VFileInput = function (_dirtyableMixin) {
@@ -82529,7 +82534,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initFormFields(e) {
     console.debug('\tForm Fields');
-    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["b" /* hookupComponents */])(e, '.v-form-field', VFormField, __WEBPACK_IMPORTED_MODULE_2__material_form_field__["MDCFormField"]);
+    Object(__WEBPACK_IMPORTED_MODULE_1__base_component__["c" /* hookupComponents */])(e, '.v-form-field', VFormField, __WEBPACK_IMPORTED_MODULE_2__material_form_field__["MDCFormField"]);
 }
 
 var VFormField = function (_VBaseContainer) {
@@ -85072,7 +85077,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initImages(e) {
     console.debug('\tImages');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-image', VImage);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-image', VImage);
 }
 
 var VImage = function (_eventHandlerMixin) {
@@ -85117,7 +85122,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initTypography(e) {
     console.debug('\tTypography');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-typography', VTypography);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-typography', VTypography);
 }
 
 var VTypography = function (_eventHandlerMixin) {
@@ -85167,7 +85172,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initTooltips(e) {
     console.debug('\tTooltips');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-tooltip', VTooltip, MaterialTooltip);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-tooltip', VTooltip, MaterialTooltip);
 }
 
 var VTooltip = function (_eventHandlerMixin) {
@@ -85206,7 +85211,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initPlugins(e) {
     console.debug('\tPlugins');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-plugin', VPluginComponent);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-plugin', VPluginComponent);
 }
 
 // Delegating plugin class. Allows a plugin to define a class-name as a data
@@ -85321,7 +85326,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function initProgress(e) {
     console.debug('\tProgress');
-    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* hookupComponents */])(e, '.v-progress', VProgress, __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__["a" /* MDCLinearProgress */]);
+    Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["c" /* hookupComponents */])(e, '.v-progress', VProgress, __WEBPACK_IMPORTED_MODULE_1__material_linear_progress__["a" /* MDCLinearProgress */]);
 }
 
 var VProgress = function (_VBaseComponent) {
@@ -85751,81 +85756,147 @@ var strings = {
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export (immutable) */ __webpack_exports__["a"] = initDragAndDrop;
-function createDragStartHandler() {
-    return function (e) {
-        var dragParamData = e.target.dataset.drag_params;
-        if (typeof dragParamData !== 'undefined') {
-            e.dataTransfer.setData("text/plain", dragParamData);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return DRAG_DATA_MIME_TYPE; });
+/* unused harmony export EVENT_DROPPED */
+/* harmony export (immutable) */ __webpack_exports__["b"] = initDragAndDrop;
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__base_component__ = __webpack_require__(0);
+/*
+    A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
+    three modes:
+
+    1. read/write, during a `dragstart` event: items can be read and added
+    2. read-only, during a `drop` event: items can be read, but not added
+    3. protected, during all other types of DragEvent: items cannot be read
+       or added.
+
+    (see https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw)
+
+    Thus, attempting to mutate the store during events other than `dragstart`
+    fails silently: no error is raised, but items are not added.
+
+
+    To read items in protected mode, serialize data as a string and store it as
+    a key instead of as a value. This makes it accessible via
+    `dataTransfer.types`:
+
+    // in a dragstart handler:
+    event.dataTransfer.setData(JSON.stringify(foo), '');
+
+    // in a later read-only or protected DragEvent handler:
+    const json = event.dataTransfer.types[someIndex];
+    const foo = JSON.stringify(json);
+
+
+    There is no workaround for attempting mutating a drag data store not in
+    read/write mode.
+ */
+
+
+
+var DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
+var EVENT_DROPPED = 'dropped';
+
+var ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
+
+function createDragStartHandler(root, element) {
+    return function (event) {
+        var dragParamData = event.target.dataset.drag_params;
+
+        if (dragParamData) {
+            event.dataTransfer.setData(DRAG_DATA_MIME_TYPE, dragParamData);
+
             var zone = JSON.parse(dragParamData).zone;
-            if (zone != null) {
-                e.dataTransfer.setData(zone, '');
+
+            if (zone) {
+                event.dataTransfer.setData(zone, '');
             }
-            e.dataTransfer.effectAllowed = 'move';
-            e.target.classList.remove('v-dnd-draggable');
-            e.target.classList.add('v-dnd-moving');
+
+            event.dataTransfer.effectAllowed = 'move';
+            event.target.classList.remove('v-dnd-draggable');
+            event.target.classList.add('v-dnd-moving');
+
+            event.dataTransfer.setData(ELEMENT_ID_MIME_TYPE, element.id);
         }
     };
 }
 
-// function createDragHandler() {
-//     return function (e) { }
-// }
+function createDragOverHandler(root, element) {
+    return function (event) {
+        var dropZone = element.dataset.dropzone;
 
-function createDragOverHandler() {
-    return function (e) {
-        var targetZone = this.dataset.dropzone;
-        if (targetZone == null || e.dataTransfer.types.includes(targetZone)) {
-            // We are allowing a drop if we are here
-            // Note that during a dragover event the event/dataTransfer object is in a protected and as a result
-            // cannot be read. However, we can interogate the set of types that it contains. My hack/workaround
-            // is that during dragStart I add the zone as a type and look for that here
-            if (e.preventDefault) {
-                e.preventDefault();
+        if (dropZone == null || event.dataTransfer.types.includes(dropZone)) {
+            if (event.preventDefault) {
+                event.preventDefault();
             }
-            this.classList.add('v-dnd-over');
+            element.classList.add('v-dnd-over');
         } else {
-            this.classList.remove('v-dnd-over');
+            element.classList.remove('v-dnd-over');
         }
     };
 }
 
-// function createDragEnterHandler() {
-//     return function (e) {}
-// }
-
-function createDragLeaveHandler() {
-    return function () {
-        this.classList.remove('v-dnd-over');
+function createDragLeaveHandler(root, element) {
+    return function (event) {
+        element.classList.remove('v-dnd-over');
     };
 }
 
-function createDropHandler() {
-    return function (e) {
-        if (e.stopPropagation) {
-            e.stopPropagation();
+function createDropHandler(root, element) {
+    // When an element is upgraded to a Voom component after being replaced via
+    // `replaces`, root may refer to the replaced element itself instead of the
+    // element's root node.
+    // Since a valid drop zone may exist anywhere on the page, it is not
+    // guaranteed that root contains the element being dragged.
+    // getRootNode will fetch `root`'s actual root node (document or shadow
+    // DOM root).
+    var trueRoot = Object(__WEBPACK_IMPORTED_MODULE_0__base_component__["b" /* getRootNode */])(root);
+
+    return function (event) {
+        event.stopPropagation();
+        event.preventDefault();
+
+        var id = event.dataTransfer.getData(ELEMENT_ID_MIME_TYPE);
+        var draggedElement = id ? trueRoot.querySelector('#' + id) : null;
+        var dragParams = {};
+
+        if (draggedElement) {
+            dragParams = JSON.parse(draggedElement.dataset.drag_params);
         }
-        if (e.preventDefault) {
-            e.preventDefault();
-        }
-        this.classList.remove('v-dnd-over');
-        this.classList.remove('v-dnd-moving');
-        this.classList.add('v-dnd-draggable');
+
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
+
+        // Emit a "dropped" event for the element being dragged:
+        // The drag_params of the dragged element are merged with the
+        // drop_params of the drop zone.
+        var dropZoneParams = JSON.parse(element.dataset.drop_params);
+        var params = Object.assign({}, dragParams, dropZoneParams);
+        var droppedEvent = new CustomEvent(EVENT_DROPPED, { detail: params });
+
+        draggedElement.dispatchEvent(droppedEvent);
+
         return false;
     };
 }
 
-function createDragEndHandler() {
-    return function (e) {
-        this.classList.remove('v-dnd-over');
-        this.classList.remove('v-dnd-moving');
-        this.classList.add('v-dnd-draggable');
+function createDragEndHandler(root, element) {
+    return function (event) {
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
     };
 }
 
-function initDragAndDrop(e) {
+var DRAGGABLE_SELECTOR = '[draggable=true]';
+var DROP_ZONE_SELECTOR = '[data-dropzone]';
 
-    var draggables = document.querySelectorAll('[draggable=true]');
+function initDragAndDrop(root) {
+    var draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
+        console.log('root matches DRAGGABLE_SELECTOR');
+        draggables.unshift(root);
+    }
+
     var _iteratorNormalCompletion = true;
     var _didIteratorError = false;
     var _iteratorError = undefined;
@@ -85834,9 +85905,8 @@ function initDragAndDrop(e) {
         for (var _iterator = draggables[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
             var elem = _step.value;
 
-            elem.addEventListener("dragstart", createDragStartHandler(), false);
-            // elem.addEventListener("drag", createDragHandler(), false);
-            elem.addEventListener("dragend", createDragEndHandler(), false);
+            elem.addEventListener('dragstart', createDragStartHandler(root, elem));
+            elem.addEventListener('dragend', createDragEndHandler(root, elem));
         }
     } catch (err) {
         _didIteratorError = true;
@@ -85853,7 +85923,13 @@ function initDragAndDrop(e) {
         }
     }
 
-    var dropZones = document.querySelectorAll('[data-dropzone]');
+    var dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
+        console.log('root matches DROP_ZONE_SELECTOR');
+        dropZones.unshift(root);
+    }
+
     var _iteratorNormalCompletion2 = true;
     var _didIteratorError2 = false;
     var _iteratorError2 = undefined;
@@ -85862,10 +85938,9 @@ function initDragAndDrop(e) {
         for (var _iterator2 = dropZones[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
             var _elem = _step2.value;
 
-            _elem.addEventListener("dragover", createDragOverHandler(), false);
-            _elem.addEventListener("drop", createDropHandler(), false);
-            // elem.addEventListener("dragenter", createDragEnterHandler(), false);
-            _elem.addEventListener("dragleave", createDragLeaveHandler(), false);
+            _elem.addEventListener('dragover', createDragOverHandler(root, _elem));
+            _elem.addEventListener('drop', createDropHandler(root, _elem));
+            _elem.addEventListener('dragleave', createDragLeaveHandler(root, _elem));
         }
     } catch (err) {
         _didIteratorError2 = true;

--- a/views/mdc/assets/js/components/base-component.js
+++ b/views/mdc/assets/js/components/base-component.js
@@ -146,7 +146,7 @@ export function unhookupComponents(root, selector) {
 }
 
 // Retrieve the element's owning document or shadow root.
-function getRootNode(node) {
+export function getRootNode(node) {
     if (!node.parentNode || isShadowRoot(node)) {
         return node;
     }

--- a/views/mdc/assets/js/components/chips.js
+++ b/views/mdc/assets/js/components/chips.js
@@ -54,7 +54,7 @@ export class VChip extends eventHandlerMixin(VBaseComponent) {
 
     // Called to collect data for submission
     prepareSubmit(params) {
-        if (this.shouldSubmitParams) {
+        if (this.shouldSubmitParams()) {
             params.push([this.name(), this.value()]);
         }
     }
@@ -75,10 +75,11 @@ export class VChip extends eventHandlerMixin(VBaseComponent) {
         this.element.setAttribute('data-value', value);
     }
 
-    get shouldSubmitParams() {
+    shouldSubmitParams() {
         // Selectable chips (those within a :filter or :choice chipset) which
         // are not currently selected do not submit their value.
-        return this.value() && (!this.selectable || this.mdcComponent.selected);
+        return this.name() && this.value()
+            && (!this.selectable || this.mdcComponent.selected);
     }
 
     get selectable() {

--- a/views/mdc/assets/js/components/chips.js
+++ b/views/mdc/assets/js/components/chips.js
@@ -8,6 +8,8 @@ export const EVENT_DESELECT = 'deselect';
 export const EVENT_TRAILING_ICON_CLICK = 'trailing_icon_click';
 
 const SELECTABLE_VARIANT_CLASS = 'v-chip-set--selectable-variant';
+const CHIP_BEHAVIOR_AUTO_REMOVE = 'auto_remove';
+const CHIP_BEHAVIOR_NO_AUTO_REMOVE = 'no_auto_remove';
 
 export function initChips(e) {
     console.debug('\tChips');
@@ -20,8 +22,7 @@ export function initChips(e) {
     // call for chips is not needed.
 
     hookupComponentsManually(e, '.v-chip-set', function(element) {
-        const selectable = element.classList.contains(SELECTABLE_VARIANT_CLASS);
-        const chipFactory = voomChipFactoryFactory(selectable);
+        const chipFactory = voomChipFactoryFactory(CHIP_BEHAVIOR_NO_AUTO_REMOVE);
         const mdcComponent = new MDCChipSet(element, undefined, chipFactory);
 
         return new VChipSet(element, mdcComponent);
@@ -90,10 +91,12 @@ export class VChip extends eventHandlerMixin(VBaseComponent) {
 }
 
 // Returns a function which constructs VChip components.
-function voomChipFactoryFactory(selectable) {
+function voomChipFactoryFactory(behavior = CHIP_BEHAVIOR_AUTO_REMOVE) {
+    const autoRemove = behavior === CHIP_BEHAVIOR_AUTO_REMOVE;
+
     return function(element) {
         const mdcComponent = new MDCChip(element);
-        mdcComponent.shouldRemoveOnTrailingIconClick = !selectable;
+        mdcComponent.shouldRemoveOnTrailingIconClick = autoRemove;
 
         return new VChip(element, mdcComponent);
     };

--- a/views/mdc/assets/js/components/drag_n_drop.js
+++ b/views/mdc/assets/js/components/drag_n_drop.js
@@ -31,9 +31,9 @@
 
 import {getRootNode} from './base-component';
 
-export const DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
 export const EVENT_DROPPED = 'dropped';
 
+const DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
 const ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
 
 function createDragStartHandler(root, element) {
@@ -155,3 +155,19 @@ export function initDragAndDrop(root) {
     }
 }
 
+/**
+ * extractDragDropData attempts to extract a payload of drag-n-drop data from
+ * the provided event previously set during  a `dragstart` event.
+ * @param {Event} event
+ * @return {Object}
+ */
+export function extractDragDropData(event) {
+    if (event.type === 'drop' && event.dataTransfer) {
+        return JSON.parse(event.dataTransfer.getData(DRAG_DATA_MIME_TYPE));
+    }
+    else if (event.type === EVENT_DROPPED) {
+        return event.detail;
+    }
+
+    return {};
+}

--- a/views/mdc/assets/js/components/drag_n_drop.js
+++ b/views/mdc/assets/js/components/drag_n_drop.js
@@ -25,7 +25,7 @@
     const foo = JSON.stringify(json);
 
 
-    There is no workaround for attempting mutating a drag data store not in
+    There is no workaround for attempting to mutate a drag data store not in
     read/write mode.
  */
 
@@ -132,7 +132,6 @@ export function initDragAndDrop(root) {
     const draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
 
     if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
-        console.log('root matches DRAGGABLE_SELECTOR');
         draggables.unshift(root);
     }
 
@@ -144,7 +143,6 @@ export function initDragAndDrop(root) {
     const dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
 
     if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
-        console.log('root matches DROP_ZONE_SELECTOR');
         dropZones.unshift(root);
     }
 

--- a/views/mdc/assets/js/components/drag_n_drop.js
+++ b/views/mdc/assets/js/components/drag_n_drop.js
@@ -1,90 +1,157 @@
-function createDragStartHandler() {
-    return function (e) {
-        var dragParamData = e.target.dataset.drag_params;
-        if(typeof dragParamData !== 'undefined'){
-            e.dataTransfer.setData("text/plain", dragParamData);
-            let zone = JSON.parse(dragParamData).zone;
-            if (zone != null){
-                e.dataTransfer.setData(zone, '');
+/*
+    A drag data store (DragEvent.prototype.dataTransfer.items) can be in one of
+    three modes:
+
+    1. read/write, during a `dragstart` event: items can be read and added
+    2. read-only, during a `drop` event: items can be read, but not added
+    3. protected, during all other types of DragEvent: items cannot be read
+       or added.
+
+    (see https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw)
+
+    Thus, attempting to mutate the store during events other than `dragstart`
+    fails silently: no error is raised, but items are not added.
+
+
+    To read items in protected mode, serialize data as a string and store it as
+    a key instead of as a value. This makes it accessible via
+    `dataTransfer.types`:
+
+    // in a dragstart handler:
+    event.dataTransfer.setData(JSON.stringify(foo), '');
+
+    // in a later read-only or protected DragEvent handler:
+    const json = event.dataTransfer.types[someIndex];
+    const foo = JSON.stringify(json);
+
+
+    There is no workaround for attempting mutating a drag data store not in
+    read/write mode.
+ */
+
+import {getRootNode} from './base-component';
+
+export const DRAG_DATA_MIME_TYPE = 'application/x.voom-drag-data+json';
+export const EVENT_DROPPED = 'dropped';
+
+const ELEMENT_ID_MIME_TYPE = 'text/x.voom-element-id';
+
+function createDragStartHandler(root, element) {
+    return function(event) {
+        const dragParamData = event.target.dataset.drag_params;
+
+        if (dragParamData) {
+            event.dataTransfer.setData(DRAG_DATA_MIME_TYPE, dragParamData);
+
+            const zone = JSON.parse(dragParamData).zone;
+
+            if (zone) {
+                event.dataTransfer.setData(zone, '');
             }
-            e.dataTransfer.effectAllowed = 'move';
-            e.target.classList.remove('v-dnd-draggable');
-            e.target.classList.add('v-dnd-moving');
+
+            event.dataTransfer.effectAllowed = 'move';
+            event.target.classList.remove('v-dnd-draggable');
+            event.target.classList.add('v-dnd-moving');
+
+            event.dataTransfer.setData(ELEMENT_ID_MIME_TYPE, element.id);
         }
-    }
-}
-
-// function createDragHandler() {
-//     return function (e) { }
-// }
-
-function createDragOverHandler() {
-    return function (e) {
-        let targetZone = this.dataset.dropzone;
-        if(targetZone == null || e.dataTransfer.types.includes(targetZone)){
-            // We are allowing a drop if we are here
-            // Note that during a dragover event the event/dataTransfer object is in a protected and as a result
-            // cannot be read. However, we can interogate the set of types that it contains. My hack/workaround
-            // is that during dragStart I add the zone as a type and look for that here
-            if (e.preventDefault) {
-                e.preventDefault();
-            }
-            this.classList.add('v-dnd-over');
-        }
-        else{
-            this.classList.remove('v-dnd-over');
-        }
-    }
-}
-
-// function createDragEnterHandler() {
-//     return function (e) {}
-// }
-
-function createDragLeaveHandler() {
-    return function () {
-        this.classList.remove('v-dnd-over');
     };
 }
 
-function createDropHandler() {
-    return function (e) {
-        if (e.stopPropagation) {
-            e.stopPropagation();
+function createDragOverHandler(root, element) {
+    return function(event) {
+        const dropZone = element.dataset.dropzone;
+
+        if (dropZone == null || event.dataTransfer.types.includes(dropZone)) {
+            if (event.preventDefault) {
+                event.preventDefault();
+            }
+            element.classList.add('v-dnd-over');
         }
-        if (e.preventDefault) {
-            e.preventDefault();
+        else {
+            element.classList.remove('v-dnd-over');
         }
-        this.classList.remove('v-dnd-over');
-        this.classList.remove('v-dnd-moving');
-        this.classList.add('v-dnd-draggable');
+    };
+}
+
+function createDragLeaveHandler(root, element) {
+    return function(event) {
+        element.classList.remove('v-dnd-over');
+    };
+}
+
+function createDropHandler(root, element) {
+    // When an element is upgraded to a Voom component after being replaced via
+    // `replaces`, root may refer to the replaced element itself instead of the
+    // element's root node.
+    // Since a valid drop zone may exist anywhere on the page, it is not
+    // guaranteed that root contains the element being dragged.
+    // getRootNode will fetch `root`'s actual root node (document or shadow
+    // DOM root).
+    const trueRoot = getRootNode(root);
+
+    return function(event) {
+        event.stopPropagation();
+        event.preventDefault();
+
+        const id = event.dataTransfer.getData(ELEMENT_ID_MIME_TYPE);
+        const draggedElement = id ? trueRoot.querySelector(`#${id}`) : null;
+        let dragParams = {};
+
+        if (draggedElement) {
+            dragParams = JSON.parse(draggedElement.dataset.drag_params);
+        }
+
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
+
+        // Emit a "dropped" event for the element being dragged:
+        // The drag_params of the dragged element are merged with the
+        // drop_params of the drop zone.
+        const dropZoneParams = JSON.parse(element.dataset.drop_params);
+        const params = Object.assign({}, dragParams, dropZoneParams);
+        const droppedEvent = new CustomEvent(EVENT_DROPPED, {detail: params});
+
+        draggedElement.dispatchEvent(droppedEvent);
+
         return false;
-    }
+    };
 }
 
-function createDragEndHandler() {
-    return function (e) {
-        this.classList.remove('v-dnd-over');
-        this.classList.remove('v-dnd-moving');
-        this.classList.add('v-dnd-draggable');
-    }
+function createDragEndHandler(root, element) {
+    return function(event) {
+        element.classList.remove('v-dnd-over', 'v-dnd-moving');
+        element.classList.add('v-dnd-draggable');
+    };
 }
 
-export function initDragAndDrop(e) {
+const DRAGGABLE_SELECTOR = '[draggable=true]';
+const DROP_ZONE_SELECTOR = '[data-dropzone]';
 
-    let draggables = document.querySelectorAll('[draggable=true]');
+export function initDragAndDrop(root) {
+    const draggables = Array.from(root.querySelectorAll(DRAGGABLE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DRAGGABLE_SELECTOR)) {
+        console.log('root matches DRAGGABLE_SELECTOR');
+        draggables.unshift(root);
+    }
+
     for (const elem of draggables) {
-        elem.addEventListener("dragstart", createDragStartHandler(), false);
-        // elem.addEventListener("drag", createDragHandler(), false);
-        elem.addEventListener("dragend", createDragEndHandler(), false);
+        elem.addEventListener('dragstart', createDragStartHandler(root, elem));
+        elem.addEventListener('dragend', createDragEndHandler(root, elem));
     }
 
-    let dropZones = document.querySelectorAll('[data-dropzone]');
+    const dropZones = Array.from(root.querySelectorAll(DROP_ZONE_SELECTOR));
+
+    if (typeof root.matches === 'function' && root.matches(DROP_ZONE_SELECTOR)) {
+        console.log('root matches DROP_ZONE_SELECTOR');
+        dropZones.unshift(root);
+    }
+
     for (const elem of dropZones) {
-        elem.addEventListener("dragover", createDragOverHandler(), false);
-        elem.addEventListener("drop", createDropHandler(), false);
-        // elem.addEventListener("dragenter", createDragEnterHandler(), false);
-        elem.addEventListener("dragleave", createDragLeaveHandler(), false);
+        elem.addEventListener('dragover', createDragOverHandler(root, elem));
+        elem.addEventListener('drop', createDropHandler(root, elem));
+        elem.addEventListener('dragleave', createDragLeaveHandler(root, elem));
     }
 }
 

--- a/views/mdc/assets/js/components/drag_n_drop.js
+++ b/views/mdc/assets/js/components/drag_n_drop.js
@@ -154,6 +154,17 @@ export function initDragAndDrop(root) {
 }
 
 /**
+ * hasDragDropData determines whether the provided event has previously-set
+ * drag-n-drop data available.
+ * @param {Event} event
+ * @return {Boolean}
+ */
+export function hasDragDropData(event) {
+    return event.type === 'drop' && event.dataTransfer
+        || event.type === EVENT_DROPPED && event.detail;
+}
+
+/**
  * extractDragDropData attempts to extract a payload of drag-n-drop data from
  * the provided event previously set during  a `dragstart` event.
  * @param {Event} event

--- a/views/mdc/assets/js/components/events.js
+++ b/views/mdc/assets/js/components/events.js
@@ -12,6 +12,7 @@ import {VStepperEvent} from './events/stepper';
 import {VNavigates} from './events/navigates';
 import {VPluginEventAction} from './events/plugin';
 import getRoot from './root_document';
+import {DRAG_DATA_MIME_TYPE} from './drag_n_drop';
 
 const EVENTS_SELECTOR = '[data-events]';
 
@@ -29,9 +30,12 @@ export class VEvents {
     call() {
         const event = this.event;
         let eventParams;
+
         if (event.type === 'drop' && event.dataTransfer) {
-            //console.log('Drop Data Params: ' + event.dataTransfer.getData('text/plain'));
-            eventParams = JSON.parse(event.dataTransfer.getData('text/plain'));
+            eventParams = JSON.parse(event.dataTransfer.getData(DRAG_DATA_MIME_TYPE));
+        }
+        else if (event.type === 'dropped') {
+            eventParams = event.detail;
         }
 
         // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries

--- a/views/mdc/assets/js/components/events.js
+++ b/views/mdc/assets/js/components/events.js
@@ -12,7 +12,7 @@ import {VStepperEvent} from './events/stepper';
 import {VNavigates} from './events/navigates';
 import {VPluginEventAction} from './events/plugin';
 import getRoot from './root_document';
-import {DRAG_DATA_MIME_TYPE} from './drag_n_drop';
+import {extractDragDropData} from './drag_n_drop';
 
 const EVENTS_SELECTOR = '[data-events]';
 
@@ -29,14 +29,7 @@ export class VEvents {
 
     call() {
         const event = this.event;
-        let eventParams;
-
-        if (event.type === 'drop' && event.dataTransfer) {
-            eventParams = JSON.parse(event.dataTransfer.getData(DRAG_DATA_MIME_TYPE));
-        }
-        else if (event.type === 'dropped') {
-            eventParams = event.detail;
-        }
+        const eventParams = extractDragDropData(event);
 
         // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries
         const fnlist = this.actions.map((action) => {

--- a/views/mdc/assets/js/components/events.js
+++ b/views/mdc/assets/js/components/events.js
@@ -12,7 +12,7 @@ import {VStepperEvent} from './events/stepper';
 import {VNavigates} from './events/navigates';
 import {VPluginEventAction} from './events/plugin';
 import getRoot from './root_document';
-import {extractDragDropData} from './drag_n_drop';
+import {hasDragDropData, extractDragDropData} from './drag_n_drop';
 
 const EVENTS_SELECTOR = '[data-events]';
 
@@ -29,7 +29,11 @@ export class VEvents {
 
     call() {
         const event = this.event;
-        const eventParams = extractDragDropData(event);
+        let eventParams = {};
+
+        if (hasDragDropData(event)) {
+            eventParams = Object.assign(eventParams, extractDragDropData(event));
+        }
 
         // Adapted from http://www.datchley.name/promise-patterns-anti-patterns/#executingpromisesinseries
         const fnlist = this.actions.map((action) => {

--- a/views/mdc/assets/scss/components/drag_n_drop.scss
+++ b/views/mdc/assets/scss/components/drag_n_drop.scss
@@ -5,13 +5,13 @@
     -moz-user-select: none;
     -webkit-user-select: none;
     -ms-user-select: none;
-    cursor: move;
+    cursor: move !important;
 }
 
 .v-dnd-draggable {
-    cursor: grab;
+    cursor: grab !important;
 }
 
 .v-dnd-over {
-    border: 2px dashed #000;
+    outline: 2px dashed #000 !important;
 }

--- a/views/mdc/components/chip.erb
+++ b/views/mdc/components/chip.erb
@@ -14,7 +14,8 @@
        class="v-chip v-input mdc-chip
               <%= color_classname(comp) %>
               <%= 'mdc-chip--selected' if comp.selected %>
-              v-menu-click"
+              v-menu-click
+              <% if comp.draggable %>v-dnd-draggable<% end %>"
        <% if comp.name %>
          data-name="<%= comp.name %>"
        <% end %>
@@ -22,6 +23,8 @@
          data-value="<%= comp.value %>"
        <% end %>
        style = "<%= color_style(comp, 'background-') %>"
+       <%= draggable_attributes(comp) %>
+       <%= drop_zone_attributes(comp) %>
        tabindex="0"
        <%= erb(:"components/event", locals: {comp: comp,
                                              events: comp.events,

--- a/views/mdc/components/chipset.erb
+++ b/views/mdc/components/chipset.erb
@@ -4,7 +4,11 @@
     variant_classes << 'v-chip-set--selectable-variant' if eq(comp.variant, :select) || eq(comp.variant, :filter)
 %>
 <div id="<%= comp.id %>"
-     class="v-chip-set mdc-chip-set <%= variant_classes.join(' ') %>"
+     class="v-chip-set mdc-chip-set
+            <%= variant_classes.join(' ') %>
+            <% if comp.draggable %>v-dnd-draggable<% end %>"
+     <%= draggable_attributes(comp) %>
+     <%= drop_zone_attributes(comp) %>
      <%= erb(:"components/event", locals: {comp: comp,
                                            events: comp.events,
                                            parent_id: comp.id}) %>>

--- a/views/mdc/components/chipset.erb
+++ b/views/mdc/components/chipset.erb
@@ -3,6 +3,10 @@
     variant_classes << "mdc-chip-set--#{comp.variant}" if comp.variant
     variant_classes << 'v-chip-set--selectable-variant' if eq(comp.variant, :select) || eq(comp.variant, :filter)
 %>
-<div class="v-chip-set mdc-chip-set <%= variant_classes.join(' ') %>">
+<div id="<%= comp.id %>"
+     class="v-chip-set mdc-chip-set <%= variant_classes.join(' ') %>"
+     <%= erb(:"components/event", locals: {comp: comp,
+                                           events: comp.events,
+                                           parent_id: comp.id}) %>>
   <%= erb :"components/render", :locals => {:components => comp.components, :scope => nil} %>
 </div>

--- a/views/mdc/package-lock.json
+++ b/views/mdc/package-lock.json
@@ -4653,7 +4653,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4674,12 +4675,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4694,17 +4697,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4821,7 +4827,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4833,6 +4840,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4847,6 +4855,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4854,12 +4863,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4878,6 +4889,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4958,7 +4970,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4970,6 +4983,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5055,7 +5069,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5091,6 +5106,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5110,6 +5126,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5153,12 +5170,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Implement `dropped` event for drag-n-drop.

The `dropped` event is fired for draggable elements when they've been dropped on a valid drop target, and is dispatched _after_ the drop target's element has dispatched its drop event.

A merge of the element-being-dragged's parameters and the drop target's parameters is used as the `dropped` event's data as follows:

* Element being dragged: `drag_params`
* Drop target element: `drop_params`

```javascript
dropped_event_data = Object.assign({}, drag_params, drop_params)
```

Any keys present on the latter override keys from the former.