### PR TITLE
Allow the use of a dialog from a list line.

### DIFF
--- a/lib/voom/presenters/dsl/components/lists/line.rb
+++ b/lib/voom/presenters/dsl/components/lists/line.rb
@@ -6,10 +6,11 @@ module Voom
           class Line < EventBase
             extend Gem::Deprecate
             include Mixins::Tooltips
+            include Mixins::Dialogs
 
             CHECKBOX_ATTRIBUTES = %i[name value checked dirtyable value off_value].freeze
 
-            attr_accessor :selected, :selectable
+            attr_accessor :selected, :selectable, :components
 
             def initialize(**attribs_, &block)
               super(type: :line, **attribs_, &block)
@@ -27,7 +28,7 @@ module Voom
               elsif attribs.key?(:checkbox)
                 self.checkbox(attribs.delete(:checkbox))
               end
-
+              @components = []
               @actions = []
               expand!
             end

--- a/public/bundle.css
+++ b/public/bundle.css
@@ -7335,7 +7335,7 @@ svg.mdc-button__icon {
   /* @alternate */
   background-color: var(--mdc-theme-secondary, #E58D36); }
 
-@keyframes mdc-checkbox-fade-in-background-u32a62053 {
+@keyframes mdc-checkbox-fade-in-background-ud2d70e45 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -7347,7 +7347,7 @@ svg.mdc-button__icon {
     /* @alternate */
     background-color: var(--mdc-theme-secondary, #E58D36); } }
 
-@keyframes mdc-checkbox-fade-out-background-u32a62053 {
+@keyframes mdc-checkbox-fade-out-background-ud2d70e45 {
   0%,
   80% {
     border-color: #E58D36;
@@ -7361,10 +7361,10 @@ svg.mdc-button__icon {
     background-color: transparent; } }
 
 .mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-u32a62053; }
+  animation-name: mdc-checkbox-fade-in-background-ud2d70e45; }
 
 .mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-u32a62053; }
+  animation-name: mdc-checkbox-fade-out-background-ud2d70e45; }
 
 .mdc-checkbox__checkmark {
   color: #fff; }
@@ -15881,7 +15881,7 @@ button.mdc-chip {
   /* @alternate */
   background-color: var(--mdc-theme-primary, #5488b2); }
 
-@keyframes mdc-checkbox-fade-in-background-u0b46f1b7 {
+@keyframes mdc-checkbox-fade-in-background-udc6d9a8a {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -15893,7 +15893,7 @@ button.mdc-chip {
     /* @alternate */
     background-color: var(--mdc-theme-primary, #5488b2); } }
 
-@keyframes mdc-checkbox-fade-out-background-u0b46f1b7 {
+@keyframes mdc-checkbox-fade-out-background-udc6d9a8a {
   0%,
   80% {
     border-color: #5488b2;
@@ -15909,12 +15909,12 @@ button.mdc-chip {
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-u0b46f1b7; }
+  animation-name: mdc-checkbox-fade-in-background-udc6d9a8a; }
 
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-u0b46f1b7; }
+  animation-name: mdc-checkbox-fade-out-background-udc6d9a8a; }
 
 .mdc-data-table .mdc-list-item__graphic {
   margin-right: 0px; }

--- a/views/mdc/components/list/line.erb
+++ b/views/mdc/components/list/line.erb
@@ -43,3 +43,4 @@
 </div>
 <%end%>
 <%= erb :"components/tooltip", :locals => {comp: line.tooltip, parent_id: line.id} %>
+<%= erb :"components/render", :locals => {:components => line.components, :scope => nil} %>


### PR DESCRIPTION
This simply allows a list line action to open a dialog. I'm not sure about this behavior. There is an [expand and collapse](https://material.io/components/lists/#types) list control spec that I think would work better. But, the MDC developers have decided [not to implement](https://github.com/material-components/material-components-web/issues/46) any expand/collapse controls in the web components. I think dialogs will do for now.