### PR TITLE
Fix text field icons

### DIFF
--- a/views/mdc/components/icon.erb
+++ b/views/mdc/components/icon.erb
@@ -24,8 +24,9 @@
             <%= 'v-actionable' if comp.events %>
             <%= color_classname(comp) %>"
       <%= "data-#{data}" if data %>
-       style = "<%= color_style(comp) %>"
-       <%= erb :"components/event", :locals => {comp: comp, events: events, parent_id: parent_id} %>>
+      style="<%= color_style(comp) %>"
+      <%= 'tabindex="0"' if comp.events %>
+      <%= erb :"components/event", :locals => {comp: comp, events: events, parent_id: parent_id} %>>
     <%= icon %>
   </i>
   <%= erb :"components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} %>


### PR DESCRIPTION
Icons rendered within text fields must have a tabindex set in order to
respond to click events. Add the tabindex attribute back with value 0.