### PR TITLE
Need quotes around behavior

### DIFF
--- a/lib/voom/presenters/dsl/components/text_field.rb
+++ b/lib/voom/presenters/dsl/components/text_field.rb
@@ -51,7 +51,7 @@ module Voom
           end
 
           def behavior
-            return "type=#{@behavior}" unless @behavior == 'currency'
+            return "type=\"#{@behavior}\"" unless @behavior == 'currency'
             return 'type="number" min="0.00" max="10000000000.00" step="0.01"'
           end
 


### PR DESCRIPTION
Having a blank behavior was leaving us with `type=value="The" portal`