### PR TITLE
fix: double file edit prints caused by multiple file watchers

### DIFF
--- a/lib/voom.rb
+++ b/lib/voom.rb
@@ -20,6 +20,6 @@ module Voom
 end
 
 if defined?(::Rails)
-  # loader.logger = Rails.logger
-  load 'voom/railtie.rb'
+  # We need this class's file to be parsed, but we want to let Zeitwerk load it
+  Voom::Railtie
 end


### PR DESCRIPTION
Loading the file manually was avoiding zeitwerk causing it to then load
again when referenced by class, leaving 2 filewatchers running and
printing.