### PR TITLE
Allow "currency" as a behavior in text fields 

### DIFF
--- a/lib/voom/presenters/dsl/components/text_field.rb
+++ b/lib/voom/presenters/dsl/components/text_field.rb
@@ -50,6 +50,11 @@ module Voom
             @hint = hint
           end
 
+          def behavior
+            return "type=#{@behavior}" unless @behavior == 'currency'
+            return 'type="number" min="0.00" max="10000000000.00" step="0.01"'
+          end
+
           private
 
           def json_regexp(regexp)

--- a/views/mdc/components/text_field.erb
+++ b/views/mdc/components/text_field.erb
@@ -16,7 +16,7 @@
 
     <input id="<%= comp.id %>-input"
            name="<%= comp.name %>"
-           type="<%= behavior %>"
+           <%= behavior %>
            value="<%= comp.value %>"
            class="mdc-text-field__input"
            aria-controls="<%= comp.id %>-input-helper-text"


### PR DESCRIPTION
The existing "number" behavior/type needs some additional attributes to treat the input as a float for currency input.