### PR TITLE
Fix snackbar callback

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -7335,7 +7335,7 @@ svg.mdc-button__icon {
   /* @alternate */
   background-color: var(--mdc-theme-secondary, #E58D36); }
 
-@keyframes mdc-checkbox-fade-in-background-u7ac1fb58 {
+@keyframes mdc-checkbox-fade-in-background-u70bb8b64 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -7347,7 +7347,7 @@ svg.mdc-button__icon {
     /* @alternate */
     background-color: var(--mdc-theme-secondary, #E58D36); } }
 
-@keyframes mdc-checkbox-fade-out-background-u7ac1fb58 {
+@keyframes mdc-checkbox-fade-out-background-u70bb8b64 {
   0%,
   80% {
     border-color: #E58D36;
@@ -7361,10 +7361,10 @@ svg.mdc-button__icon {
     background-color: transparent; } }
 
 .mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-u7ac1fb58; }
+  animation-name: mdc-checkbox-fade-in-background-u70bb8b64; }
 
 .mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-u7ac1fb58; }
+  animation-name: mdc-checkbox-fade-out-background-u70bb8b64; }
 
 .mdc-checkbox__checkmark {
   color: #fff; }
@@ -15881,7 +15881,7 @@ button.mdc-chip {
   /* @alternate */
   background-color: var(--mdc-theme-primary, #5488b2); }
 
-@keyframes mdc-checkbox-fade-in-background-ucd386d18 {
+@keyframes mdc-checkbox-fade-in-background-ud52354eb {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -15893,7 +15893,7 @@ button.mdc-chip {
     /* @alternate */
     background-color: var(--mdc-theme-primary, #5488b2); } }
 
-@keyframes mdc-checkbox-fade-out-background-ucd386d18 {
+@keyframes mdc-checkbox-fade-out-background-ud52354eb {
   0%,
   80% {
     border-color: #5488b2;
@@ -15909,12 +15909,12 @@ button.mdc-chip {
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-ucd386d18; }
+  animation-name: mdc-checkbox-fade-in-background-ud52354eb; }
 
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-ucd386d18; }
+  animation-name: mdc-checkbox-fade-out-background-ud52354eb; }
 
 .mdc-data-table .mdc-list-item__graphic {
   margin-right: 0px; }

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -48672,8 +48672,7 @@ var VPosts = function (_VBase) {
                 var snackbar = element.vComponent;
 
                 if (contentType && contentType.includes('application/json')) {
-                    var messages = JSON.parse(response).messages;
-
+                    var messages = JSON.parse(response).message;
                     if (messages && messages.snackbar) {
                         var message = messages.snackbar.join('<br/>');
 

--- a/public/wc.js
+++ b/public/wc.js
@@ -34146,8 +34146,7 @@ var VPosts = function (_VBase) {
                 var snackbar = element.vComponent;
 
                 if (contentType && contentType.includes('application/json')) {
-                    var messages = JSON.parse(response).messages;
-
+                    var messages = JSON.parse(response).message;
                     if (messages && messages.snackbar) {
                         var message = messages.snackbar.join('<br/>');
 

--- a/views/mdc/assets/js/components/events/posts.js
+++ b/views/mdc/assets/js/components/events/posts.js
@@ -106,8 +106,7 @@ export class VPosts extends VBase {
             const snackbar = element.vComponent;
 
             if (contentType && contentType.includes('application/json')) {
-                const messages = JSON.parse(response).messages;
-
+                const messages = JSON.parse(response).message;
                 if (messages && messages.snackbar) {
                     const message = messages.snackbar.join('<br/>');
 


### PR DESCRIPTION
The contents of a POST response returns `message`, not `messages`, which was preventing the snackbar from showing when the response contained a snackbar message.