### PR TITLE
Fix frozen string mutation issue with Ruby 2.7.0

### DIFF
--- a/lib/voom/presenters/dsl/components/lists/line.rb
+++ b/lib/voom/presenters/dsl/components/lists/line.rb
@@ -72,7 +72,7 @@ module Voom
               # Append [] if the list is selectable and the checkbox's name
               # doesn't already include brackets:
               field_name = attributes.delete(:name).to_s
-              field_name << '[]' if @selectable && !field_name.include?('[')
+              field_name += '[]' if @selectable && !field_name.include?('[')
 
               @checkbox = Components::Checkbox.new(parent: self,
                                                    name: field_name,


### PR DESCRIPTION
As of Ruby 2.7.0, `nil.to_s` now returns a frozen string. Attempting to
mutate it via `#<<` now results in a frozen String error.

See https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released:

>Module#name, true.to_s, false.to_s, and nil.to_s now always return a frozen String. The returned String is always the same for a given object. [Experimental] [[Feature #16150](https://bugs.ruby-lang.org/issues/16150)]