### PR TITLE
Add before_render configuration setting

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,81 @@
+# Configuration
+Presenters can be configured via settings set in e.g. Rails initializers.
+
+## Overview
+Configuration is handled via [dry-configurable](https://github.com/dry-rb/dry-configurable).
+
+```ruby
+Voom::Presenters::Settings.configure do |config|
+  config.presenters.helpers << SomeHelperClass
+end
+```
+
+## Table of Contents
+* [`before_render`](#before_render)
+
+## Settings
+### `before_render`
+`before_render` is an array of things which respond to `#call/1`. The items in
+the array are lazily invoked with the current request prior to a Presenter
+being rendered.
+
+If an item returns a non-`nil` Presenter name, this Presenter will be rendered
+instead of the Presenter that was about to be rendered. In this case, subsequent
+`before_render` items will not be invoked.
+
+```ruby
+# request: /foos/foo?id=1
+
+Voom::Presenters::Settings.configure do |config|
+  config.presenters.before_render << lambda do |req|
+    if some_predicate?
+      return :render_me_instead
+      # /render_me_instead?id=1 will be rendered instead of /foos/foo?id=1.
+    end
+
+    # return nil will not intercept rendering and the next lambda will be
+    # invoked.
+  end
+
+  # this lambda will be invoked only if all previous lambdas returned nil.
+  config.presenters.before_render << lambda do |req|
+    puts 'if you see me, some_predicate? returned true'
+
+    # return nil will not intercept rendering and the next lambda will be
+    # invoked.
+  end
+end
+```
+
+If all items return `nil`, the original Presenter is rendered unintercepted.
+
+#### Returning context
+
+A `before_render` item may optionally return a context hash. This hash will be
+passed to the rendered presenter and merged with existing context at render
+time. **Key names in a returned context hash will overwrite the request's
+context, so use with caution.**
+
+```ruby
+# request: /foos/foo?id=1
+
+class AuthenticationCheck
+  def initialize; end
+
+  def call(req)
+    unless authenticated?(req)
+      return ['auth:login', { timestamp: Time.current.to_i }]
+      # /auth/login?id=1&timestamp=1579535489 will be rendered instead of
+      # /foos/foo?id=1.
+      # /auth/login will have context { id: 1, timestamp: 1579535489 }
+    end
+
+    # return nil will not intercept rendering and the next lambda will be
+    # invoked.
+  end
+end
+
+Voom::Presenters::Settings.configure do |config|
+  config.presenters.before_render << AuthenticationCheck.new
+end
+```

--- a/lib/voom/presenters/api/app.rb
+++ b/lib/voom/presenters/api/app.rb
@@ -33,16 +33,28 @@ module Voom
         # analogous to Voom::Presenters::WebClient::App#render_presenter
         def render_presenter(presenter)
           begin
+            before_render = Presenters::Settings.config.presenters.before_render
+            render_instead, ctx = before_render
+                                    .lazy
+                                    .map { |p| p.call(request) }
+                                    .detect(&:itself)
+
+            if Presenters::App.registered?(render_instead)
+              presenter = render_instead
+            end
+
+            p = params.merge(ctx || {})
             presenter = Voom::Presenters::App[presenter].call
-            pom = presenter.expand(router: router, context: prepare_context)
+            pom = presenter.expand(router: router, context: prepare_context(p))
             content_type :json
             JSON.dump(pom.to_hash)
           rescue StandardError => e
+            presenter_name = presenter.respond_to?(:name) ? presenter.name : '(unknown)'
             Presenters::Settings.config.presenters.error_logger.call(
               @env['rack.errors'],
               e,
               params,
-              presenter.name
+              presenter_name
             )
             raise e
           end
@@ -52,10 +64,10 @@ module Voom
           settings.router_.new(base_url: "#{request.base_url}#{env['SCRIPT_NAME']}")
         end
 
-        def prepare_context
+        def prepare_context(base_params = params)
           prepare_context = Presenters::Settings.config.presenters.web_client.prepare_context.dup
           prepare_context.push(method(:scrub_context))
-          context = params.dup
+          context = base_params.dup
           prepare_context.reduce(context) do |params, context_proc|
             context_proc.call(params, session, env)
           end

--- a/lib/voom/presenters/settings.rb
+++ b/lib/voom/presenters/settings.rb
@@ -68,6 +68,7 @@ unless defined?(Voom::Presenters::Settings)
             ].join("\n\t")
             file.puts(msg)
           }
+          setting :before_render, [] # an array of `#call`ables
         end
 
         def self.default(type, key)


### PR DESCRIPTION
The `before_render` configuration setting holds an array of objects
which respond to `#call/1`. Each is lazily invoked with the current
request before a Presenter is rendered (in both the web client and the
API app).

If a `before_render` item returns a non-`nil` registered Presenter name,
the Presenter identified by the returned name will be rendered instead
of the original Presenter.

If all `before_render` items return `nil`, rendering is not intercepted,
and the original Presenter is rendered unhindered.

`before_render` items can also optionally return a context hash which
will be merged with the request's original context. The returned context
hash from `before_render` will destructively overwrite keys on the
request's original context hash.

This setting and its behaviors are documented in the new documentation
file `docs/settings.md`.