### PR TITLE
Ensure lifecycle events are always dispatched

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -7335,7 +7335,7 @@ svg.mdc-button__icon {
   /* @alternate */
   background-color: var(--mdc-theme-secondary, #E58D36); }
 
-@keyframes mdc-checkbox-fade-in-background-uf550c25e {
+@keyframes mdc-checkbox-fade-in-background-u7ac1fb58 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -7347,7 +7347,7 @@ svg.mdc-button__icon {
     /* @alternate */
     background-color: var(--mdc-theme-secondary, #E58D36); } }
 
-@keyframes mdc-checkbox-fade-out-background-uf550c25e {
+@keyframes mdc-checkbox-fade-out-background-u7ac1fb58 {
   0%,
   80% {
     border-color: #E58D36;
@@ -7361,10 +7361,10 @@ svg.mdc-button__icon {
     background-color: transparent; } }
 
 .mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-uf550c25e; }
+  animation-name: mdc-checkbox-fade-in-background-u7ac1fb58; }
 
 .mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-uf550c25e; }
+  animation-name: mdc-checkbox-fade-out-background-u7ac1fb58; }
 
 .mdc-checkbox__checkmark {
   color: #fff; }
@@ -15881,7 +15881,7 @@ button.mdc-chip {
   /* @alternate */
   background-color: var(--mdc-theme-primary, #5488b2); }
 
-@keyframes mdc-checkbox-fade-in-background-u69b797b8 {
+@keyframes mdc-checkbox-fade-in-background-ucd386d18 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -15893,7 +15893,7 @@ button.mdc-chip {
     /* @alternate */
     background-color: var(--mdc-theme-primary, #5488b2); } }
 
-@keyframes mdc-checkbox-fade-out-background-u69b797b8 {
+@keyframes mdc-checkbox-fade-out-background-ucd386d18 {
   0%,
   80% {
     border-color: #5488b2;
@@ -15909,12 +15909,12 @@ button.mdc-chip {
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-u69b797b8; }
+  animation-name: mdc-checkbox-fade-in-background-ucd386d18; }
 
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-u69b797b8; }
+  animation-name: mdc-checkbox-fade-out-background-ucd386d18; }
 
 .mdc-data-table .mdc-list-item__graphic {
   margin-right: 0px; }

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -48507,6 +48507,8 @@ var VPosts = function (_VBase) {
     _createClass(VPosts, [{
         key: 'call',
         value: function call(results, eventParams) {
+            var _this2 = this;
+
             this.clearErrors();
             var errors = this.validate();
             var method = this.method;
@@ -48529,8 +48531,9 @@ var VPosts = function (_VBase) {
                 detail: this,
                 composed: true
             });
-            var target = Object(__WEBPACK_IMPORTED_MODULE_4__get_event_target__["a" /* getEventTarget */])(this.event);
-            target.dispatchEvent(ev);
+
+            this.dispatchLifecycleEvent(this.event, ev);
+
             // Manually build the FormData.
             // Passing in a <form> element (if available) would skip over
             // unchecked toggle elements, which would be unexpected if the user
@@ -48684,12 +48687,12 @@ var VPosts = function (_VBase) {
             return new Promise(function (resolve, reject) {
                 httpRequest.onreadystatechange = function (event) {
                     if (httpRequest.readyState === XMLHttpRequest.DONE) {
-                        var contentType = this.getResponseHeader('content-type');
+                        var contentType = httpRequest.getResponseHeader('content-type');
                         console.debug(httpRequest.status + ':' + contentType);
 
                         var result = {
                             action: 'posts',
-                            method: this.method,
+                            method: httpRequest.method,
                             statusCode: httpRequest.status,
                             contentType: contentType,
                             content: httpRequest.responseText,
@@ -48703,7 +48706,7 @@ var VPosts = function (_VBase) {
                             detail: { event: vEvent, result: result },
                             composed: true
                         });
-                        target.dispatchEvent(_ev);
+                        _this2.dispatchLifecycleEvent(_this2.event, _ev);
 
                         if (httpRequest.status >= 200 && httpRequest.status < 300) {
                             results.push(result);
@@ -48727,7 +48730,7 @@ var VPosts = function (_VBase) {
                             detail: { event: vEvent, result: result },
                             composed: true
                         });
-                        target.dispatchEvent(evFinished);
+                        _this2.dispatchLifecycleEvent(_this2.event, evFinished);
                     }
                 };
                 // Set up our request
@@ -48814,6 +48817,22 @@ var VPosts = function (_VBase) {
                 return this.parentElement();
             }
             return null;
+        }
+    }, {
+        key: 'dispatchLifecycleEvent',
+        value: function dispatchLifecycleEvent(domEvent, lifecycleEvent) {
+            var target = Object(__WEBPACK_IMPORTED_MODULE_4__get_event_target__["a" /* getEventTarget */])(domEvent);
+
+            if (!target || !target.isConnected) {
+                // If an action has hidden `target` or its parent (via e.g.
+                // `hides :some_element`), it will no longer be connected to the DOM
+                // and its dispatched lifecycle events won't make it up to the root.
+                // Instead, dispatch straight from the root instead of bubbling up
+                // from the DOM event's target.
+                target = this.root;
+            }
+
+            return target.dispatchEvent(lifecycleEvent);
         }
     }]);
 

--- a/public/wc.js
+++ b/public/wc.js
@@ -33981,6 +33981,8 @@ var VPosts = function (_VBase) {
     _createClass(VPosts, [{
         key: 'call',
         value: function call(results, eventParams) {
+            var _this2 = this;
+
             this.clearErrors();
             var errors = this.validate();
             var method = this.method;
@@ -34003,8 +34005,9 @@ var VPosts = function (_VBase) {
                 detail: this,
                 composed: true
             });
-            var target = Object(__WEBPACK_IMPORTED_MODULE_4__get_event_target__["a" /* getEventTarget */])(this.event);
-            target.dispatchEvent(ev);
+
+            this.dispatchLifecycleEvent(this.event, ev);
+
             // Manually build the FormData.
             // Passing in a <form> element (if available) would skip over
             // unchecked toggle elements, which would be unexpected if the user
@@ -34158,12 +34161,12 @@ var VPosts = function (_VBase) {
             return new Promise(function (resolve, reject) {
                 httpRequest.onreadystatechange = function (event) {
                     if (httpRequest.readyState === XMLHttpRequest.DONE) {
-                        var contentType = this.getResponseHeader('content-type');
+                        var contentType = httpRequest.getResponseHeader('content-type');
                         console.debug(httpRequest.status + ':' + contentType);
 
                         var result = {
                             action: 'posts',
-                            method: this.method,
+                            method: httpRequest.method,
                             statusCode: httpRequest.status,
                             contentType: contentType,
                             content: httpRequest.responseText,
@@ -34177,7 +34180,7 @@ var VPosts = function (_VBase) {
                             detail: { event: vEvent, result: result },
                             composed: true
                         });
-                        target.dispatchEvent(_ev);
+                        _this2.dispatchLifecycleEvent(_this2.event, _ev);
 
                         if (httpRequest.status >= 200 && httpRequest.status < 300) {
                             results.push(result);
@@ -34201,7 +34204,7 @@ var VPosts = function (_VBase) {
                             detail: { event: vEvent, result: result },
                             composed: true
                         });
-                        target.dispatchEvent(evFinished);
+                        _this2.dispatchLifecycleEvent(_this2.event, evFinished);
                     }
                 };
                 // Set up our request
@@ -34288,6 +34291,22 @@ var VPosts = function (_VBase) {
                 return this.parentElement();
             }
             return null;
+        }
+    }, {
+        key: 'dispatchLifecycleEvent',
+        value: function dispatchLifecycleEvent(domEvent, lifecycleEvent) {
+            var target = Object(__WEBPACK_IMPORTED_MODULE_4__get_event_target__["a" /* getEventTarget */])(domEvent);
+
+            if (!target || !target.isConnected) {
+                // If an action has hidden `target` or its parent (via e.g.
+                // `hides :some_element`), it will no longer be connected to the DOM
+                // and its dispatched lifecycle events won't make it up to the root.
+                // Instead, dispatch straight from the root instead of bubbling up
+                // from the DOM event's target.
+                target = this.root;
+            }
+
+            return target.dispatchEvent(lifecycleEvent);
         }
     }]);
 


### PR DESCRIPTION
If an action block hides an event target element (or its parent), the
`V:postFinished` event cannot bubble up to the root, as hidden
elements are no longer connected to the DOM.

This change dispatches the lifecycle event from the root instead of the
disconnected source element.

This affected the progress bar component, which was using the
`V:postFinished` event to hide itself.