### PR TITLE
Only load scripts from a flow-matic once

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -7335,7 +7335,7 @@ svg.mdc-button__icon {
   /* @alternate */
   background-color: var(--mdc-theme-secondary, #E58D36); }
 
-@keyframes mdc-checkbox-fade-in-background-ub00f1824 {
+@keyframes mdc-checkbox-fade-in-background-u32a62053 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -7347,7 +7347,7 @@ svg.mdc-button__icon {
     /* @alternate */
     background-color: var(--mdc-theme-secondary, #E58D36); } }
 
-@keyframes mdc-checkbox-fade-out-background-ub00f1824 {
+@keyframes mdc-checkbox-fade-out-background-u32a62053 {
   0%,
   80% {
     border-color: #E58D36;
@@ -7361,10 +7361,10 @@ svg.mdc-button__icon {
     background-color: transparent; } }
 
 .mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-ub00f1824; }
+  animation-name: mdc-checkbox-fade-in-background-u32a62053; }
 
 .mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-ub00f1824; }
+  animation-name: mdc-checkbox-fade-out-background-u32a62053; }
 
 .mdc-checkbox__checkmark {
   color: #fff; }
@@ -15881,7 +15881,7 @@ button.mdc-chip {
   /* @alternate */
   background-color: var(--mdc-theme-primary, #5488b2); }
 
-@keyframes mdc-checkbox-fade-in-background-ue8f7bd27 {
+@keyframes mdc-checkbox-fade-in-background-u0b46f1b7 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -15893,7 +15893,7 @@ button.mdc-chip {
     /* @alternate */
     background-color: var(--mdc-theme-primary, #5488b2); } }
 
-@keyframes mdc-checkbox-fade-out-background-ue8f7bd27 {
+@keyframes mdc-checkbox-fade-out-background-u0b46f1b7 {
   0%,
   80% {
     border-color: #5488b2;
@@ -15909,12 +15909,12 @@ button.mdc-chip {
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-ue8f7bd27; }
+  animation-name: mdc-checkbox-fade-in-background-u0b46f1b7; }
 
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-ue8f7bd27; }
+  animation-name: mdc-checkbox-fade-out-background-u0b46f1b7; }
 
 .mdc-data-table .mdc-list-item__graphic {
   margin-right: 0px; }

--- a/public/wc.js
+++ b/public/wc.js
@@ -28978,6 +28978,12 @@ var FlowMatic = function (_HTMLElement) {
         value: function loadScripts(root) {
             var _this3 = this;
 
+            if (window.FLOW_MATIC_SCRIPTS_LOADED) {
+                return Promise.resolve();
+            } else {
+                window.FLOW_MATIC_SCRIPTS_LOADED = true;
+            }
+
             var scripts = Array.from(root.querySelectorAll('script'));
             var remoteScripts = scripts.filter(function (s) {
                 return s.hasAttribute('src');

--- a/views/mdc/assets/js/wc.js
+++ b/views/mdc/assets/js/wc.js
@@ -68,6 +68,12 @@ class FlowMatic extends HTMLElement {
     // This function collects a promise for each remote script and once they're all loaded
     // it adds the inline scripts.
     loadScripts(root) {
+        if (window.FLOW_MATIC_SCRIPTS_LOADED) {
+          return Promise.resolve();
+        } else {
+          window.FLOW_MATIC_SCRIPTS_LOADED = true;
+        }
+
         const scripts = Array.from(root.querySelectorAll('script'));
         const remoteScripts = scripts.filter((s) => { return s.hasAttribute('src'); });
         const inlineScripts = scripts.filter((s) => { return !remoteScripts.includes(s); });


### PR DESCRIPTION
If we use a flow-matic more than once on a page that each load the same
js the second was raising errors for classes already being defined.
Preventing that with a variable now.  This will cause issues down the
road if we load 2 different components that have different scripts