### PR TITLE
Unescape attrs before passing them to replaces

### DIFF
--- a/lib/voom/presenters/dsl/components/table.rb
+++ b/lib/voom/presenters/dsl/components/table.rb
@@ -157,17 +157,21 @@ module Voom
               (@total.to_f / @page_size.to_f).ceil
             end
 
+            def unescaped(hash)
+              hash.transform_values { |v| v.is_a?(String) ? CGI::unescapeHTML(v) : v }
+            end
+
             def button(icon_name, page, replace_id = @replace_id, replace_presenter = @replace_presenter)
-              __attribs__ = attribs.merge({page: page, page_size: @page_size})
+              __attribs__ = unescaped(attribs.merge({page: page, page_size: @page_size}))
               Components::Button.new(parent: self, type: :icon, icon: icon_name) do
                 event :click do
-                   replaces replace_id, replace_presenter, __attribs__
+                  replaces replace_id, replace_presenter, __attribs__
                 end
               end
             end
 
             def select(options, current_option, total_records, replace_id = @replace_id, replace_presenter = @replace_presenter)
-              __attribs__ = attribs.reject{|key,val| [:page_size, :page].include? key }
+              __attribs__ = unescaped(attribs.reject{|key,val| [:page_size, :page].include? key })
               Components::Select.new(parent: self, name: :page_size, full_width: false) do
                 options.each do |num|
                   option selected: (num == current_option) do


### PR DESCRIPTION
Base component is html escaping all params on initialization.
Pagination then passes all those attrs when it replaces.  We want those
attrs left alone as they aren't meant to be html


I think Ideally we shouldn't be html escaping all attributes in `Components::Base` because presenters should be agnostic of the actual UI language.  I'm not sure what that will break at this point so for now I'm just unescaping where I need it.  Might also be able to unescape in `replaces`