### PR TITLE
Introduce text_field `behavior` attribute

### DIFF
--- a/lib/voom/presenters/dsl/components/text_field.rb
+++ b/lib/voom/presenters/dsl/components/text_field.rb
@@ -3,16 +3,20 @@ module Voom
     module DSL
       module Components
         class TextField < Input
-          attr_reader :required, :full_width, :password, :auto_complete, :case_type
+          attr_reader :required,
+                      :full_width,
+                      :auto_complete,
+                      :case_type,
+                      :behavior
           VALID_CASE_TYPES = %i[mixed upper lower].freeze
 
           def initialize(**attribs_, &block)
             super(type: :text_field, **attribs_, &block)
             @required = attribs.delete(:required){ false }
             @full_width = attribs.delete(:full_width){ true }
-            @password = attribs.delete(:password){ false }
             @case_type = validate_case_type(attribs.delete(:case_type) { :mixed })
             @auto_complete = validate_auto_complete(attribs.delete(:auto_complete) { :off })
+            @behavior = determine_behavior(attribs.delete(:password), attribs.delete(:behavior))
             label(attribs.delete(:label))if attribs.key?(:label)
             value(attribs.delete(:value))if attribs.key?(:value)
             expand!
@@ -50,6 +54,7 @@ module Voom
           end
 
           private
+
           def json_regexp(regexp)
             str = regexp.inspect.
                 sub('\\A', '^').
@@ -82,9 +87,25 @@ module Voom
             case_type
           end
 
+          def determine_behavior(password, behavior)
+            unless password.nil?
+              logger.warn(
+                'The `password` attribute of text_field is deprecated. ' \
+                'Use `text_field behavior: :password` instead.'
+              )
+            end
+
+            case password
+            when nil
+              behavior
+            when true
+              :password
+            when false
+              :text
+            end
+          end
         end
       end
     end
   end
 end
-

--- a/views/mdc/components/text_field.erb
+++ b/views/mdc/components/text_field.erb
@@ -2,6 +2,7 @@
      leading_icon = comp.icon && comp.icon.position.select {|p| eq(p, :left)}.any?
      trailing_icon = comp.icon && comp.icon.position.select {|p| eq(p, :right)}.any?
      auto_complete = comp.auto_complete&.to_sym == :off ? 'extra-off' : comp.auto_complete
+     behavior = comp.behavior || 'text'
 %>
   <div id="<%= comp.id %>"
        <% if comp.tag %>data-input-tag="<%= comp.tag %>"<% end %>
@@ -16,7 +17,7 @@
 
     <input id="<%= comp.id %>-input"
            name="<%= comp.name %>"
-           type="<%= comp.password ? 'password' : 'text' %>"
+           type="<%= behavior %>"
            value="<%= comp.value %>"
            class="mdc-text-field__input"
            aria-controls="<%= comp.id %>-input-helper-text"


### PR DESCRIPTION
The behavior allows clients to determine how the text field functions. The user-provided value is passed through to the client, which may or may not implement the specified behavior.

For instance, `behavior: :password` allows the MDC web client to render a masked text field that does not reveal its contents (via the `type="password"` `<input>` attribute).

To maintain backward compatibility with existing text fields, the `password` attribute is translated to `behavior: :password`.