### PR TITLE
Render table pagination buttons as buttons

### DIFF
--- a/lib/voom/presenters/dsl/components/table.rb
+++ b/lib/voom/presenters/dsl/components/table.rb
@@ -159,7 +159,7 @@ module Voom
 
             def button(icon_name, page, replace_id = @replace_id, replace_presenter = @replace_presenter)
               __attribs__ = attribs.merge({page: page, page_size: @page_size})
-              Components::Icon.new(parent: self, icon: icon_name) do
+              Components::Button.new(parent: self, type: :icon, icon: icon_name) do
                 event :click do
                    replaces replace_id, replace_presenter, __attribs__
                 end

--- a/views/mdc/components/table/pagination.erb
+++ b/views/mdc/components/table/pagination.erb
@@ -6,10 +6,6 @@
   <span class="v-paging__count">
     <%= comp.range&.join(' - ') %> of <%= comp.total %>
   </span>
-  <button class="v-button v-button--icon v-button--pagination v-button--pagination--previous mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon v-paging__prev">
-    <%= erb :"components/icon", :locals => {:comp=>comp.previous_button} %>
-  </button>
-  <button class="v-button v-button--icon v-button--pagination v-button--pagination--next mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon v-paging__next">
-    <%= erb :"components/icon", :locals => {:comp=>comp.next_button} %>
-  </button>
+  <%= erb :'components/button', locals: { comp: comp.previous_button, class_name: 'v-actionable v-button--pagination v-button--pagination--previous v-paging__prev' } %>
+  <%= erb :'components/button', locals: { comp: comp.next_button, class_name: 'v-actionable v-button--pagination v-button--pagination--next v-paging__next' } %>
 </div>


### PR DESCRIPTION
When an Icon component is rendered within a `<button>` element, the Icon
component's `<i>` element never receives events (e.g. click) as they
are handled by the parent `<button>`.