### PR TITLE
Presenter definition options

### DIFF
--- a/lib/voom/presenters/dsl/definition.rb
+++ b/lib/voom/presenters/dsl/definition.rb
@@ -5,11 +5,12 @@ module Voom
       # This class is held in the container. When a request to render a UI comes in
       # It creates a new UserInterface instance, binding it to the router and context of the request
       class Definition
-        attr_reader :name, :namespace
-        def initialize(name, namespace, &block)
+        attr_reader :name, :namespace, :options
+        def initialize(name, namespace, options, &block)
           @block = block
           @name = name
           @namespace = namespace
+          @options = options
         end
 
         def build

--- a/lib/voom/presenters/registry.rb
+++ b/lib/voom/presenters/registry.rb
@@ -11,10 +11,10 @@ module Voom
         @registry
       end
 
-      def self.define(name, namespace, &block)
+      def self.define(name, namespace, options, &block)
         namespace = Array(namespace).map(&:to_s)
         fq_name = namespace.any? ? namespace.join(':') + ':' + name.to_s : name.to_s
-        registry[fq_name] = Voom::Presenters::DSL::Definition.new(name, namespace, &block)
+        registry[fq_name] = Voom::Presenters::DSL::Definition.new(name, namespace, options, &block)
       end
 
       def self.load(directory)
@@ -52,12 +52,12 @@ module Voom
       end
     end
 
-    def self.define(name, namespace: nil, &block)
+    def self.define(name, namespace: nil, options: {}, &block)
       unless namespace
         namespace = name.to_s.split(':')
         name = namespace.pop
       end
-      Registry.define(name, namespace, &block)
+      Registry.define(name, namespace, options, &block)
     end
 
   end

--- a/lib/voom/presenters/web_client/app.rb
+++ b/lib/voom/presenters/web_client/app.rb
@@ -14,6 +14,7 @@ module Voom
         set :bind, '0.0.0.0'
         set :views, Proc.new {File.join(root, "views", ENV['VIEW_ENGINE'] || 'mdc')}
         set :dump_errors, false
+        set :protection, :except => :frame_options
         configure do
           enable :logging
         end
@@ -197,7 +198,7 @@ module Voom
             @pom = presenter.expand(router: router, context: prepare_context(p))
             @base_url = request.base_url
             layout = !(request.env['HTTP_X_NO_LAYOUT'] == 'true')
-            response.headers['X-Frame-Options'] = 'ALLOWALL' if ENV['ALLOWALL_FRAME_OPTIONS'] || presenter.options.fetch(:allow_all_frame_options, false)
+            response.headers['X-Frame-Options'] = ENV['ALLOWALL_FRAME_OPTIONS'] || presenter.options.fetch(:allow_all_frame_options, false) ? 'ALLOWALL' : 'SAMEORIGIN'
             erb :web, layout: layout
           rescue StandardError => e
             Presenters::Settings.config.presenters.error_logger.call(

--- a/lib/voom/presenters/web_client/app.rb
+++ b/lib/voom/presenters/web_client/app.rb
@@ -197,7 +197,7 @@ module Voom
             @pom = presenter.expand(router: router, context: prepare_context(p))
             @base_url = request.base_url
             layout = !(request.env['HTTP_X_NO_LAYOUT'] == 'true')
-            response.headers['X-Frame-Options'] = 'ALLOWALL' if ENV['ALLOWALL_FRAME_OPTIONS']
+            response.headers['X-Frame-Options'] = 'ALLOWALL' if ENV['ALLOWALL_FRAME_OPTIONS'] || presenter.options.fetch(:allow_all_frame_options, false)
             erb :web, layout: layout
           rescue StandardError => e
             Presenters::Settings.config.presenters.error_logger.call(


### PR DESCRIPTION
Add an `options` parameter to Voom::Presenters.define(). Currently only supports an option to set the X-Frame-Options header to 'ALLOWALL'